### PR TITLE
refactor: 重写主页ui

### DIFF
--- a/src/one_dragon_qt/_rc/qss/dark/game_button.qss
+++ b/src/one_dragon_qt/_rc/qss/dark/game_button.qss
@@ -2,7 +2,7 @@ PrimaryPushButton {
     color: black;
     background-color: #f5d742;
     border: none;
-    border-radius: 20px;
+    border-radius: 4px;
 }
 
 PrimaryPushButton:hover {

--- a/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
@@ -1,10 +1,14 @@
-#title { color: #fff; }
+#title {
+    color: #fff;
+}
 
 #title:hover {
     color: #f5d742;
 }
 
-#date { color: #ddd; }
+#date {
+    color: #ddd;
+}
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
@@ -1,10 +1,10 @@
-#title { color: #fff !important; }
+#title { color: #fff; }
 
 #title:hover {
     color: #f5d742;
 }
 
-#date { color: #ddd !important; }
+#date { color: #ddd; }
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
@@ -27,7 +27,7 @@ QStackedWidget {
     color: #f5d742;
     background-color: #333333;
     border: 2px solid #f5d742;
-    border-radius: 10px;
+    border-radius: 4px;
     padding: 5px;
     font-size: 12px;
 }

--- a/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/dark/notice_card.qss
@@ -1,14 +1,10 @@
-#title {
-    color: #fff;
-}
+#title { color: #fff !important; }
 
 #title:hover {
     color: #f5d742;
 }
 
-#date {
-    color: #fff;
-}
+#date { color: #ddd !important; }
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/_rc/qss/light/game_button.qss
+++ b/src/one_dragon_qt/_rc/qss/light/game_button.qss
@@ -2,7 +2,7 @@ PrimaryPushButton {
     color: black;
     background-color: #f5d742;
     border: none;
-    border-radius: 20px;
+    border-radius: 4px;
 }
 
 PrimaryPushButton:hover {

--- a/src/one_dragon_qt/_rc/qss/light/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/light/notice_card.qss
@@ -1,14 +1,10 @@
-#title {
-    color: #fff;
-}
+#title { color: #000 !important; }
 
 #title:hover {
     color: #f5d742;
 }
 
-#date {
-    color: #fff;
-}
+#date { color: #333 !important; }
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/_rc/qss/light/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/light/notice_card.qss
@@ -27,7 +27,7 @@ QStackedWidget {
     color: #f5d742;
     background-color: #333333;
     border: 2px solid #f5d742;
-    border-radius: 10px;
+    border-radius: 4px;
     padding: 5px;
     font-size: 12px;
 }

--- a/src/one_dragon_qt/_rc/qss/light/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/light/notice_card.qss
@@ -1,10 +1,10 @@
-#title { color: #000 !important; }
+#title { color: #000; }
 
 #title:hover {
     color: #f5d742;
 }
 
-#date { color: #333 !important; }
+#date { color: #333; }
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/_rc/qss/light/notice_card.qss
+++ b/src/one_dragon_qt/_rc/qss/light/notice_card.qss
@@ -1,10 +1,14 @@
-#title { color: #000; }
+#title {
+    color: #000;
+}
 
 #title:hover {
     color: #f5d742;
 }
 
