### PR TITLE
Fix/0729 修复<迷失之地-通用选择>画面识别不到<确认>而无法进入导致后续流水线卡死的问题

### DIFF
--- a/assets/game_data/screen_info/arcade.yml
+++ b/assets/game_data/screen_info/arcade.yml
@@ -3,6 +3,8 @@ screen_name: 电玩店
 pc_alt: false
 area_list:
 - area_name: 游戏名称
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1268
   - 556
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 玩家数量
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1726
   - 560
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 下一个游戏
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1426
   - 736
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 选择
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1598
   - 1004
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 模式列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 848
   - 760
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 开始游戏
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1598
   - 1004
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 蛇对蛇-点击空白处继续
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 636
   - 892
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 蛇对蛇-加载完成
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 226
   - 992
@@ -90,3 +120,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/battle.yml
+++ b/assets/game_data/screen_info/battle.yml
@@ -4,6 +4,7 @@ pc_alt: true
 area_list:
 - area_name: 头像-3-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 104
   - 40
@@ -14,9 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按键-特殊攻击
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1620
   - 917
@@ -27,9 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.9
+  color_range: null
   goto_list: []
 - area_name: 按键-终结技
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 778
@@ -40,9 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 连携技-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 479
   - 828
@@ -53,9 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 连携技-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1322
   - 828
@@ -66,9 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按键-切换角色
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1731
   - 920
@@ -79,9 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按键-普通攻击
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1403
   - 916
@@ -92,9 +105,11 @@ area_list:
   template_sub_dir: battle
   template_id: btn_normal_attack
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 战斗结果-完成
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 1004
@@ -105,9 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 战斗结果-再来一次
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1232
   - 1006
@@ -118,9 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 距离显示区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 432
   - 132
@@ -131,9 +150,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 菜单
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 46
@@ -144,9 +165,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 战斗结果-撤退
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 526
   - 848
@@ -157,9 +180,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 战斗结果-倒带
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 874
   - 850
@@ -170,9 +195,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 战斗结果-退出
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 1004
@@ -183,9 +210,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 头像-3-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 559
   - 40
@@ -196,9 +225,11 @@ area_list:
   template_sub_dir: battle
   template_id: avatar_2_anby
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 头像-3-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 741
   - 40
@@ -209,9 +240,11 @@ area_list:
   template_sub_dir: battle
   template_id: avatar_2_anton
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 头像-2-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 594
   - 40
@@ -222,9 +255,11 @@ area_list:
   template_sub_dir: battle
   template_id: avatar_2_piper
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按键-交互
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1403
   - 916
@@ -235,4 +270,5 @@ area_list:
   template_sub_dir: battle
   template_id: btn_interact
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []

--- a/assets/game_data/screen_info/battle_menu.yml
+++ b/assets/game_data/screen_info/battle_menu.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-退出战斗
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1616
   - 1006
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-设置
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1646
   - 26
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 菜单-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 12
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-退出战斗-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1038
   - 600
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-重新开始
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1288
   - 1002

--- a/assets/game_data/screen_info/battle_result_fail.yml
+++ b/assets/game_data/screen_info/battle_result_fail.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-挑战结果
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 624
   - 144
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-退出
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1570
   - 1004

--- a/assets/game_data/screen_info/city_fund.yml
+++ b/assets/game_data/screen_info/city_fund.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 成长任务
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1436
   - 26
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 等级回馈
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1218
   - 20
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 等级-全部领取
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1240
   - 982
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 任务-全部领取
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1592
   - 982
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 开启丽都城募
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1402
   - 936
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-已关闭-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 874
   - 600

--- a/assets/game_data/screen_info/coffee_shop.yml
+++ b/assets/game_data/screen_info/coffee_shop.yml
@@ -3,6 +3,8 @@ screen_name: 咖啡店
 pc_alt: true
 area_list:
 - area_name: 点单
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1702
   - 966
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 咖啡列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 132
   - 682
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 对话框前往
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 728
   - 600
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 对话框确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1040
   - 600
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 点单后跳过
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1684
   - 64
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 电量确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 876
   - 706
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 不可贪杯确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 606
@@ -79,3 +105,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/combat_simulation.yml
+++ b/assets/game_data/screen_info/combat_simulation.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 挑战奖励
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 84
   - 1006
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 副本名称列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 128
   - 724
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 剩余电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1440
   - 1000
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 需要电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1508
   - 1000
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 下一步
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1590
   - 1000
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 出战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1638
   - 1002
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 挑战等级
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1454
   - 26
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 恢复电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 824
   - 348
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 副本类型列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 406
   - 592
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 外层-卡片1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 130
   - 222
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: 内层-已选择卡片1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 254
   - 128
@@ -158,6 +169,7 @@ area_list:
   goto_list: []
 - area_name: 内层-卡片1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 546
   - 170
@@ -172,6 +184,7 @@ area_list:
   goto_list: []
 - area_name: 保存方案
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1600
   - 1008
@@ -186,6 +199,7 @@ area_list:
   goto_list: []
 - area_name: 确定并出战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1026
   - 602
@@ -200,6 +214,7 @@ area_list:
   goto_list: []
 - area_name: 预备编队
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 470
   - 985
@@ -214,6 +229,7 @@ area_list:
   goto_list: []
 - area_name: 预备出战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1634
   - 1000
@@ -228,6 +244,7 @@ area_list:
   goto_list: []
 - area_name: 副本名称列表顶部
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 128
   - 740

--- a/assets/game_data/screen_info/commission_assistant.yml
+++ b/assets/game_data/screen_info/commission_assistant.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 对话框标题
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 874
   - 798
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 右侧选项区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1438
   - 536
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 中间选项区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 578
   - 312
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 左上角街区
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 234
   - 26
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 对话框确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1022
   - 544
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 左上角返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 文本-剧情右上角
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1680
   - 106
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 标题-短信
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 412
   - 148
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-短信-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1462
   - 130
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 区域-短信-文本框
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 790
   - 314
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-自动
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1686
   - 186

