### PR TITLE
fix: 修复打断状态其实没有效果的BUG，优化青衣闪电鞭

### DIFF
--- a/config/auto_battle_operation/青衣-特殊技.sample.yml
+++ b/config/auto_battle_operation/青衣-特殊技.sample.yml
@@ -5,6 +5,4 @@ operations:
     seconds: 1.5
   - op_name: "按键-特殊攻击"
     post_delay: 0.1
-    repeat: 15
-  - op_name: "设置状态"
-    state: "自定义-青衣-续普攻"
+    repeat: 10

--- a/config/auto_battle_operation/青衣-终结技.sample.yml
+++ b/config/auto_battle_operation/青衣-终结技.sample.yml
@@ -5,9 +5,9 @@ operations:
     seconds_add: -1
   - op_name: "设置状态"
     state: "自定义-动作不打断"
-    seconds: 4.7
+    seconds: 4.5
   - op_name: "按键-终结技"
     post_delay: 0.1
     repeat: 30
   - op_name: "等待秒数"
-    seconds: 1.7
+    seconds: 1.5

--- a/config/auto_battle_operation/青衣-醉花云月转.sample.yml
+++ b/config/auto_battle_operation/青衣-醉花云月转.sample.yml
@@ -3,15 +3,14 @@ operations:
   - op_name: "设置状态"
     state: "自定义-青衣-醉花云月转"
 
-  - op_name: "按键-普通攻击"
-    way: "按下"
-    press: 2
+  - op_name: "按键-普通攻击-按下"
   - op_name: "清除状态"
     state: "自定义-青衣-醉花云月转"
-
-  - op_name: "按键-普通攻击"
-    way: "松开"
+  - op_name: "等待秒数"
+    seconds: 2
+  - op_name: "按键-普通攻击-松开"
   - op_name: "设置状态"
+  
     state: "自定义-动作不打断"
     seconds: 1.2
   - op_name: "等待秒数"

--- a/config/auto_battle_operation/青衣-闪电鞭.sample.yml
+++ b/config/auto_battle_operation/青衣-闪电鞭.sample.yml
@@ -1,0 +1,5 @@
+# 根据动画实测
+operations:
+  - op_name: "按键-普通攻击"
+    post_delay: 0.1
+    repeat: 999

--- a/config/auto_battle_state_handler/速切模板-青衣.sample.yml
+++ b/config/auto_battle_state_handler/速切模板-青衣.sample.yml
@@ -21,7 +21,7 @@ handlers:
           - states: "[按键可用-快速支援, 0, 0.5]"
             operations:
               - op_name: "等待秒数"
-                seconds: 1.0
+                seconds: 0.3
           - states: ""
             operations:
               - op_name: "等待秒数"
@@ -31,37 +31,17 @@ handlers:
         operations:
           - operation_template: "青衣-醉花云月转"
 
-      - states: "[自定义-青衣-续普攻, 0, 1]"
-        sub_handlers:
-          - states: "[青衣-电压]{0, 40}"
-            operations:
-              - operation_template: "青衣-续普攻"
-          - states: "[青衣-电压]{40, 100}"
-            operations:
-              - operation_template: "青衣-续普攻"
-              - operation_template: "青衣-醉花云月转"
-
-      - states: "[青衣-终结技可用]"
+      - states: "[青衣-终结技可用] & [青衣-电压]{0,25}"
         operations:
           - operation_template: "青衣-终结技"
-          - operation_template: "青衣-醉花云月转"
 
       - states: "[青衣-特殊技可用]"
-        sub_handlers:
-          - states: "[青衣-电压]{0, 60}"
-            operations:
-              - operation_template: "青衣-特殊技"
-          - states: "[青衣-电压]{60, 100}"
-            operations:
-              - operation_template: "青衣-特殊技"
-              - operation_template: "青衣-醉花云月转"
+        interrupt_states: "[青衣-电压]{75,100}"
+        operations:
+        - operation_template: "青衣-特殊技"
+        - operation_template: "青衣-闪电鞭"
 
       - states: "[青衣-电压]{0, 75}"
