### PR TITLE
:sparkles: 使得飞书机器人推送时带有图片

### DIFF
--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -148,8 +148,65 @@ class Push():
 
         self.log_info("飞书 服务启动")
 
+        app_id = self.get_config("FS_APPID")
+        app_secret = self.get_config("FS_APPSECRET")
+        if image and app_id and app_secret and app_id != "" and app_secret != "":
+            image.seek(0)
+            # 获取飞书自建应用的tenant_access_token
+            auth_endpoint = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
+            auth_headers = {
+                "Content-Type": "application/json; charset=utf-8"
+            }
+            auth_response = requests.post(auth_endpoint, headers=auth_headers, json={
+                "app_id": app_id,
+                "app_secret": app_secret
+            })
+            auth_response.raise_for_status()
+            tenant_access_token = auth_response.json()["tenant_access_token"]
+            # 上传图片并获取图片的image_key
+            image_endpoint = "https://open.feishu.cn/open-apis/im/v1/images"
+            image_headers = {
+                "Authorization": f"Bearer {tenant_access_token}"
+            }
+            files = {
+                'image': ('image.jpg', image.getvalue(), 'image/jpeg'),
+                'image_type': (None, 'message')
+            }
+            image_response = requests.post(image_endpoint , headers=image_headers, files=files)
+            if (image_response.status_code % 100 != 2):
+                log.error(image_response.text)
+                image_response.raise_for_status()
+            image_key = image_response.json()["data"]["image_key"]
+        else:
+            image_key = None
+
+        if image_key:
+            data = {
+                "msg_type": "post",
+                "content": {
+                    "post": {
+                        "zh_cn": {
+                            "title": title,
+                            "content": [
+                                [{
+                                    "tag": "text",
+                                    "text": f"{content}"
+                                }, {
+                                    "tag": "img",
+                                    "image_key": image_key
+                                }]
+                            ]
+                        }
+                    }
+                }
+            }
+        else:
+            data = {
+                "msg_type": "text",
+                "content": {"text": f"{title}\n{content}"}
+            }
+
         url = f'https://open.feishu.cn/open-apis/bot/v2/hook/{self.get_config("FS_KEY")}'
-        data = {"msg_type": "text", "content": {"text": f"{title}\n{content}"}}
         response = requests.post(url, data=json.dumps(data)).json()
 
         if response.get("StatusCode") == 0 or response.get("code") == 0:

--- a/src/one_dragon_qt/widgets/push_cards.py
+++ b/src/one_dragon_qt/widgets/push_cards.py
@@ -131,6 +131,22 @@ class PushCards:
             "placeholder": "请输入飞书机器人的密钥",
             "type": "text",
             "required": True
+        },
+        {
+            "var_suffix": "APPID",
+            "title": "自建应用 App ID",
+            "icon": "APPLICATION",
+            "placeholder": "非必填，填写则用于发送图片",
+            "type": "text",
+            "required": False
+        },
+        {
+            "var_suffix": "APPSECRET",
+            "title": "自建应用 Secret",
+            "icon": "VPN",
+            "placeholder": "非必填，填写则用于发送图片",
+            "type": "text",
+            "required": False
         }
     ],
     "ONEBOT": [


### PR DESCRIPTION
若填写了自建机器人的appId以及app密钥，若自建应用开启了图片上传，则能成功推送图片到飞书

<img width="1054" height="703" alt="image" src="https://github.com/user-attachments/assets/b8cc2770-333d-4ccd-bee4-2deb3353338d" />

<img width="552" height="372" alt="image" src="https://github.com/user-attachments/assets/a3a0ef75-2402-4655-bc3a-9a141d168847" />
