### PR TITLE
修复 - 首次运行时 uv 安装依赖时网络问题导致的程序异常退出

### DIFF
--- a/src/one_dragon/devtools/python_launcher.py
+++ b/src/one_dragon/devtools/python_launcher.py
@@ -67,6 +67,7 @@ def configure_environment():
         'PYTHON': python_path,
         'PYTHONPATH': os.path.join(path, "src"),
         'UV_PATH': uv_path,
+        'UV_DEFAULT_INDEX': config.get('pip_source', 'https://pypi.org/simple/'),
         'AUTO_UPDATE': str(auto_update).lower(),
     })
     for var in ['PYTHON', 'PYTHONPATH', 'UV_PATH', 'AUTO_UPDATE']:


### PR DESCRIPTION
这个问题的详细描述详见 #1019 。

修复方式：将 config 设置的 pip 源通过环境变量传递给 uv 。

（参考：https://docs.astral.sh/uv/reference/environment/#uv_default_index ）