### PR TITLE
chore: mark invalid issues as 'not_planned'

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -40,7 +40,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              state: 'closed'
+              state: 'closed',
+              state_reason: 'not_planned',
             });
             console.log('Issue 已被标记为“无效”并关闭。');
             return;


### PR DESCRIPTION
~不言而明，一目了然~

未认真选择的issue被机器人关闭时，会被标记为`closed as not planned`