### PR TITLE
feat: change scroll areas for RunInterface page

### DIFF
--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -85,11 +85,48 @@ class OneDragonRunInterface(VerticalScrollInterface):
         layout = QVBoxLayout()
 
         scroll_area = SingleDirectionScrollArea(orient=Qt.Orientation.Vertical)
-        scroll_area.setStyleSheet("QScrollArea { background-color: transparent; border: none; }")
+        # 应用自定义滚动条样式
+        scroll_area.setStyleSheet("""
+            QScrollArea { 
+                background-color: transparent; 
+                border: none; 
+            }
+            QScrollBar:vertical {
+                background: transparent;
+                width: 8px;
+                border-radius: 4px;
+                margin: 2px;
+                border: none;
+            }
+            QScrollBar::handle:vertical {
+                background: rgba(128, 128, 128, 60);
+                border-radius: 4px;
+                min-height: 20px;
+                margin: 1px;
+            }
+            QScrollBar::handle:vertical:hover {
+                background: rgba(128, 128, 128, 120);
+            }
+            QScrollBar::handle:vertical:pressed {
+                background: rgba(128, 128, 128, 180);
+            }
+            QScrollBar::add-line:vertical,
+            QScrollBar::sub-line:vertical {
+                height: 0px;
+                width: 0px;
+            }
+            QScrollBar::add-page:vertical,
+            QScrollBar::sub-page:vertical {
+                background: transparent;
+            }
+            QScrollBar::corner {
+                background: transparent;
+            }
+        """)
 
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
-        scroll_layout.setContentsMargins(0, 0, 0, 0)
+        scroll_layout.setContentsMargins(0, 0, 12, 0)
         
         self.app_card_group = SettingCardGroup(gt('任务列表'))
         scroll_layout.addWidget(self.app_card_group)

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout
-from qfluentwidgets import FluentIcon, SettingCardGroup, SubtitleLabel, PrimaryPushButton, PushButton
+from qfluentwidgets import FluentIcon, SettingCardGroup, SubtitleLabel, PrimaryPushButton, PushButton, SingleDirectionScrollArea
 from typing import List, Optional
 
 from one_dragon.base.config.one_dragon_app_config import OneDragonAppConfig
@@ -83,9 +83,24 @@ class OneDragonRunInterface(VerticalScrollInterface):
         :return:
         """
         layout = QVBoxLayout()
-        self.app_card_group = SettingCardGroup(gt('任务列表'))
-        layout.addWidget(self.app_card_group)
 
+        scroll_area = SingleDirectionScrollArea(orient=Qt.Orientation.Vertical)
+        scroll_area.setStyleSheet("QScrollArea { background-color: transparent; border: none; }")
+
+        scroll_content = QWidget()
+        scroll_layout = QVBoxLayout(scroll_content)
+        scroll_layout.setContentsMargins(0, 0, 0, 0)
+        
+        self.app_card_group = SettingCardGroup(gt('任务列表'))
+        scroll_layout.addWidget(self.app_card_group)
+        # 填充剩余空间
+        scroll_layout.addStretch(1)
+
+        scroll_area.setWidget(scroll_content)
+        scroll_area.setWidgetResizable(True)
+        
+        layout.addWidget(scroll_area)
+        
         return layout
 
     def _get_right_layout(self) -> QVBoxLayout:
@@ -143,8 +158,15 @@ class OneDragonRunInterface(VerticalScrollInterface):
         self.stop_btn.clicked.connect(self._on_stop_clicked)
         btn_row.addWidget(self.stop_btn, stretch=1)
 
+        # 日志
+        log_scroll_area = SingleDirectionScrollArea(orient=Qt.Orientation.Vertical)
+        log_scroll_area.setStyleSheet("QScrollArea { background-color: transparent; border: none; }")
+        
         self.log_card = LogDisplayCard()
-        layout.addWidget(self.log_card, stretch=1)
+        log_scroll_area.setWidget(self.log_card)
+        log_scroll_area.setWidgetResizable(True)
+        
+        layout.addWidget(log_scroll_area, stretch=1)
 
         return layout
 

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -66,8 +66,8 @@ class OneDragonRunInterface(VerticalScrollInterface):
         horizontal_layout.addLayout(self._get_right_layout(), stretch=1)
 
         # 确保 QHBoxLayout 可以伸缩
-        horizontal_layout.setSpacing(0)
-        horizontal_layout.setContentsMargins(0, 0, 0, 0)
+        horizontal_layout.setSpacing(20)
+        horizontal_layout.setContentsMargins(10, 0, 10, 0)
 
         # 设置伸缩因子，让 QHBoxLayout 占据空间
         main_layout.addLayout(horizontal_layout, stretch=1)

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -66,8 +66,8 @@ class OneDragonRunInterface(VerticalScrollInterface):
         horizontal_layout.addLayout(self._get_right_layout(), stretch=1)
 
         # 确保 QHBoxLayout 可以伸缩
-        horizontal_layout.setSpacing(20)
-        horizontal_layout.setContentsMargins(10, 0, 10, 0)
+        horizontal_layout.setSpacing(10)
+        horizontal_layout.setContentsMargins(0, 0, 0, 0)
 
         # 设置伸缩因子，让 QHBoxLayout 占据空间
         main_layout.addLayout(horizontal_layout, stretch=1)
@@ -84,60 +84,20 @@ class OneDragonRunInterface(VerticalScrollInterface):
         """
         layout = QVBoxLayout()
 