--- a/assets/game_data/screen_info/common_deploy.yml
+++ b/assets/game_data/screen_info/common_deploy.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-下一步
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1586
   - 1002
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-出战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1570
   - 982
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-队员数量少-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-等级低-确定并出战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602

--- a/assets/game_data/screen_info/common_screen.yml
+++ b/assets/game_data/screen_info/common_screen.yml
@@ -3,6 +3,8 @@ screen_name: 画面-通用
 pc_alt: false
 area_list:
 - area_name: 左上角-街区
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 234
   - 26
@@ -13,3 +15,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/compendium.yml
+++ b/assets/game_data/screen_info/compendium.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 716
   - 120
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 分类列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 166
   - 292
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 副本列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 498
   - 308
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 传送确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 活跃度奖励-4
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1532
   - 234
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 活跃度奖励-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 704
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 今日最大活跃度
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 502
   - 270
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-退出
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1730
   - 206
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 前往列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1312
   - 334
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 目标列表-训练
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1254
   - 376
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: 目标列表-作战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1254
   - 552

--- a/assets/game_data/screen_info/compendium_combat.yml
+++ b/assets/game_data/screen_info/compendium_combat.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB-训练
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -19,6 +20,7 @@ area_list:
   - 快捷手册-训练
 - area_name: TAB-目标
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -34,6 +36,7 @@ area_list:
   - 快捷手册-目标
 - area_name: TAB-日常
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -49,6 +52,7 @@ area_list:
   - 快捷手册-日常
 - area_name: TAB-作战
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -70,6 +74,7 @@ area_list:
   - 快捷手册-作战
 - area_name: TAB-战术
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -85,6 +90,7 @@ area_list:
   - 快捷手册-战术
 - area_name: 按钮-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 206

--- a/assets/game_data/screen_info/compendium_errands.yml
+++ b/assets/game_data/screen_info/compendium_errands.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB-训练
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -19,6 +20,7 @@ area_list:
   - 快捷手册-训练
 - area_name: TAB-目标
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -34,6 +36,7 @@ area_list:
   - 快捷手册-目标
 - area_name: TAB-日常
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -55,6 +58,7 @@ area_list:
   - 快捷手册-日常
 - area_name: TAB-作战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -70,6 +74,7 @@ area_list:
   - 快捷手册-作战
 - area_name: TAB-战术
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -85,6 +90,7 @@ area_list:
   - 快捷手册-战术
 - area_name: 按钮-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 206

--- a/assets/game_data/screen_info/compendium_primer.yml
+++ b/assets/game_data/screen_info/compendium_primer.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB-训练
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -19,6 +20,7 @@ area_list:
   - 快捷手册-训练
 - area_name: TAB-目标
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -40,6 +42,7 @@ area_list:
   - 快捷手册-目标
 - area_name: TAB-日常
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -55,6 +58,7 @@ area_list:
   - 快捷手册-日常
 - area_name: TAB-作战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -70,6 +74,7 @@ area_list:
   - 快捷手册-作战
 - area_name: TAB-战术
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -85,6 +90,7 @@ area_list:
   - 快捷手册-战术
 - area_name: 按钮-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 206

--- a/assets/game_data/screen_info/compendium_tactics.yml
+++ b/assets/game_data/screen_info/compendium_tactics.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB-训练
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -19,6 +20,7 @@ area_list:
   - 快捷手册-训练
 - area_name: TAB-目标
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -34,6 +36,7 @@ area_list:
   - 快捷手册-目标
 - area_name: TAB-日常
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -49,6 +52,7 @@ area_list:
   - 快捷手册-日常
 - area_name: TAB-作战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -64,6 +68,7 @@ area_list:
   - 快捷手册-作战
 - area_name: TAB-战术
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -85,6 +90,7 @@ area_list:
   - 快捷手册-战术
 - area_name: 按钮-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 206

--- a/assets/game_data/screen_info/compendium_training.yml
+++ b/assets/game_data/screen_info/compendium_training.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: TAB-训练
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -25,6 +26,7 @@ area_list:
   - 快捷手册-训练
 - area_name: TAB-目标
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -40,6 +42,7 @@ area_list:
   - 快捷手册-目标
 - area_name: TAB-日常
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -55,6 +58,7 @@ area_list:
   - 快捷手册-日常
 - area_name: TAB-作战
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -70,6 +74,7 @@ area_list:
   - 快捷手册-作战
 - area_name: TAB-战术
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 708
   - 118
@@ -85,6 +90,7 @@ area_list:
   - 快捷手册-战术
 - area_name: 按钮-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 206
@@ -101,6 +107,7 @@ area_list:
   - 大世界-普通
 - area_name: 文本-电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1346
   - 214
@@ -115,6 +122,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-奖励
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1334
   - 214
@@ -129,6 +137,7 @@ area_list:
   goto_list: []
 - area_name: 文本-电量2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1048
   - 214

--- a/assets/game_data/screen_info/coupon.yml
+++ b/assets/game_data/screen_info/coupon.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 920
   - 737
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 绳网信用
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1090
   - 362
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 使用
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1040
   - 1005
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 数量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 936
   - 1012

--- a/assets/game_data/screen_info/drive_disc_dismantle.yml
+++ b/assets/game_data/screen_info/drive_disc_dismantle.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-驱动盘拆解
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 184
   - 4
@@ -14,9 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-快速选择
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 166
   - 1000
@@ -27,9 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-全选已弃置
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 642
   - 466
@@ -40,9 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-A及以下
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 984
   - 568
@@ -53,9 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-S及以下
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 642
   - 628
@@ -66,9 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-快速选择-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 994
   - 754
@@ -79,9 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-拆解
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1626
   - 876
@@ -92,9 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-拆解-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 622
@@ -105,9 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-B
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 642
   - 566
@@ -118,4 +135,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []

--- a/assets/game_data/screen_info/email.yml
+++ b/assets/game_data/screen_info/email.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 全部领取
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 122
   - 982
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 708
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 标题-邮件
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 160
   - 18
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 13