-#date { color: #333; }
+#date {
+    color: #333;
+}
 
 QListWidget {
     background-color: transparent;

--- a/src/one_dragon_qt/widgets/banner.py
+++ b/src/one_dragon_qt/widgets/banner.py
@@ -56,7 +56,7 @@ class Banner(QWidget):
 
             # 创建圆角路径
             path = QPainterPath()
-            path.addRoundedRect(self.rect(), 20, 20)
+            path.addRoundedRect(self.rect(), 4, 4)
             painter.setClipPath(path)
 
             # 计算绘制位置，使图片居中

--- a/src/one_dragon_qt/widgets/notice_card.py
+++ b/src/one_dragon_qt/widgets/notice_card.py
@@ -270,7 +270,8 @@ class NoticeCard(SimpleCardWidget):
         self.mainLayout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # 亚克力背景层（轻量实现）
-        self._acrylic = AcrylicBackground(self, radius=4, tint=self._tint_for_theme())
+        acrylic_tint = QColor(20, 20, 20, 160) if qconfig.theme == Theme.DARK else QColor(245, 245, 245, 160)
+        self._acrylic = AcrylicBackground(self, radius=4, tint=acrylic_tint)
         # 确保阴影在后，背景在最底层
         self._acrylic.stackUnder(self)
 
@@ -467,9 +468,6 @@ class NoticeCard(SimpleCardWidget):
             widget.clear()
             self.add_posts_to_widget(widget, type)
 
-    def _tint_for_theme(self) -> QColor:
-        return QColor(20, 20, 20, 160) if qconfig.theme == Theme.DARK else QColor(245, 245, 245, 160)
-
     def apply_theme_colors(self):
         """在现有样式后附加文本颜色规则，确保覆盖资源 QSS。"""
         if qconfig.theme == Theme.DARK:
@@ -484,19 +482,9 @@ class NoticeCard(SimpleCardWidget):
 
     def _on_theme_changed(self):
         if hasattr(self, '_acrylic'):
-            self._acrylic.tint = self._tint_for_theme()
+            self._acrylic.tint = (QColor(20, 20, 20, 160) if qconfig.theme == Theme.DARK else QColor(245, 245, 245, 160))
             self._acrylic.update()
         self.apply_theme_colors()
-        self._update_shadow_color()
-
-    def _update_shadow_color(self):
-        # light: 中等阴影；dark: 稍弱，避免过黑
-        if qconfig.theme == Theme.DARK:
-            color = QColor(0, 0, 0, 170)
-        else:
-            color = QColor(0, 0, 0, 150)
-        if hasattr(self, '_shadow') and self._shadow:
-            self._shadow.setColor(color)
 
     def scrollNext(self):
         if self.banners:

--- a/src/one_dragon_qt/widgets/notice_card.py
+++ b/src/one_dragon_qt/widgets/notice_card.py
@@ -37,7 +37,7 @@ class SkeletonBanner(QFrame):
                     stop:0 rgba(240, 240, 240, 200),
                     stop:0.5 rgba(255, 255, 255, 230),
                     stop:1 rgba(240, 240, 240, 200));
-                border-radius: 10px;
+                border-radius: 4px;
                 border: 2px solid rgba(200, 200, 200, 100);
             }
         """)
@@ -75,7 +75,7 @@ class SkeletonContent(QWidget):
                         stop:0 rgba(224, 224, 224, 150),
                         stop:0.5 rgba(240, 240, 240, 200),
                         stop:1 rgba(224, 224, 224, 150));
-                    border-radius: 8px;
+                    border-radius: 4px;
                     border: 1px solid rgba(200, 200, 200, 80);
                 }
             """)
@@ -180,7 +180,7 @@ class DataFetcher(QThread):
 class NoticeCard(SimpleCardWidget):
     def __init__(self):
         SimpleCardWidget.__init__(self)
-        self.setBorderRadius(10)
+        self.setBorderRadius(4)
         self.setFixedWidth(351)
         self.mainLayout = QVBoxLayout(self)
         self.mainLayout.setContentsMargins(3, 3, 0, 0)
@@ -329,7 +329,7 @@ class NoticeCard(SimpleCardWidget):
 
         # 实现遮罩
         path = QPainterPath()
-        path.addRoundedRect(self.flipView.rect(), 10, 10, Qt.SizeMode.AbsoluteSize)
+        path.addRoundedRect(self.flipView.rect(), 4, 4, Qt.SizeMode.AbsoluteSize)
         region = QRegion(path.toFillPolygon().toPolygon())
         self.flipView.setMask(region)
 

--- a/src/one_dragon_qt/widgets/notice_card.py
+++ b/src/one_dragon_qt/widgets/notice_card.py
@@ -24,6 +24,32 @@ from one_dragon.utils.log_utils import log
 from .label import EllipsisLabel
 
 