-        scroll_area = SingleDirectionScrollArea(orient=Qt.Orientation.Vertical)
-        # 应用自定义滚动条样式
-        scroll_area.setStyleSheet("""
-            QScrollArea { 
-                background-color: transparent; 
-                border: none; 
-            }
-            QScrollBar:vertical {
-                background: transparent;
-                width: 8px;
-                border-radius: 4px;
-                margin: 2px;
-                border: none;
-            }
-            QScrollBar::handle:vertical {
-                background: rgba(128, 128, 128, 60);
-                border-radius: 4px;
-                min-height: 20px;
-                margin: 1px;
-            }
-            QScrollBar::handle:vertical:hover {
-                background: rgba(128, 128, 128, 120);
-            }
-            QScrollBar::handle:vertical:pressed {
-                background: rgba(128, 128, 128, 180);
-            }
-            QScrollBar::add-line:vertical,
-            QScrollBar::sub-line:vertical {
-                height: 0px;
-                width: 0px;
-            }
-            QScrollBar::add-page:vertical,
-            QScrollBar::sub-page:vertical {
-                background: transparent;
-            }
-            QScrollBar::corner {
-                background: transparent;
-            }
-        """)
-
+        scroll_area = SingleDirectionScrollArea()
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
-        scroll_layout.setContentsMargins(0, 0, 12, 0)
-        
+        scroll_layout.setContentsMargins(0, 0, 16, 0)
+
         self.app_card_group = SettingCardGroup(gt('任务列表'))
         scroll_layout.addWidget(self.app_card_group)
-        # 填充剩余空间
         scroll_layout.addStretch(1)
 
         scroll_area.setWidget(scroll_content)
         scroll_area.setWidgetResizable(True)
-        
+
         layout.addWidget(scroll_area)
-        
+
         return layout
 
     def _get_right_layout(self) -> QVBoxLayout:
@@ -195,15 +155,8 @@ class OneDragonRunInterface(VerticalScrollInterface):
         self.stop_btn.clicked.connect(self._on_stop_clicked)
         btn_row.addWidget(self.stop_btn, stretch=1)
 
-        # 日志
-        log_scroll_area = SingleDirectionScrollArea(orient=Qt.Orientation.Vertical)
-        log_scroll_area.setStyleSheet("QScrollArea { background-color: transparent; border: none; }")
-        
         self.log_card = LogDisplayCard()
-        log_scroll_area.setWidget(self.log_card)
-        log_scroll_area.setWidgetResizable(True)
-        
-        layout.addWidget(log_scroll_area, stretch=1)
+        layout.addWidget(self.log_card, stretch=1)
 
         return layout
 

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -65,7 +65,7 @@ class OneDragonRunInterface(VerticalScrollInterface):
         horizontal_layout.addLayout(self._get_left_layout(), stretch=1)
         horizontal_layout.addLayout(self._get_right_layout(), stretch=1)
 
-        # 确保 QHBoxLayout 可以伸缩
+        # 设置 QHBoxLayout 的间距和边框
         horizontal_layout.setSpacing(10)
         horizontal_layout.setContentsMargins(0, 0, 0, 0)
 


### PR DESCRIPTION
应邀，修改`一条龙`页面的滚动功能，现在滚动仅限在左边任务列表区域，不会导致右边的运行设置和日志一起滚动。
![image](https://github.com/user-attachments/assets/3413bb78-c547-412e-b2b2-2cbc231985c7)

![image](https://github.com/user-attachments/assets/ed0ceb2a-273d-4425-a4c5-2171d77b0d40)
