### PR TITLE
修复战斗失败检测缺失问题

### DIFF
--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -350,7 +350,11 @@ class CombatSimulation(ZOperation):
     @node_from(from_name='自动战斗')
     @operation_node(name='战斗结束')
     def after_battle(self) -> OperationRoundResult:
-        # TODO 还没有判断战斗失败
+        # 检查战斗结果
+        if self.auto_op.auto_battle_context.last_check_end_result == '普通战斗-撤退':
+            log.error('实战模拟室战斗失败')
+            return self.round_fail('战斗失败')
+        
         self.can_run_times -= 1
         self.ctx.charge_plan_config.add_plan_run_times(self.plan)
         return self.round_success()

--- a/src/zzz_od/operation/compendium/expert_challenge.py
+++ b/src/zzz_od/operation/compendium/expert_challenge.py
@@ -193,7 +193,11 @@ class ExpertChallenge(ZOperation):
     @node_from(from_name='自动战斗')
     @operation_node(name='战斗结束')
     def after_battle(self) -> OperationRoundResult:
-        # TODO 还没有判断战斗失败
+        # 检查战斗结果
+        if self.auto_op.auto_battle_context.last_check_end_result == '普通战斗-撤退':
+            log.error('专业挑战室战斗失败')
+            return self.round_fail('战斗失败')
+        
         self.can_run_times -= 1
         self.ctx.charge_plan_config.add_plan_run_times(self.plan)
         return self.round_success()


### PR DESCRIPTION
- 在实战模拟室添加战斗失败检测机制，检测'普通战斗-撤退'状态
- 在专业挑战室添加相同的战斗失败检测逻辑
- 解决战斗失败后程序卡死的问题，现在会正确返回失败状态
- 增加失败日志记录，便于问题排查

修复 #TODO 战斗失败判断缺失