+def get_notice_theme_palette():
+    """返回与主题相关的颜色配置。
+
+    返回:
+        dict: {
+            'tint': QColor,           # 背景半透明色
+            'title': str,             # 标题文本颜色
+            'date': str,              # 日期文本颜色
+            'shadow': QColor          # 外部阴影颜色
+        }
+    """
+    if qconfig.theme == Theme.DARK:
+        return {
+            'tint': QColor(20, 20, 20, 160),
+            'title': '#fff',
+            'date': '#ddd',
+            'shadow': QColor(0, 0, 0, 170),
+        }
+    else:
+        return {
+            'tint': QColor(245, 245, 245, 160),
+            'title': '#000',
+            'date': '#333',
+            'shadow': QColor(0, 0, 0, 150),
+        }
+
 class SkeletonBanner(QFrame):
     """骨架屏Banner组件 - 简化版"""
 
@@ -270,8 +296,8 @@ class NoticeCard(SimpleCardWidget):
         self.mainLayout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # 亚克力背景层（轻量实现）
-        acrylic_tint = QColor(20, 20, 20, 160) if qconfig.theme == Theme.DARK else QColor(245, 245, 245, 160)
-        self._acrylic = AcrylicBackground(self, radius=4, tint=acrylic_tint)
+        palette = get_notice_theme_palette()
+        self._acrylic = AcrylicBackground(self, radius=4, tint=palette['tint'])
         # 确保阴影在后，背景在最底层
         self._acrylic.stackUnder(self)
 
@@ -470,10 +496,8 @@ class NoticeCard(SimpleCardWidget):
 
     def apply_theme_colors(self):
         """在现有样式后附加文本颜色规则，确保覆盖资源 QSS。"""
-        if qconfig.theme == Theme.DARK:
-            title_color, date_color = "#fff", "#ddd"
-        else:
-            title_color, date_color = "#000", "#333"
+        palette = get_notice_theme_palette()
+        title_color, date_color = palette['title'], palette['date']
         extra = (
             f"\nQWidget#title, QLabel#title{{color:{title_color} !important;}}"
             f"\nQWidget#date, QLabel#date{{color:{date_color} !important;}}\n"
@@ -482,7 +506,7 @@ class NoticeCard(SimpleCardWidget):
 
     def _on_theme_changed(self):
         if hasattr(self, '_acrylic'):
-            self._acrylic.tint = (QColor(20, 20, 20, 160) if qconfig.theme == Theme.DARK else QColor(245, 245, 245, 160))
+            self._acrylic.tint = get_notice_theme_palette()['tint']
             self._acrylic.update()
         self.apply_theme_colors()
 
@@ -570,11 +594,7 @@ class NoticeCardContainer(QWidget):
         shadow = QGraphicsDropShadowEffect(self)
         shadow.setBlurRadius(36)
         shadow.setOffset(0, 12)
-        # 颜色与主题匹配
-        if qconfig.theme == Theme.DARK:
-            shadow.setColor(QColor(0, 0, 0, 170))
-        else:
-            shadow.setColor(QColor(0, 0, 0, 150))
+        shadow.setColor(get_notice_theme_palette()['shadow'])
         self.setGraphicsEffect(shadow)
 
         # 控制状态

--- a/src/one_dragon_qt/widgets/notice_card.py
+++ b/src/one_dragon_qt/widgets/notice_card.py
@@ -5,8 +5,8 @@ import json
 import os
 import requests
 import webbrowser
-from PySide6.QtCore import Qt, QSize, QTimer, QThread, Signal, QPoint, QRect, QRectF
-from PySide6.QtGui import QPixmap, QFont, QPainterPath, QRegion, QColor, QPainter, QImage
+from PySide6.QtCore import Qt, QSize, QTimer, QThread, Signal, QRectF
+from PySide6.QtGui import QPixmap, QFont, QPainterPath, QColor, QPainter, QImage
 from PySide6.QtWidgets import (
     QVBoxLayout,
     QListWidgetItem,
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QHBoxLayout,
     QStackedWidget,
-    QFrame, QGraphicsBlurEffect, QGraphicsScene, QGraphicsPixmapItem, QGraphicsDropShadowEffect,
+    QFrame, QGraphicsDropShadowEffect,
 )
 from qfluentwidgets import SimpleCardWidget, HorizontalFlipView, ListWidget, qconfig, Theme
 

--- a/src/one_dragon_qt/widgets/notice_card.py
+++ b/src/one_dragon_qt/widgets/notice_card.py
@@ -217,87 +217,46 @@ class DataFetcher(QThread):
 
 
 class AcrylicBackground(QWidget):
-    """轻量毛玻璃/Acrylic 半透明浅色底色 + 微弱噪声纹理 + 细边框，模拟材质质感
-    """
+    """“虚化”背景：半透明底色 + 轻噪声 + 细描边"""
 
-    def __init__(self, parent=None, radius: int = 10, blur_radius: float = 30.0, tint: QColor = QColor(245, 245, 245, 130)):
+    def __init__(self, parent=None, radius: int = 4, tint: QColor = QColor(245, 245, 245, 130)):
         super().__init__(parent)
         self.radius = radius
-        self.blur_radius = blur_radius
         self.tint = tint
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
-        self.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent, False) # 确保透明
-
-        # 创建用于模糊的场景和效果
-        self._blur_effect = QGraphicsBlurEffect(self)
-        self._blur_effect.setBlurRadius(self.blur_radius)
-        self._blur_effect.setBlurHints(QGraphicsBlurEffect.BlurHint.PerformanceHint) # 可以根据需要调整
-
-        self._scene = QGraphicsScene(self)
-        self._pixmap_item = QGraphicsPixmapItem()
-        self._pixmap_item.setGraphicsEffect(self._blur_effect)
-        self._scene.addItem(self._pixmap_item)
+        self.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent, False)
+        self._noise_tile = self._generate_noise_tile(64, 64)
 
     def _generate_noise_tile(self, width: int, height: int) -> QPixmap:
         img = QImage(width, height, QImage.Format.Format_ARGB32)
         for y in range(height):
             for x in range(width):