-        sub_handlers:
-          - states: "[青衣-电压]{0, 40}"
-            operations:
-              - operation_template: "青衣-普通攻击"
-          - states: "[青衣-电压]{40, 100}"
-            operations:
-              - operation_template: "青衣-普通攻击"
-              - operation_template: "青衣-醉花云月转"
+        interrupt_states: "[青衣-电压]{75,100}"
+        operations:
+          - operation_template: "青衣-闪电鞭"

--- a/config/auto_battle_state_handler/闪A模板-青衣.sample.yml
+++ b/config/auto_battle_state_handler/闪A模板-青衣.sample.yml
@@ -12,28 +12,12 @@ handlers:
           - op_name: "按键-普通攻击"
             post_delay: 0.1
             repeat: 12
-      - states: "[青衣-电压]{60, 75}"
-        operations:
-          - op_name: "设置状态"
-            state: "自定义-动作不打断"
-            seconds: 1
-          - op_name: "等待秒数"
-            seconds: 0.05
-          - operation_template: "通用-闪避-左"
-          - op_name: "按键-普通攻击"
-            post_delay: 0.1
-            repeat: 10
-          - operation_template: "青衣-醉花云月转"
       - states: ""
         operations:
           - op_name: "设置状态"
             state: "自定义-动作不打断"
             seconds: 1
-          - op_name: "等待秒数"
-            seconds: 0.05
           - operation_template: "通用-闪避-左"
           - op_name: "按键-普通攻击"
             post_delay: 0.1
             repeat: 10
-          - op_name: "设置状态"
-            state: "自定义-青衣-续普攻"

--- a/src/one_dragon/base/conditional_operation/conditional_operator.py
+++ b/src/one_dragon/base/conditional_operation/conditional_operator.py
@@ -328,15 +328,11 @@ class ConditionalOperator(YamlConfig):
             with self._task_lock:
                 interrupt: bool = False
                 if (self.running_task is not None and self.running_task.running
-                        and self.running_task.interrupt_states is not None
-                        and len(self.running_task.interrupt_states) > 0):
-                    for state_record in state_records:
-                        if state_record.is_clear:
-                            continue
-                        if state_record.state_name in self.running_task.interrupt_states:
-                            interrupt = True
-                            log.debug('出现打断场景 %s', state_record.state_name)
-                            break
+                        and self.running_task.interrupt_cal_tree is not None):
+                    now = time.time()
+                    if self.running_task.interrupt_cal_tree.in_time_range(now):
+                        interrupt = True
+                        log.debug('复合中断条件满足，执行中断')
                 if interrupt:
                     self._stop_running_task()
 

--- a/src/one_dragon/base/conditional_operation/operation_task.py
+++ b/src/one_dragon/base/conditional_operation/operation_task.py
@@ -1,9 +1,10 @@
 from concurrent.futures import ThreadPoolExecutor, Future
 
 from threading import Lock
-from typing import Optional, List, Set
+from typing import Optional, List
 
 from one_dragon.base.conditional_operation.atomic_op import AtomicOp
+from one_dragon.base.conditional_operation.state_cal_tree import StateCalNode
 from one_dragon.utils import thread_utils
 from one_dragon.utils.log_utils import log
 
@@ -18,7 +19,7 @@ class OperationTask:
         :param op_list:
         """
         self.trigger: Optional[str] = None  # 触发器
-        self.interrupt_states: Set[str] = set()  # 可被打断的状态
+        self.interrupt_cal_tree: Optional['StateCalNode'] = None  # 可被打断的状态
         self.is_trigger: bool = False  # 是否触发器场景
         self.priority: Optional[int] = None  # 优先级 只能被高等级的打断；为None时可以被随意打断
 
@@ -127,14 +128,13 @@ class OperationTask:
         self.trigger = trigger
         self.is_trigger = trigger is not None and trigger != ''
 
-    def add_interrupt_states(self, interrupt_states: Set[str]) -> None:
+    def set_interrupt_cal_tree(self, interrupt_cal_tree: Optional['StateCalNode']) -> None:
         """
         添加可打断的场景
