### PR TITLE
fix: 启动器中不检查环境同步

### DIFF
--- a/src/one_dragon/devtools/python_launcher.py
+++ b/src/one_dragon/devtools/python_launcher.py
@@ -117,7 +117,7 @@ def execute_python_script(app_path, log_folder, no_windows: bool, args: list = N
     else:
         print_message("开始获取最新代码...", "INFO")
         try:
-            result = subprocess.run([uv_path, 'run', '-m', 'one_dragon.envs.git_service'])
+            result = subprocess.run([uv_path, 'run', '--no-sync', '-m', 'one_dragon.envs.git_service'])
             if result.returncode == 0:
                 print_message("代码更新完成", "PASS")
             else:
@@ -126,7 +126,7 @@ def execute_python_script(app_path, log_folder, no_windows: bool, args: list = N
             print_message(f"代码更新异常: {e}", "ERROR")
 
     # 构建 uv run 命令参数
-    run_args = ['run', app_script_path]
+    run_args = ['run', '--no-sync', app_script_path]
     if args:
         run_args.extend(args)
         print_message(f"传递参数：{' '.join(args)}", "INFO")

--- a/src/one_dragon/envs/env_config.py
+++ b/src/one_dragon/envs/env_config.py
@@ -242,6 +242,18 @@ class EnvConfig(YamlConfig):
         self.update('auto_update', new_value)
 
     @property
+    def sync(self) -> bool:
+        """
+        自动同步环境
+        :return:
+        """
+        return self.get('sync', True)
+
+    @sync.setter
+    def sync(self, new_value: bool) -> None:
+        self.update('sync', new_value)
+
+    @property
     def cpython_source(self) -> str:
         """
         cpython-build-standalone 源

--- a/src/one_dragon_qt/view/setting/setting_env_interface.py
+++ b/src/one_dragon_qt/view/setting/setting_env_interface.py
@@ -84,9 +84,14 @@ class SettingEnvInterface(VerticalScrollInterface):
         code_group.addSettingCard(self.force_update_opt)
 
         self.auto_update_opt = SwitchSettingCard(
-            icon=FluentIcon.SYNC, title='自动更新', content='使用exe启动时，自动检测并更新代码',
+            icon=FluentIcon.SYNC, title='自动更新代码', content='使用exe启动时，自动检测并更新代码',
         )
         code_group.addSettingCard(self.auto_update_opt)
+
+        self.sync_opt = SwitchSettingCard(
+            icon=FluentIcon.SYNC, title='自动更新依赖', content='使用exe启动时，自动检测并更新环境依赖',
+        )
+        code_group.addSettingCard(self.sync_opt)
 
         return code_group
 
@@ -193,6 +198,7 @@ class SettingEnvInterface(VerticalScrollInterface):
 
         self.force_update_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('force_update'))
         self.auto_update_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('auto_update'))
+        self.sync_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('sync'))
         self.pip_source_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('pip_source'))
         self.cpython_source_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('cpython_source'))
 


### PR DESCRIPTION
注意，此pr禁用了自动依赖更新，原因是uv会认为不同源安装的依赖和锁文件不匹配，导致重新sync。
目前可选的解决方案：
1.主程序加入同步环境按钮
2.自动更新加入选项：是否更新依赖
3.维持现状，文档内提示用户选择官方源以加速启动