### PR TITLE
fix(battle): 修复角色识别因缓存污染导致的卡死问题并完善皮肤配置

### DIFF
--- a/src/zzz_od/auto_battle/auto_battle_agent_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_agent_context.py
@@ -15,6 +15,7 @@ from zzz_od.context.zzz_context import ZContext
 from zzz_od.game_data.agent import Agent, AgentEnum, AgentStateCheckWay, CommonAgentStateEnum, AgentStateDef
 
 _battle_agent_context_executor = ThreadPoolExecutor(thread_name_prefix='od_battle_agent_context', max_workers=16)
+_yuzuha_debug_printed = False
 _agent_state_check_method: dict[AgentStateCheckWay, Callable] = {
     AgentStateCheckWay.COLOR_RANGE_CONNECT: agent_state_checker.check_cnt_by_color_range,
     AgentStateCheckWay.COLOR_RANGE_EXIST: agent_state_checker.check_exist_by_color_range,
@@ -444,19 +445,23 @@ class AutoBattleAgentContext:
         """
         prefix = 'avatar_1_' if is_front else 'avatar_2_'
         for agent, specific_template_id in possible_agents:
-            # 上次识别过的模板 ID，接着用
+            # 构建一个带优先级的待检查模板列表
+            # 1. 优先使用上次成功匹配的ID
+            # 2. 然后使用该角色所有可用的模板
+            templates_to_check = []
             if specific_template_id:
-                template_to_check = prefix + specific_template_id
-                mrl = self.ctx.tm.match_template(img, 'battle', template_to_check, threshold=0.8)
+                templates_to_check.append(specific_template_id)
+
+            for t_id in agent.template_id_list:
+                if t_id not in templates_to_check:
+                    templates_to_check.append(t_id)
+
+            # 按优先级顺序进行匹配
+            for template_id in templates_to_check:
+                template_name = prefix + template_id
+                mrl = self.ctx.tm.match_template(img, 'battle', template_name, threshold=0.8)
                 if mrl.max is not None:
-                    return agent, specific_template_id
-            # 没有上次识别过的模板 ID，匹配所有可能的模板 ID
-            else:
-                for template_id in agent.template_id_list:
-                    template_to_check = prefix + template_id
-                    mrl = self.ctx.tm.match_template(img, 'battle', template_to_check, threshold=0.8)
-                    if mrl.max is not None:
-                        return agent, template_id
+                    return agent, template_id  # 匹配成功，返回实际命中的模板ID
 
         return None, None
 

--- a/src/zzz_od/context/zzz_context.py
+++ b/src/zzz_od/context/zzz_context.py
@@ -173,9 +173,9 @@ class ZContext(OneDragonContext):
         self.hollow.data_service.reload()
         self.init_hollow_config()
         if self.agent_outfit_config.compatibility_mode:
-            self.init_agent_template_id()
-        else:
             self.init_agent_template_id_list()
+        else:
+            self.init_agent_template_id()
 
     def init_hollow_config(self) -> None:
         """
@@ -198,6 +198,7 @@ class ZContext(OneDragonContext):
         AgentEnum.ELLEN.value.template_id_list = [self.agent_outfit_config.ellen]
         AgentEnum.ASTRA_YAO.value.template_id_list = [self.agent_outfit_config.astra_yao]
         AgentEnum.YIXUAN.value.template_id_list = [self.agent_outfit_config.yixuan]
+        AgentEnum.YUZUHA.value.template_id_list = [self.agent_outfit_config.yuzuha]
 
     def init_agent_template_id_list(self) -> None:
         """
@@ -208,6 +209,7 @@ class ZContext(OneDragonContext):
         AgentEnum.ELLEN.value.template_id_list = self.agent_outfit_config.ellen_outfit_list
         AgentEnum.ASTRA_YAO.value.template_id_list = self.agent_outfit_config.astra_yao_outfit_list
         AgentEnum.YIXUAN.value.template_id_list = self.agent_outfit_config.yixuan_outfit_list
+        AgentEnum.YUZUHA.value.template_id_list = self.agent_outfit_config.yuzuha_outfit_list
 
     def after_app_shutdown(self) -> None:
         """


### PR DESCRIPTION
### 修复的问题 (The Fix)

修复了在特定队伍（如包含妮可）和特定角色（如浮波柚叶）换装后，自动战斗中的角色识别会卡住或永久失效的问题。

### 问题根源 (Root Cause)

经过深入排查，发现问题由两个层面的原因共同导致：

1.  **配置层缺陷**:
    *   `ZContext` 在初始化角色模板时，遗漏了对“浮波柚叶”的皮肤配置加载。
    *   “兼容模式”的实际逻辑与UI描述相反，导致配置行为不符合预期。

2.  **战斗逻辑缺陷**:
    *   核心识别函数 `_match_agent_in` 在使用缓存的模板ID (`specific_template_id`) 进行优先匹配时，一旦匹配失败，会直接放弃对该角色的识别，而不会尝试该角色的其他可用模板。
    *   这导致在战斗中一旦因为画面干扰(比如浮波柚叶原皮和泳装过于相似导致在小头像被错误识别)等原因发生一次错误识别（缓存被“污染”），后续的识别流程将陷入无法自我纠正的死循环，表现为永久识别失败。

### 解决方案 (Solution)

本次修复采取了“双管齐下”的方案，从配置和逻辑两个层面彻底解决问题：

1.  **完善 `ZContext`**:
    *   在 `init_agent_template_id` 和 `init_agent_template_id_list` 函数中，补充了对“浮波柚叶”的模板加载逻辑。
    *   纠正了“兼容模式”的判断，使其行为与UI描述一致（开启后加载所有皮肤模板）。

2.  **增强 `_match_agent_in`**:
    *   重构了识别函数，实现了更健壮的优先级匹配逻辑。
    *   新逻辑会先构建一个带优先级的待选模板列表（缓存ID优先，其次是其他可用模板），然后按顺序进行匹配。
    *   这保证了即使缓存的优先ID匹配失败，程序也能继续尝试其他模板，从而具备了**运行时自愈能力**。

### 带来的改进 (Improvements)

*   **问题修复**: 彻底解决了特定场景下的角色识别卡死问题。
*   **功能完善**: 使得“浮波柚叶”的皮肤配置和“兼容模式”功能真正生效。
*   **健壮性提升**: 大大增强了角色识别系统的鲁棒性，使其在面对临时的识别干扰时能够快速自我纠正，避免了连锁失败。

### 未来可优化方向 (Future Optimization)

本次修复通过引入带优先级的完整模板匹配，已经从根本上解决了性能和准确性的平衡问题。因此，强制用户选择“首选皮肤”的必要性已经降低。未来可以评估移除每个角色的单选皮肤设置，只保留一个全局的“兼容模式”（即始终尝试所有皮肤）开关，甚至可以考虑将“兼容模式”作为默认且唯一的行为，从而简化UI和用户配置。