--- a/assets/game_data/screen_info/enter_game.yml
+++ b/assets/game_data/screen_info/enter_game.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 点击进入游戏
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 810
   - 846
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号密码
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 608
   - 728
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 368
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 国服-密码输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 470
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 国服-同意按钮
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 606
   - 576
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号密码进入游戏
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 608
   - 648
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 切换账号确定
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1036
   - 604
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 切换账号
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1796
   - 974
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: B服-登陆
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 839
   - 626
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: B服-账号输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 889
   - 443
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: B服-密码输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1891
   - 495
@@ -158,6 +169,7 @@ area_list:
   goto_list: []
 - area_name: B服-同意按钮
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 834
   - 571
@@ -172,6 +184,7 @@ area_list:
   goto_list: []
 - area_name: B服-账号删除区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1032
   - 436
@@ -186,6 +199,7 @@ area_list:
   goto_list: []
 - area_name: 标题-退出登录
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 546
   - 250
@@ -200,6 +214,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-退出登录-确定
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 752
@@ -214,6 +229,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号密码-新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 608
   - 768
@@ -228,6 +244,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号输入区域-新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 335
@@ -242,6 +259,7 @@ area_list:
   goto_list: []
 - area_name: 国服-密码输入区域-新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 430
@@ -256,6 +274,7 @@ area_list:
   goto_list: []
 - area_name: 国服-同意按钮-新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 606
   - 605
@@ -270,6 +289,7 @@ area_list:
   goto_list: []
 - area_name: 国服-账号密码进入游戏-新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 608
   - 680
@@ -284,6 +304,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-登陆其他账号
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 614
   - 680
@@ -298,6 +319,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-点击登录
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 810
   - 846
@@ -312,6 +334,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-账号输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 368
@@ -326,6 +349,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-密码输入区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 612
   - 470
@@ -340,6 +364,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-账号密码进入游戏
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 608
   - 625
@@ -354,6 +379,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-换服
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 782
   - 966
@@ -368,6 +394,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-换服-欧洲
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 616
   - 428
@@ -382,6 +409,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-换服-美国
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 616
   - 518
@@ -396,6 +424,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-换服-亚洲
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 616
   - 616
@@ -410,6 +439,7 @@ area_list:
   goto_list: []
 - area_name: 国际服-换服-港澳台
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 616
   - 714
@@ -424,6 +454,7 @@ area_list:
   goto_list: []
 - area_name: 重试
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 822
   - 598
@@ -438,6 +469,7 @@ area_list:
   goto_list: []
 - area_name: 一周年自选奖励
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1576
   - 118

--- a/assets/game_data/screen_info/expert_challenge.yml
+++ b/assets/game_data/screen_info/expert_challenge.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 剩余电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1475
   - 1000
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 需要电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1535
   - 1000

--- a/assets/game_data/screen_info/fishing.yml
+++ b/assets/game_data/screen_info/fishing.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 指令文本区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 286
   - 110
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按键-时机上鱼
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1516
   - 798
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按键-左
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 253
   - 816
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按键-右
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1516
   - 798
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 按键-返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 54
   - 8
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-点击空白处关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 824
   - 966
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 标题-挑战结果
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 602
   - 110
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-确定
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 870
   - 866
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 按键-强力-左
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 130
   - 744
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 按键-强力-右
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1686
   - 746

--- a/assets/game_data/screen_info/hdd.yml
+++ b/assets/game_data/screen_info/hdd.yml
@@ -3,6 +3,8 @@ screen_name: HDD
 pc_alt: false
 area_list:
 - area_name: 章节显示
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1510
   - 0
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 章节列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1508
   - 104
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 委托区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 256
   - 124
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 下一步
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1592
   - 1004
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 副本区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 964
   - 192
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 出战
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1626
   - 1004
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 街区
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 230
   - 24
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 空白
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 416
   - 28
@@ -90,7 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 确定并出战
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1026
   - 602
@@ -101,3 +135,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/hollow_zero_battle.yml
+++ b/assets/game_data/screen_info/hollow_zero_battle.yml
@@ -3,6 +3,8 @@ screen_name: 零号空洞-战斗
 pc_alt: false
 area_list:
 - area_name: 鸣徽-确定
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 860
   - 776
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 战斗结果-确定
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1048
   - 810
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 挑战结果
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 556
   - 8
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 退出战斗
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1614
   - 1006
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 退出战斗-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1026
   - 604
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 结算周期上限-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 878
   - 598
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 通关-丁尼奖励
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1312
   - 530
@@ -79,3 +105,5 @@ area_list:
   template_sub_dir: hollow
   template_id: critical_reward_money
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/hollow_zero_entry.yml
+++ b/assets/game_data/screen_info/hollow_zero_entry.yml
@@ -3,6 +3,8 @@ screen_name: 零号空洞-入口
 pc_alt: false
 area_list:
 - area_name: 街区
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 236
   - 26
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 副本列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1128
   - 184
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 下一步
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1584
   - 1002
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 出战
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1628
   - 1002
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 继续-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1036
   - 604
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 行动中-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 884
   - 606
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 奖励入口
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 68
   - 946
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 悬赏委托
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1548
   - 0
@@ -90,7 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 全部领取
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1586
   - 1002
@@ -101,3 +135,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/hollow_zero_event.yml
+++ b/assets/game_data/screen_info/hollow_zero_event.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 事件文本
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1230
   - 4
@@ -14,9 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 角色-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 830
   - 966
@@ -27,9 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 角色-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 930
   - 966
@@ -40,9 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 角色-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 966
@@ -53,9 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 呼叫增援-角色行
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1232
   - 434
@@ -66,9 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 消息-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 880
   - 626
@@ -79,9 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 空白
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 22
   - 1060
@@ -92,9 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 底部-清除列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 278
   - 678
@@ -105,9 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 底部-选择列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 332
   - 752
@@ -118,9 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 背包
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1448
   - 980
@@ -131,9 +150,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 通关-完成
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1564
   - 1004
@@ -144,9 +165,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽名称-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 416
   - 490
@@ -157,9 +180,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽名称-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 832
   - 490
@@ -170,9 +195,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽名称-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1248
   - 490
@@ -183,9 +210,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽选择-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 456
   - 774
@@ -196,9 +225,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽选择-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 872
   - 774