-        :param interrupt_states: 可以被打断的状态
+        :param interrupt_cal_tree: 可以被打断的状态
         :return:
         """
-        if interrupt_states is not None:
-            self.interrupt_states.update(interrupt_states)
+        self.interrupt_cal_tree = interrupt_cal_tree
 
     @property
     def expr_display(self) -> str:

--- a/src/one_dragon/base/conditional_operation/utils.py
+++ b/src/one_dragon/base/conditional_operation/utils.py
@@ -115,9 +115,10 @@ def construct_state_handler(
         debug_name = f'[#{debug_name}]'  # 添加方括号
 
     state_cal_tree = construct_state_cal_tree(states_expr, state_getter, debug_name)
-    interrupt_states = state_data.get('interrupt_states', None)
-    if interrupt_states is not None:
-        interrupt_states = set(interrupt_states)
+    interrupt_expr = state_data.get('interrupt_states', None)
+    interrupt_cal_tree = None
+    if interrupt_expr is not None and isinstance(interrupt_expr, str) and len(interrupt_expr) > 0:
+        interrupt_cal_tree = construct_state_cal_tree(interrupt_expr, state_getter)
     # sub_states 是旧的 后续可以删除
     if 'sub_states' in state_data or 'sub_handlers' in state_data:
         if 'sub_states' in state_data:
@@ -138,7 +139,7 @@ def construct_state_handler(
         )
         return StateHandler(states_expr, state_cal_tree,
                           sub_handlers=sub_handler_list,
-                          interrupt_states=interrupt_states,
+                          interrupt_cal_tree=interrupt_cal_tree,
                           debug_name=debug_name)  # 新增：传入debug_name
     else:
         ops = get_ops_from_data(
@@ -149,7 +150,7 @@ def construct_state_handler(
             raise ValueError('状态( %s )下指令为空', states_expr)
         return StateHandler(states_expr, state_cal_tree,
                           operations=ops,
-                          interrupt_states=interrupt_states,
+                          interrupt_cal_tree=interrupt_cal_tree,
                           debug_name=debug_name)  # 新增：传入debug_name
 
 


### PR DESCRIPTION
feat(conditional_operation): 增强 interrupt_states 以支持复杂表达式

**功能增强:**

`interrupt_states` 字段现在支持与 `states` 字段完全相同的复杂表达式解析，包括值范围、逻辑运算符（&, |, !）和括号。这允许定义更精确、更灵活的操作中断条件。

**修改原因:**

旧的 `interrupt_states` 实现只能处理简单的状态名称列表，无法解析带有值范围（如 `[状态]{min,max}`）或逻辑组合的表达式，导致功能受限且与 `states` 字段的行为不一致。

**实现方式:**

1.  **复用解析逻辑**: 将 `interrupt_states` 的解析统一到 `construct_state_cal_tree` 函数，复用现有的状态表达式解析能力。
2.  **更新数据结构**: 在 `StateHandler` 和 `OperationTask` 中，使用 `interrupt_cal_tree` (StateCalNode) 替代原有的 `interrupt_states` (Set[str])，以存储解析后的状态树。
3.  **修复嵌套Bug**: 修正了在嵌套 `sub_handlers` 中，父级的 `interrupt_cal_tree` 会覆盖子级中断树的问题，现在会通过 `OR` 逻辑将它们正确合并。
4.  **更新中断判断**: 修改了 `ConditionalOperator` 中的中断逻辑，使其使用解析后的 `interrupt_cal_tree` 进行判断。

**重要：配置变更:**

为了使用此新功能，`interrupt_states` 在 YAML 配置文件中的格式已从**列表（list）**变更为**单一字符串（string）**。

**用法示例:**

**旧格式 (不再支持):**
```yaml
interrupt_states:
  - "[状态A]{10,20}"
  
**新格式 (合法):**
  # 单一条件
interrupt_states: "[状态A]{10,20}"

# 使用 OR 逻辑组合多个条件
interrupt_states: "[状态A]{10,20} | [状态B]"

# 使用 AND 和 NOT 逻辑的复杂条件
interrupt_states: "([状态A] > 50 & ![状态C]) | [状态D]"