-                v = 235 + random.randint(-8, 8)  # 轻微灰度波动
+                v = 240 + random.randint(-10, 10)
                 v = max(0, min(255, v))
                 img.setPixel(x, y, QColor(v, v, v, 255).rgba())
         return QPixmap.fromImage(img)
 
-    def _blur_image(self, img: QImage) -> QImage:
-        """使用 QGraphicsBlurEffect 对图像进行高斯模糊"""
-        if img.isNull():
-            return img
-
-        # 将背景图设置到场景中
-        self._pixmap_item.setPixmap(QPixmap.fromImage(img))
-
-        # 渲染场景到一张新的图片上，从而应用模糊效果
-        blurred_img = QImage(img.size(), QImage.Format.Format_ARGB32_Premultiplied)
-        blurred_img.fill(Qt.GlobalColor.transparent)
-
-        painter = QPainter(blurred_img)
-        # 确保渲染区域和原图一致
-        self._scene.render(painter, source=QRectF(self._pixmap_item.pixmap().rect()))
-        painter.end()
-
-        return blurred_img
-
     def paintEvent(self, event):
-        if not self.parent():
-            return super().paintEvent(event)
-
-        w = self.window()
-        if w is None or not w.isVisible():
-            return super().paintEvent(event)
-
-        # 抓取窗口画面并裁剪到本控件区域
-        global_pos: QPoint = self.mapTo(w, QPoint(0, 0))
-        grab_rect = QRect(global_pos.x(), global_pos.y(), self.width(), self.height())
-
-        # 抓图前先临时隐藏自己，避免把自己也抓进去造成循环模糊
-        self.hide()
-        bg = w.grab(grab_rect).toImage()
-        self.show()
-
-        if bg.isNull():
-            return super().paintEvent(event)
-
-        blurred = self._blur_image(bg)
-
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
+        rectF = QRectF(self.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
         path = QPainterPath()
-        path.addRoundedRect(self.rect(), self.radius, self.radius)
-        painter.setClipPath(path)
+        path.addRoundedRect(rectF, self.radius, self.radius)
 
-        # 绘制模糊背景
-        painter.drawImage(0, 0, blurred)
+        # 半透明底色
         painter.fillPath(path, self.tint)
+
+        # 轻度噪声覆盖
+        painter.save()
+        painter.setClipPath(path)
+        painter.setOpacity(0.05)
+        painter.drawTiledPixmap(self.rect(), self._noise_tile)
+        painter.restore()
+
+        # 细描边
+        painter.setPen(QColor(255, 255, 255, 36))
+        painter.drawPath(path)
         painter.end()
 
 

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -318,6 +318,17 @@ class HomeInterface(VerticalScrollInterface):
         self.start_button.setFixedSize(max(180, text_width + 48), 48)
         self.start_button.clicked.connect(self._on_start_game)
 
+        # 按钮阴影
+        try:
+            from PySide6.QtWidgets import QGraphicsDropShadowEffect
+            shadow = QGraphicsDropShadowEffect(self.start_button)
+            shadow.setBlurRadius(24)
+            shadow.setOffset(0, 8)
+            shadow.setColor(QColor(0, 0, 0, 120))
+            self.start_button.setGraphicsEffect(shadow)
+        except Exception:
+            pass
+
         v1_layout = QVBoxLayout()
         # 保持到底部右侧，并设置离边缘约 1cm（根据屏幕 DPI 计算像素）
         screen = QApplication.primaryScreen()

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -293,8 +293,11 @@ class HomeInterface(VerticalScrollInterface):
         h2_layout = QHBoxLayout()
         h2_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        # 左边留白区域
-        h2_layout.addItem(QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
+        # 左边距 ~ 1cm（随 DPI 换算）
+        screen = QApplication.primaryScreen()
+        dpi = screen.logicalDotsPerInch() if screen else 96
+        two_cm_px = max(1, int(dpi * 1 / 2.54))
+        h2_layout.addItem(QSpacerItem(two_cm_px, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
 
         # 公告卡片
         self.notice_container = NoticeCardContainer()
@@ -308,11 +311,11 @@ class HomeInterface(VerticalScrollInterface):
         # 启动游戏按钮布局
         self.start_button = PrimaryPushButton(text="启动一条龙🚀")
         self.start_button.setObjectName("start_button")
-        self.start_button.setFont(QFont("Microsoft YaHei", 18, QFont.Weight.Bold))
+        self.start_button.setFont(QFont("Microsoft YaHei", 16, QFont.Weight.Bold))
         # 动态计算宽度：文本宽度 + 左右内边距（约 48px）
         fm = QFontMetrics(self.start_button.font())
         text_width = fm.horizontalAdvance(self.start_button.text())
-        self.start_button.setFixedSize(max(200, text_width + 56), 56)
+        self.start_button.setFixedSize(max(180, text_width + 48), 48)
         self.start_button.clicked.connect(self._on_start_game)
 
         v1_layout = QVBoxLayout()
@@ -320,13 +323,13 @@ class HomeInterface(VerticalScrollInterface):
         screen = QApplication.primaryScreen()
         dpi = screen.logicalDotsPerInch() if screen else 96
         one_cm_px = max(1, int(dpi / 2.54))
-        v1_layout.setContentsMargins(0, 0, one_cm_px, one_cm_px)
+        v1_layout.setContentsMargins(0, 0, one_cm_px, max(1, one_cm_px // 2))
         v1_layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignBottom)
 
         h2_layout.addLayout(v1_layout)
 
-        # 空白占位符（已由右侧布局 margin 控制，这里设为 0）
-        h2_layout.addItem(QSpacerItem(0, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
+        one_cm_px = max(0, int(dpi / 2.54))
+        v_layout.setContentsMargins(0, 0, 0, one_cm_px)
 
         # 将底部水平布局添加到垂直布局
         v_layout.addLayout(h2_layout)

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -293,11 +293,8 @@ class HomeInterface(VerticalScrollInterface):
         h2_layout = QHBoxLayout()
         h2_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        # 左边距 ~ 1cm（随 DPI 换算）
-        screen = QApplication.primaryScreen()
-        dpi = screen.logicalDotsPerInch() if screen else 96
-        two_cm_px = max(1, int(dpi * 1 / 2.54))
-        h2_layout.addItem(QSpacerItem(two_cm_px, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
+        # 左边距与右侧、顶部按钮组统一为 20px
+        h2_layout.addItem(QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
 
         # 公告卡片
         self.notice_container = NoticeCardContainer()
@@ -330,16 +327,16 @@ class HomeInterface(VerticalScrollInterface):
             pass
 
         v1_layout = QVBoxLayout()
-        # 保持到底部右侧，并设置离边缘约 1cm（根据屏幕 DPI 计算像素）
-        screen = QApplication.primaryScreen()
-        dpi = screen.logicalDotsPerInch() if screen else 96
-        one_cm_px = max(1, int(dpi / 2.54))
+        # 保持到底部右侧
         # 与顶部 ButtonGroup 的右侧间距（约 20px）对齐
         v1_layout.setContentsMargins(0, 0, 20, 0)
         v1_layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignBottom)
 
         h2_layout.addLayout(v1_layout)
 
+        # 底部保持约 1cm 间距
+        screen = QApplication.primaryScreen()
+        dpi = screen.logicalDotsPerInch() if screen else 96
         one_cm_px = max(0, int(dpi / 2.54))
         v_layout.setContentsMargins(0, 0, 0, one_cm_px)
 

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QSpacerItem,
     QSizePolicy,
     QApplication,
+    QWidget,
 )
 from qfluentwidgets import (
     FluentIcon,
@@ -291,11 +292,11 @@ class HomeInterface(VerticalScrollInterface):
         v_layout.addStretch()
 
         # 底部部分 (公告卡片 + 启动按钮)
-        h2_layout = QHBoxLayout()
+        bottom_bar = QWidget()
+        h2_layout = QHBoxLayout(bottom_bar)
         h2_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        # 左边距与右侧、顶部按钮组统一为 20px
-        h2_layout.addItem(QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum))
+        h2_layout.setContentsMargins(20, 0, 20, 0)
 
         # 公告卡片
         self.notice_container = NoticeCardContainer()
@@ -324,9 +325,7 @@ class HomeInterface(VerticalScrollInterface):
         self.start_button.setGraphicsEffect(shadow)
 
         v1_layout = QVBoxLayout()
-        # 保持到底部右侧
-        # 与顶部 ButtonGroup 的右侧间距（约 20px）对齐
-        v1_layout.setContentsMargins(0, 0, 20, 0)
+        v1_layout.setContentsMargins(0, 0, 0, 0)
         v1_layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignBottom)
 
         h2_layout.addLayout(v1_layout)
@@ -337,8 +336,8 @@ class HomeInterface(VerticalScrollInterface):
         one_cm_px = max(0, int(dpi / 2.54))
         v_layout.setContentsMargins(0, 0, 0, one_cm_px)
 
-        # 将底部水平布局添加到垂直布局
-        v_layout.addLayout(h2_layout)
+        # 将底部容器添加到主垂直布局
+        v_layout.addWidget(bottom_bar)
 
         # 初始化父类
         super().__init__(

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -334,7 +334,8 @@ class HomeInterface(VerticalScrollInterface):
         screen = QApplication.primaryScreen()
         dpi = screen.logicalDotsPerInch() if screen else 96
         one_cm_px = max(1, int(dpi / 2.54))
-        v1_layout.setContentsMargins(0, 0, one_cm_px, 0)
+        # 与顶部 ButtonGroup 的右侧间距（约 20px）对齐
+        v1_layout.setContentsMargins(0, 0, 20, 0)
         v1_layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignBottom)
 
         h2_layout.addLayout(v1_layout)

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -38,6 +38,8 @@ class ButtonGroup(SimpleCardWidget):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
 
+        self.setBorderRadius(4)
+
         self.setFixedSize(56, 180)
 
         layout = QVBoxLayout(self)


### PR DESCRIPTION
应邀，重写主页部分元素。

- 移除大部分不统一的圆角，统一改为4px。
- 为noticecard加入毛玻璃特效。
- 一条龙按钮动态背景拾色
- 加入阴影

<img width="1643" height="1095" alt="image" src="https://github.com/user-attachments/assets/348e6f6c-e8ae-4998-b2fb-4d5226353abb" />
<img width="1643" height="1095" alt="image" src="https://github.com/user-attachments/assets/d0f86803-2e70-4054-a6e8-0bfab7d5e0be" />

~~known issue: light mode的闪烁现象。可能由高斯模糊持续运算引起。尝试保留高斯模糊去除闪烁会导致卡顿。~~ 删了就没有这些问题

cc @idk500 @yokuminto 