@@ -209,9 +240,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 鸣徽选择-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1284
   - 774
@@ -222,9 +255,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 快进
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 174
   - 25
@@ -235,9 +270,11 @@ area_list:
   template_sub_dir: hollow
   template_id: speed_up
   template_match_threshold: 0.9
+  color_range: null
   goto_list: []
 - area_name: 当前层数
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 420
   - 38
@@ -248,9 +285,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 放弃
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1564
   - 1004
@@ -261,9 +300,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 放弃-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1024
   - 600
@@ -274,9 +315,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 菜单
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 74
   - 28
@@ -287,9 +330,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 背包已满
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 826
   - 344
@@ -300,9 +345,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 旧都失物-返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -313,9 +360,11 @@ area_list:
   template_sub_dir: menu
   template_id: back
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 格子入口选项
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1392
   - 750
@@ -326,9 +375,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 交互可再次触发事件
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1004
   - 884
@@ -339,4 +390,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []

--- a/assets/game_data/screen_info/hollow_zero_merchant.yml
+++ b/assets/game_data/screen_info/hollow_zero_merchant.yml
@@ -3,6 +3,8 @@ screen_name: 零号空洞-商店
 pc_alt: false
 area_list:
 - area_name: 右上角-返回
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1773
   - 25
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: hollow
   template_id: right_top_back
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 购买后确定
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 846
   - 768
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 二级标题
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1266
   - 28
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1306
   - 374
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品描述区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1416
   - 258
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品购买区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1800
   - 290
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: hollow
   template_id: merchant_add
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格-3-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1290
   - 376
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格-3-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1290
   - 568
@@ -90,7 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格-3-3
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1290
   - 758
@@ -101,7 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格-2-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1290
   - 472
@@ -112,7 +150,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 商品价格-2-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1290
   - 660
@@ -123,3 +165,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/life_on_line.yml
+++ b/assets/game_data/screen_info/life_on_line.yml
@@ -3,6 +3,8 @@ screen_name: 真拿命验收
 pc_alt: false
 area_list:
 - area_name: 第二章间章
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1510
   - 2
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 对话选项
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1434
   - 640
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 对话人
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 890
   - 798
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 确定并出战
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1026
   - 602
@@ -46,3 +60,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/lost_void_bangboo_store.yml
+++ b/assets/game_data/screen_info/lost_void_bangboo_store.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 文本-详情
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 192
   - 22
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-刷新
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1678
   - 1002
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 区域-藏品名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 90
   - 480
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 区域-价格
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 90
   - 735
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 区域-购买按钮
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 90
   - 780
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-购买-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1034
   - 600
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-刷新-可用
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1678
   - 1002
@@ -122,6 +130,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-刷新-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1034
   - 600
@@ -136,6 +145,7 @@ area_list:
   goto_list: []
 - area_name: 标识-血量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1485
   - 1000
@@ -150,6 +160,7 @@ area_list:
   goto_list: []
 - area_name: 标识-金币
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1485
   - 1000
@@ -164,6 +175,7 @@ area_list:
   goto_list: []
 - area_name: 区域-角色头像
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1224
   - 20

--- a/assets/game_data/screen_info/lost_void_battle_fail.yml
+++ b/assets/game_data/screen_info/lost_void_battle_fail.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-撤退
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 530
   - 850
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-重播
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 878
   - 850
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-分析
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1226
   - 848

--- a/assets/game_data/screen_info/lost_void_battle_result.yml
+++ b/assets/game_data/screen_info/lost_void_battle_result.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-挑战结果
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 566
   - 92
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-确定
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1054
   - 900
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-完成
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 1002
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 奖励-零号业绩
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1312
   - 486
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 奖励-丁尼
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1312
   - 486

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 文本-详情
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 74
   - 24
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-确定
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 866
   - 712
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 区域-藏品名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 90
   - 508
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 区域-武备名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 415
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 区域-标题
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 760
   - 146
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 迷失之地-TAB
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 0
   - 482
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-刷新
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1672
   - 22
@@ -108,6 +115,7 @@ area_list:
   goto_list: []
 - area_name: 区域-藏品已选择
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 210
@@ -122,6 +130,7 @@ area_list:
   goto_list: []
 - area_name: 区域-武备标识
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 80
   - 730

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -19,7 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-确定
   id_mark: true
-  gray_mark: false
+  gray_mark: true
   pc_rect:
   - 866
   - 712

--- a/assets/game_data/screen_info/lost_void_entry.yml
+++ b/assets/game_data/screen_info/lost_void_entry.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-街区
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 234
   - 26
@@ -19,6 +20,7 @@ area_list:
   - 大世界-普通
 - area_name: 按钮-悬赏委托
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1550
   - 24
@@ -33,6 +35,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-战线肃清
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 850
   - 206
@@ -48,6 +51,7 @@ area_list:
   - 迷失之地-战线肃清
 - area_name: 按钮-悬赏委托-全部领取
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1342
   - 316
@@ -62,6 +66,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-悬赏委托-关闭
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1526
   - 198
@@ -76,6 +81,7 @@ area_list:
   goto_list: []
 - area_name: 按键-特遣调查
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 196
   - 212

--- a/assets/game_data/screen_info/lost_void_entry_task_force.yml
+++ b/assets/game_data/screen_info/lost_void_entry_task_force.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-街区
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 238
   - 26
@@ -19,6 +20,7 @@ area_list:
   - 大世界
 - area_name: 菜单-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -34,6 +36,7 @@ area_list:
   - 迷失之地-入口
 - area_name: 按钮-特遣任务
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1322
   - 1002
@@ -48,6 +51,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-下一步
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1606
   - 1002
@@ -62,6 +66,7 @@ area_list:
   goto_list: []
 - area_name: 区域-代理人头像
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 990
   - 396
@@ -76,6 +81,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-调查战略
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1708
   - 198

--- a/assets/game_data/screen_info/lost_void_gear.yml
+++ b/assets/game_data/screen_info/lost_void_gear.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-携带
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1732
   - 846
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 文本-详情
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 186
   - 28
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 武备列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 190
   - 892
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 等级列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 300
   - 920

--- a/assets/game_data/screen_info/lost_void_lottery.yml
+++ b/assets/game_data/screen_info/lost_void_lottery.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-奖励预览
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1620
   - 36
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-开始
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 804
   - 904
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 文本-剩余次数
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 874
   - 902
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-获取确定
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 790
   - 10

--- a/assets/game_data/screen_info/lost_void_normal_world.yml
+++ b/assets/game_data/screen_info/lost_void_normal_world.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 区域-文本提示
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1564
   - 50
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-挑战-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 604
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 区域-对话角色名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 860
   - 798
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按键-交互-不可用
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1400
   - 916
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 迷失之地-TAB
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 0
   - 482
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 战斗-菜单
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 58
   - 40
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 区域-对话内容
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 406
   - 878
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 区域-右侧对话选项
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1438
   - 536
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 区域-右侧对话图标
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1438
   - 536
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 区域-交互文本
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 726
   - 10

--- a/assets/game_data/screen_info/lost_void_purge.yml
+++ b/assets/game_data/screen_info/lost_void_purge.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-战线肃清
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 986
   - 208
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-街区
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 234
   - 26
@@ -33,6 +35,7 @@ area_list:
   - 大世界-普通
 - area_name: 周期增益-第一个
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1000
   - 388
@@ -47,6 +50,7 @@ area_list:
   goto_list: []
 - area_name: 周期增益-第二个
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1000
   - 536
@@ -61,6 +65,7 @@ area_list:
   goto_list: []
 - area_name: 周期增益-第三个
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1000
   - 678
@@ -75,6 +80,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-难度
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1578
   - 22
@@ -89,6 +95,7 @@ area_list:
   goto_list: []
 - area_name: 区域-难度列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 94
@@ -103,6 +110,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-调查战略
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1708
   - 198

--- a/assets/game_data/screen_info/lost_void_route_change.yml
+++ b/assets/game_data/screen_info/lost_void_route_change.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 58
   - 10
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-图例详情
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 86
   - 1006

--- a/assets/game_data/screen_info/map.yml
+++ b/assets/game_data/screen_info/map.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 传送点名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 70
   - 1000
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1024
   - 600

--- a/assets/game_data/screen_info/menu.yml
+++ b/assets/game_data/screen_info/menu.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 返回
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 邮件
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 934
   - 544
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 底部列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 200
   - 924
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 更多登出确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1036
   - 604
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 更多功能区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 474
   - 280
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 兑换码输入框
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 718
   - 536
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 兑换码兑换
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 878
   - 690
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -117,6 +125,7 @@ area_list:
   - 大世界-普通
 - area_name: 底部-快捷手册
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 200
   - 924
@@ -132,6 +141,7 @@ area_list:
   - 快捷手册-训练
 - area_name: 按钮-朋友
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 495
   - 11
@@ -146,6 +156,7 @@ area_list:
   goto_list: []
 - area_name: 底部-仓库
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 200
   - 924
@@ -161,6 +172,7 @@ area_list:
   - 仓库-音擎仓库
 - area_name: 底部-邮件
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 200
   - 924
@@ -176,6 +188,7 @@ area_list:
   - 邮件
 - area_name: 底部-更多
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 200
   - 924
@@ -191,6 +204,7 @@ area_list:
   - 菜单-更多功能
 - area_name: 文本-电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1200
   - 25

--- a/assets/game_data/screen_info/menu_more.yml
+++ b/assets/game_data/screen_info/menu_more.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-更多功能
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 522
   - 210
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-关闭
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1302
   - 166
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-预备编队
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 478
   - 282
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-兑换码
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 478
   - 282

--- a/assets/game_data/screen_info/news_stand.yml
+++ b/assets/game_data/screen_info/news_stand.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 刮刮卡
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 94
   - 956
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 每日可刮取一次
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 704
   - 656
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 刮层-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 780
   - 522
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 刮层-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 782
   - 556
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 刮层-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 788
   - 590
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 叫醒他
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1434
   - 638
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 嗷呜被你叫醒了
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 780
   - 518
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 嗷呜对话
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 686
   - 830
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 嗷呜标题
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 890
   - 792
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 叫醒嗷呜
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1434
   - 638
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: 对话选项
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1438
   - 560
@@ -158,6 +169,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-同类型确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 602

--- a/assets/game_data/screen_info/noodle_shop.yml
+++ b/assets/game_data/screen_info/noodle_shop.yml
@@ -3,6 +3,8 @@ screen_name: 拉面店
 pc_alt: false
 area_list:
 - area_name: 点单
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1678
   - 678
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 拉面列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 106
   - 820
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 点单确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 620
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 效果确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 882
   - 622
@@ -46,3 +60,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/normal_world.yml
+++ b/assets/game_data/screen_info/normal_world.yml
@@ -4,6 +4,7 @@ pc_alt: true
 area_list:
 - area_name: 信息
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1728
   - 918
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 菜单
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 54
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 地图
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1730
   - 318
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 快捷手册
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1530
   - 44
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 好感度标题
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 892
   - 798
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 好感度选项
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1420
   - 552
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 对话框取消
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 726
   - 600
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 小地图
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1630
   - 183

--- a/assets/game_data/screen_info/normal_world_basic.yml
+++ b/assets/game_data/screen_info/normal_world_basic.yml
@@ -4,6 +4,7 @@ pc_alt: true
 area_list:
 - area_name: 按钮-信息
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1728
   - 918
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-菜单
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 96
   - 34

--- a/assets/game_data/screen_info/notorious_hunt.yml
+++ b/assets/game_data/screen_info/notorious_hunt.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 副本名称列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 240
   - 216
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 剩余次数
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 384
   - 996
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 当期剩余奖励次数
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 192
   - 992
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 选择
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 860
   - 772
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 重新开始
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1228
   - 1008
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 重新开始-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 奖励入口
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 68
   - 948
@@ -102,6 +109,7 @@ area_list:
   goto_list: []
 - area_name: 全部领取
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1192
   - 344
@@ -116,6 +124,7 @@ area_list:
   goto_list: []
 - area_name: 难度选择入口
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 24
@@ -130,6 +139,7 @@ area_list:
   goto_list: []
 - area_name: 难度选择区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1570
   - 100
@@ -144,6 +154,7 @@ area_list:
   goto_list: []
 - area_name: 鸣徽交互区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 218
   - 218
@@ -158,6 +169,7 @@ area_list:
   goto_list: []
 - area_name: 剩余奖励次数
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1380
   - 1004
@@ -172,6 +184,7 @@ area_list:
   goto_list: []
 - area_name: 退出战斗
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1614
   - 1004
@@ -186,6 +199,7 @@ area_list:
   goto_list: []
 - area_name: 退出战斗-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602
@@ -200,6 +214,7 @@ area_list:
   goto_list: []
 - area_name: 挑战结果-退出
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1562
   - 1006
@@ -214,6 +229,7 @@ area_list:
   goto_list: []
 - area_name: 区域-鸣徽选择列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 160
   - 772
@@ -228,6 +244,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-深度追猎-ON
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1658
   - 672
@@ -248,6 +265,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-深度追猎-确认
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 602
@@ -262,6 +280,7 @@ area_list:
   goto_list: []
 - area_name: 文本-剩余电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1465
   - 1000
@@ -276,6 +295,7 @@ area_list:
   goto_list: []
 - area_name: 文本-需要电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1533
   - 1000
@@ -290,6 +310,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-无报酬模式
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1602
   - 1000
@@ -304,6 +325,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-街区
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 238
   - 24
@@ -318,6 +340,7 @@ area_list:
   goto_list: []
 - area_name: 标题-副本名称
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 750
   - 168
@@ -332,6 +355,7 @@ area_list:
   goto_list: []
 - area_name: 标识-BOSS血条
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1620
   - 16

--- a/assets/game_data/screen_info/random_play.yml
+++ b/assets/game_data/screen_info/random_play.yml
@@ -3,6 +3,8 @@ screen_name: 影像店营业
 pc_alt: false
 area_list:
 - area_name: 昨日账本
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 528
   - 224
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 返回
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 54
   - 12
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 宣传员入口
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 800
   - 620
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 录像带入口
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1106
   - 618
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 经营状况
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1272
   - 14
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 录像带主题-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 784
   - 136
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 录像带主题-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 914
   - 136
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 录像带主题-3
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1030
   - 136
@@ -90,7 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 宣传员-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 532
   - 144
@@ -101,7 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 宣传员-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 744
   - 144
@@ -112,7 +150,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1590
   - 1004
@@ -123,7 +165,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 上架筛选
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1588
   - 28
@@ -134,7 +180,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 主题筛选
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1124
   - 104
@@ -145,7 +195,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 上架
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1628
   - 1004
@@ -156,7 +210,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 下架
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1628
   - 1004
@@ -167,7 +225,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 选择宣传员
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 104
   - 1006
@@ -178,7 +240,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 开始营业
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1536
   - 950
@@ -189,7 +255,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 开始营业-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1032
   - 600
@@ -200,7 +270,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 正在营业
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1536
   - 950
@@ -211,7 +285,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 推荐上架
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1320
   - 1002
@@ -222,7 +300,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 宣传员列表
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 530
   - 140
@@ -233,3 +315,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/ridu_weekly.yml
+++ b/assets/game_data/screen_info/ridu_weekly.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 丽都周纪
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 414
   - 812
@@ -14,9 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 代办列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 534
   - 400
@@ -27,9 +30,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 确认代办
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 818
   - 798
@@ -40,9 +45,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 领取
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 452
   - 804
@@ -53,9 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 未完成
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 452
   - 804
@@ -66,9 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 任务区域
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 168
   - 260
@@ -79,9 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 领取奖励
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1558
   - 314
@@ -92,9 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 积分行-1
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 170
   - 440
@@ -105,9 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 积分行-2
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 170
   - 670
@@ -118,9 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 积分行-3
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 170
   - 900
@@ -131,4 +150,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []

--- a/assets/game_data/screen_info/routine_cleanup.yml
+++ b/assets/game_data/screen_info/routine_cleanup.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 副本名称列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 148
   - 714
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 剩余电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1430
   - 1000
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 需要电量
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1497
   - 1000

--- a/assets/game_data/screen_info/shiyu_defense.yml
+++ b/assets/game_data/screen_info/shiyu_defense.yml
@@ -3,6 +3,8 @@ screen_name: 式舆防卫战
 pc_alt: false
 area_list:
 - area_name: 节点区域
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -13,7 +15,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 节点-01
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -24,7 +30,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_01
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 节点-02
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -35,7 +45,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_02
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 街区
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 238
   - 28
@@ -46,7 +60,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 弱点-1-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 850
   - 520
@@ -57,7 +75,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 弱点-1-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1080
   - 520
@@ -68,7 +90,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 弱点-2-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1390
   - 520
@@ -79,7 +105,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 弱点-2-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1620
   - 520
@@ -90,7 +120,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 抗性-1-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 850
   - 645
@@ -101,7 +135,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 抗性-1-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1080
   - 645
@@ -112,7 +150,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 抗性-2-1
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1390
   - 645
@@ -123,7 +165,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 抗性-2-2
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1620
   - 645
@@ -134,7 +180,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 角色头像
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 768
   - 738
@@ -145,7 +195,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 下一步
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1570
   - 1004
@@ -156,7 +210,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 退出战斗
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1614
   - 1004
@@ -167,7 +225,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 退出战斗-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1034
   - 604
@@ -178,7 +240,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 战斗结束-下一防线
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1242
   - 1006
@@ -189,7 +255,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 战斗结束-退出
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1566
   - 1006
@@ -200,7 +270,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 战斗结束-撤退
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 532
   - 848
@@ -211,7 +285,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 节点-03
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -222,7 +300,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_03
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 节点-04
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -233,7 +315,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_04
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 节点-05
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -244,7 +330,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_05
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 节点-06
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -255,7 +345,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_06
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 节点-07
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 100
   - 174
@@ -266,7 +360,11 @@ area_list:
   template_sub_dir: shiyu_defense
   template_id: node_07
   template_match_threshold: 0.9
+  color_range: null
+  goto_list: []
 - area_name: 奖励入口
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 66
   - 948
@@ -277,7 +375,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 全部领取
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1274
   - 328
@@ -288,7 +390,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 领取奖励-确认
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 878
   - 706
@@ -299,7 +405,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 领取奖励-关闭
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1434
   - 196
@@ -310,7 +420,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 前次行动最佳记录
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 500
   - 234
@@ -321,7 +435,11 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 前次-关闭
+  id_mark: false
+  gray_mark: false
   pc_rect:
   - 1374
   - 228
@@ -332,3 +450,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/storage_drive_disc.yml
+++ b/assets/game_data/screen_info/storage_drive_disc.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-驱动仓库
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 70
   - 116
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-拆解
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 250
   - 900
@@ -33,6 +35,7 @@ area_list:
   - 仓库-驱动仓库-驱动盘拆解
 - area_name: 左上角-街区
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 236
   - 28

--- a/assets/game_data/screen_info/storage_wengine.yml
+++ b/assets/game_data/screen_info/storage_wengine.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-音擎仓库
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 70
   - 116
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-回收
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 250
   - 900
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 左上角-街区
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 238
   - 26
@@ -47,6 +50,7 @@ area_list:
   - 大世界-普通
 - area_name: TAB-驱动盘
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1510
   - 126

--- a/assets/game_data/screen_info/suibian_temple_craft.yml
+++ b/assets/game_data/screen_info/suibian_temple_craft.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 标题-制造坊
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 160
   - 6
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 菜单-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 区域-商品列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 306
   - 326

--- a/assets/game_data/screen_info/suibian_temple_entry.yml
+++ b/assets/game_data/screen_info/suibian_temple_entry.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-邻里街坊
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1332
   - 922
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-派驻邦布
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 110
   - 740
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-游历
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1524
   - 578
@@ -60,6 +64,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-经营
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1246
   - 578
@@ -74,6 +79,7 @@ area_list:
   goto_list: []
 - area_name: 标题-制造坊
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 166
   - 10
@@ -88,6 +94,7 @@ area_list:
   goto_list: []
 - area_name: 区域-制造坊商品列表
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 306
   - 326

--- a/assets/game_data/screen_info/suibian_temple_squad.yml
+++ b/assets/game_data/screen_info/suibian_temple_squad.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-游历小队
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1556
   - 20
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 菜单-返回
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 82
   - 13
@@ -32,6 +34,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-街区
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 234
   - 20
@@ -46,6 +49,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-自动选择邦布
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1324
   - 902

--- a/assets/game_data/screen_info/suibian_temple_yumchaxian.yml
+++ b/assets/game_data/screen_info/suibian_temple_yumchaxian.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 按钮-定期采办
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1586
   - 110
@@ -18,6 +19,7 @@ area_list:
   goto_list: []
 - area_name: 按钮-邻里心愿
   id_mark: true
+  gray_mark: false
   pc_rect:
   - 1306
   - 110

--- a/assets/game_data/screen_info/trigrams_collection.yml
+++ b/assets/game_data/screen_info/trigrams_collection.yml
@@ -4,6 +4,7 @@ pc_alt: false
 area_list:
 - area_name: 区域-获取卦象
   id_mark: false
+  gray_mark: false
   pc_rect:
   - 1318
   - 298

--- a/src/one_dragon/base/screen/screen_area.py
+++ b/src/one_dragon/base/screen/screen_area.py
@@ -17,6 +17,7 @@ class ScreenArea:
                  template_match_threshold: float = 0.7,
                  pc_alt: bool = False,
                  id_mark: bool = False,
+                 gray_mark: bool = False,
                  goto_list: Optional[list[str]] = None,
                  color_range: Optional[list[list[int]]] = None,
                  ):
@@ -29,6 +30,7 @@ class ScreenArea:
         self.template_match_threshold: float = template_match_threshold
         self.pc_alt: bool = pc_alt  # PC端需要使用ALT后才能点击
         self.id_mark: bool = id_mark  # 是否用于画面的唯一标识
+        self.gray_mark: bool = gray_mark  # 是否灰度化区域
         self.goto_list: list[str] = [] if goto_list is None else goto_list  # 交互后 可能会跳转的画面名称列表
         self.color_range: Optional[list[list[int]]] = color_range  # 识别时候的筛选的颜色范围 文本时候有效
 
@@ -127,6 +129,7 @@ class ScreenArea:
         order_dict = dict()
         order_dict['area_name'] = self.area_name
         order_dict['id_mark'] = self.id_mark
+        order_dict['gray_mark'] = self.gray_mark
         order_dict['pc_rect'] = [self.pc_rect.x1, self.pc_rect.y1, self.pc_rect.x2, self.pc_rect.y2]
         order_dict['text'] = self.text
         order_dict['lcs_percent'] = self.lcs_percent

--- a/src/one_dragon/base/screen/screen_info.py
+++ b/src/one_dragon/base/screen/screen_info.py
@@ -78,6 +78,7 @@ class ScreenInfo(YamlOperator):
                 color_range=data_area.get('color_range'),
                 pc_alt=self.pc_alt,
                 id_mark=data_area.get('id_mark', False),
+                gray_mark=data_area.get('gray_mark', False),
                 goto_list=data_area.get('goto_list', [])
             )
             self.area_list.append(area)

--- a/src/one_dragon/base/screen/screen_utils.py
+++ b/src/one_dragon/base/screen/screen_utils.py
@@ -54,6 +54,11 @@ def find_area_in_screen(ctx: OneDragonContext, screen: MatLike, area: ScreenArea
     find: bool = False
     if area.is_text_area:
         if ctx.env_config.ocr_cache:
+            if area.gray_mark:
+                # 对区域进行灰度化处理
+                gray_image = cv2.cvtColor(screen, cv2.COLOR_BGR2GRAY)
+                # 保持3通道以便于OCR处理
+                screen = cv2.cvtColor(gray_image, cv2.COLOR_GRAY2RGB)
             ocr_result_map = ctx.ocr_service.get_ocr_result_list(
                 image=screen,
                 color_range=area.color_range,
@@ -63,6 +68,11 @@ def find_area_in_screen(ctx: OneDragonContext, screen: MatLike, area: ScreenArea
             rect = area.rect
             part = cv2_utils.crop_image_only(screen, rect)
 
+            if area.gray_mark:
+                # 对区域进行灰度化处理
+                gray_image = cv2.cvtColor(part, cv2.COLOR_BGR2GRAY)
+                # 保持3通道以便于OCR处理
+                part = cv2.cvtColor(gray_image, cv2.COLOR_GRAY2RGB)
             if area.color_range is None:
                 to_ocr = part
             else:
@@ -81,6 +91,12 @@ def find_area_in_screen(ctx: OneDragonContext, screen: MatLike, area: ScreenArea
     elif area.is_template_area:
         rect = area.rect
         part = cv2_utils.crop_image_only(screen, rect)
+
+        if area.gray_mark:
+            # 对区域进行灰度化处理
+            gray_image = cv2.cvtColor(part, cv2.COLOR_BGR2GRAY)
+            # 保持3通道以便于OCR处理
+            part = cv2.cvtColor(gray_image, cv2.COLOR_GRAY2RGB)
 
         mrl = ctx.tm.match_template(part, area.template_sub_dir, area.template_id,
                                     threshold=area.template_match_threshold)

--- a/src/one_dragon/base/screen/设计文档.md
+++ b/src/one_dragon/base/screen/设计文档.md
@@ -87,6 +87,7 @@ sequenceDiagram
 - **text**: 文本识别内容（文本区域）
 - **template_id**: 模板标识（模板区域）
 - **id_mark**: 是否为画面唯一标识区域
+- **gray_mark**: 画面是否需要灰度化处理
 - **goto_list**: 点击后可能跳转的画面列表
 - **color_range**: 颜色筛选范围
 
@@ -267,6 +268,7 @@ pc_alt: false
 area_list:
   - area_name: "开始游戏"
     id_mark: true
+    gray_mark: false
     pc_rect: [100, 200, 300, 250]
     text: "开始游戏"
     lcs_percent: 0.8

--- a/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
+++ b/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
@@ -123,7 +123,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
         self.area_table.setBorderVisible(True)
         self.area_table.setBorderRadius(8)
         self.area_table.setWordWrap(True)
-        self.area_table.setColumnCount(10)
+        self.area_table.setColumnCount(11)
         self.area_table.verticalHeader().hide()
         self.area_table.setHorizontalHeaderLabels([
             gt('操作'),
@@ -135,6 +135,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
             gt('阈值'),
             gt('颜色范围'),
             gt('唯一标识'),
+            gt('灰度化'),
             gt('前往画面')
         ])
         self.area_table.setColumnWidth(0, 40)  # 操作
@@ -239,6 +240,11 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
             id_check.setProperty('area_name', area_item.area_name)
             id_check.stateChanged.connect(self.on_area_id_check_changed)
 
+            gray_check = CheckBox()
+            gray_check.setChecked(area_item.gray_mark)
+            gray_check.setProperty('area_name', area_item.area_name)
+            gray_check.stateChanged.connect(self.on_area_gray_check_changed)
+
             self.area_table.setCellWidget(idx, 0, del_btn)
             self.area_table.setItem(idx, 1, QTableWidgetItem(area_item.area_name))
             self.area_table.setItem(idx, 2, QTableWidgetItem(str(area_item.pc_rect)))
@@ -248,7 +254,8 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
             self.area_table.setItem(idx, 6, QTableWidgetItem(str(area_item.template_match_threshold)))
             self.area_table.setItem(idx, 7, QTableWidgetItem(str(area_item.color_range_display_text)))
             self.area_table.setCellWidget(idx, 8, id_check)
-            self.area_table.setItem(idx, 9, QTableWidgetItem(area_item.goto_list_display_text))
+            self.area_table.setCellWidget(idx, 9, gray_check)
+            self.area_table.setItem(idx, 10, QTableWidgetItem(area_item.goto_list_display_text))
 
 
         add_btn = ToolButton(FluentIcon.ADD, parent=None)
@@ -263,6 +270,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
         self.area_table.setItem(area_cnt, 7, QTableWidgetItem(''))
         self.area_table.setItem(area_cnt, 8, QTableWidgetItem(''))
         self.area_table.setItem(area_cnt, 9, QTableWidgetItem(''))
+        self.area_table.setItem(area_cnt, 10, QTableWidgetItem(''))
 
         self.area_table.blockSignals(False)
 
@@ -558,6 +566,16 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface):
             if row_idx < 0 or row_idx >= len(self.chosen_screen.area_list):
                 return
             self.chosen_screen.area_list[row_idx].id_mark = btn.isChecked()
+
+    def on_area_gray_check_changed(self):
+        if self.chosen_screen is None:
+            return
+        btn: CheckBox = self.sender()
+        if btn is not None:
+            row_idx = self.area_table.indexAt(btn.pos()).row()
+            if row_idx < 0 or row_idx >= len(self.chosen_screen.area_list):
+                return
+            self.chosen_screen.area_list[row_idx].gray_mark = btn.isChecked()
 
     def on_area_table_cell_clicked(self, row: int, column: int):
         if self.area_table_row_selected == row:


### PR DESCRIPTION
新增灰度标记<gray_mark>功能，以及find_area_in_screen函数中对于gray_mark的相关处理 #1242 

1、鉴于这个问题具有普遍性，可能还会在其他场合发生。
①为所有的screen_info增添了gray_mark选项，默认值为false，即是否在识别前进行灰度化处理
②仅为（src\one_dragon\base\screen\screen_utils.py）find_area_in_screen函数增加了gray_mark的判断以及灰度化处理，因为其他涉及到识别的函数还很多，我需要先整理一下才知道是哪些，还不便乱加处理。
2、新增了以上功能后，解决了识别问题。
③仅为<迷失之地-通用选择>设置了gray_mark:true，其他场景均为false
3、修改代码后，完整的运行了一遍<迷失之地>，问题没有复现，成功运行，log文件如下
[log.txt](https://github.com/user-attachments/files/21488976/log.txt)
