### PR TITLE
feat: 优化迷失之地卡死的问题，优化成就模式武备鸣徽选择错误，新增换人优先级（脱困，移动前）

### DIFF
--- a/assets/image_analysis_pipelines/迷失之地-武备列表检测.yml
+++ b/assets/image_analysis_pipelines/迷失之地-武备列表检测.yml
@@ -16,6 +16,10 @@
   params:
     kernel_size: 3
     iterations: 1
+- step: 膨胀
+  params:
+    kernel_size: 3
+    iterations: 1
 - step: 查找轮廓
   params:
     mode: EXTERNAL
@@ -23,6 +27,6 @@
     draw_contours: 0
 - step: 按面积过滤
   params:
-    min_area: 1000
+    min_area: 2000
     max_area: 100000
     draw_contours: true

--- a/config/lost_void_challenge/成就模式.yml
+++ b/config/lost_void_challenge/成就模式.yml
@@ -1,6 +1,7 @@
 auto_battle: 全配队通用
 region_type_priority:
 - 战斗-武备
+- 战斗-鸣徽
 - 挑战-无伤
 - 邦布商店
 - 挚交会谈
@@ -8,18 +9,16 @@ region_type_priority:
 - 战斗-终结之役
 - 战斗-硬币
 - 挑战-限时
-- 战斗-鸣徽
 artifact_priority:
+- 无详情 获得鸣徽
+artifact_priority_2:
 - 终结
 - 绝境
 - 通用
-- 无详情 获得鸣徽
-artifact_priority_2:
-- 异常·击破 混沌量杯
-- 通用 三相战斗陀螺
-- 绝境
 buy_only_priority_1: 2
 buy_only_priority_2: 1
 period_buff_no: 第一个
 investigation_strategy: 攻其不备战略
 chase_new_mode: true
+artifact_priority_new: true
+store_blood: true

--- a/src/one_dragon/base/cv_process/cv_step.py
+++ b/src/one_dragon/base/cv_process/cv_step.py
@@ -50,6 +50,74 @@ class CvPipelineContext:
     def ocr(self):
         return self.service.ocr if self.service else None
 
+    def get_absolute_rects(self) -> List[tuple[int, int, int, int]]:
+        """
+        获取所有轮廓的绝对坐标矩形框(x1, y1, x2, y2格式)
+        Returns:
+            轮廓的绝对坐标列表，每个元素为 (x1, y1, x2, y2) 格式
+        """
+        rects = []
+        for contour in self.contours:
+            x, y, w, h = cv2.boundingRect(contour)
+            # 转换为绝对坐标
+            x1 = x + self.crop_offset[0]
+            y1 = y + self.crop_offset[1]
+            x2 = x1 + w
+            y2 = y1 + h
+            rects.append((x1, y1, x2, y2))
+        return rects
+
+    def get_absolute_rect_pairs(self) -> List[tuple[np.ndarray, tuple[int, int, int, int]]]:
+        """
+        获取轮廓和对应的绝对坐标矩形框对(x1, y1, x2, y2格式)
+        Returns:
+            轮廓和对应绝对坐标的列表，每个元素为 (轮廓, (x1, y1, x2, y2))
+        """
+        pairs = []
+        for contour in self.contours:
+            x, y, w, h = cv2.boundingRect(contour)
+            # 转换为绝对坐标
+            x1 = x + self.crop_offset[0]
+            y1 = y + self.crop_offset[1]
+            x2 = x1 + w
+            y2 = y1 + h
+            pairs.append((contour, (x1, y1, x2, y2)))
+        return pairs
+
+    def format_absolute_rect_xywh(self, x: int, y: int, w: int, h: int) -> str:
+        """
+        格式化相对矩形坐标为xywh格式的绝对坐标字符串
+        Args:
+            x: 相对X坐标
+            y: 相对Y坐标
+            w: 宽度
+            h: 高度
+
+        Returns:
+            绝对矩形坐标的字符串表示，格式如: "(100, 200, 50, 30)"，表示(x, y, w, h)
+        """
+        abs_x = x + self.crop_offset[0]
+        abs_y = y + self.crop_offset[1]
+        return f"({abs_x}, {abs_y}, {w}, {h})"
+
+    def format_absolute_rect_xyxy(self, x: int, y: int, w: int, h: int) -> str:
+        """
+        格式化相对矩形坐标为xyxy格式的绝对坐标字符串
+        Args:
+            x: 相对X坐标
+            y: 相对Y坐标
+            w: 宽度
+            h: 高度
+
+        Returns:
+            绝对矩形坐标的字符串表示，格式如: "(100, 200, 150, 230)"，表示(x1, y1, x2, y2)
+        """
+        x1 = x + self.crop_offset[0]
+        y1 = y + self.crop_offset[1]
+        x2 = x1 + w
+        y2 = y1 + h
+        return f"({x1}, {y1}, {x2}, {y2})"
+
 
 class CvStep:
     """

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -192,13 +192,14 @@ class LostVoidMoveByDet(ZOperation):
                     self.get_out_of_stuck()
             self.last_target_result = None
             return self.round_success(LostVoidMoveByDet.STATUS_NO_FOUND)
-
         self.last_target_result = target_result
         pos = target_result.entire_rect.center
         turn = self.turn_to_target(pos)
         if turn:
             return self.round_wait('转动朝向目标', wait=0.5)
 
+        # 移动前切换到最佳角色
+        auto_battle_utils.switch_to_best_agent_for_moving(self.ctx.lost_void.auto_op)
         return self.round_success('开始移动')
 
     @node_from(from_name='移动前转向', status='开始移动')
@@ -262,57 +263,71 @@ class LostVoidMoveByDet(ZOperation):
             min_turn = 5
             max_turn = 200
 
-        screen_center_x = self.ctx.controller.standard_width / 2  # 屏幕中心X坐标
-        diff_x = target.x - screen_center_x  # 目标与中心的差距
+        screen_center_x = self.ctx.controller.standard_width / 2
+        screen_center_y = self.ctx.controller.standard_height / 2
+        diff_x = target.x - screen_center_x
+        diff_y = target.y - screen_center_y
 
-        # 在中心区域内，无需转动
-        if abs(diff_x) <= 50:
+        # --- X轴转向计算 (逻辑完全不变) ---
+        turn_distance_x = 0
+        if abs(diff_x) > 50:
+            # 根据上次转向的实际效果，动态校准转向比例
+            if self.last_target_x is not None and self.last_actual_turn_distance != 0:
+                last_diff_x = self.last_target_x - screen_center_x
+                actual_pixel_moved = diff_x - last_diff_x
+
+                # 当目标穿越中心点(过冲)时，强力抑制，比例减半并重置校准过程
+                if last_diff_x * diff_x < 0:
+                    self.estimated_turn_ratio *= 0.5
+                    self.turn_calibration_count = 1
+                # 正常校准：使用移动平均法平滑更新比例
+                elif abs(actual_pixel_moved) > 1:
+                    current_ratio = abs(self.last_actual_turn_distance / actual_pixel_moved)
+                    if self.turn_calibration_count == 1:  # 首次校准，直接采用侦察值
+                        self.estimated_turn_ratio = current_ratio
+                    else:  # 后续校准，使用移动平均法平滑更新
+                        n = self.turn_calibration_count
+                        self.estimated_turn_ratio = (self.estimated_turn_ratio * (n - 1) + current_ratio) / n
+                    self.turn_calibration_count += 1
+
+            # 计算转向指令，首次使用固定值进行侦察，后续使用自适应指令
+            if self.turn_calibration_count == 1:
+                turn_distance_x = 5 if diff_x > 0 else -5
+                self.turn_calibration_count += 1
+            else:
+                turn_distance_x = int(diff_x * self.estimated_turn_ratio)
+
+            # 限制指令幅度，防止过小或过大
+            if 0 < abs(turn_distance_x) < min_turn:
+                turn_distance_x = min_turn if turn_distance_x > 0 else -min_turn
+            elif abs(turn_distance_x) > max_turn:
+                turn_distance_x = max_turn if turn_distance_x > 0 else -max_turn
+
+        # --- Y轴转向计算 (您的三值逻辑) ---
+        turn_distance_y = 0
+        if diff_y > 300:
+            turn_distance_y = 10
+        elif diff_y < -300:
+            turn_distance_y = -10
+
+        # --- 如果没有任何移动指令，则提前返回 ---
+        if turn_distance_x == 0 and turn_distance_y == 0:
             return False
 
-        # 根据上次转向的实际效果，动态校准转向比例
-        if self.last_target_x is not None and self.last_actual_turn_distance != 0:
-            last_diff_x = self.last_target_x - screen_center_x
-            actual_pixel_moved = diff_x - last_diff_x
-
-            # 当目标穿越中心点(过冲)时，强力抑制，比例减半并重置校准过程
-            if last_diff_x * diff_x < 0:
-                self.estimated_turn_ratio *= 0.5
-                self.turn_calibration_count = 1
-            # 正常校准：使用移动平均法平滑更新比例
-            elif abs(actual_pixel_moved) > 1:
-                current_ratio = abs(self.last_actual_turn_distance / actual_pixel_moved)
-                if self.turn_calibration_count == 1:  # 首次校准，直接采用侦察值
-                    self.estimated_turn_ratio = current_ratio
-                else:  # 后续校准，使用移动平均法平滑更新
-                    n = self.turn_calibration_count
-                    self.estimated_turn_ratio = (self.estimated_turn_ratio * (n - 1) + current_ratio) / n
-                self.turn_calibration_count += 1
-
-        # 计算转向指令，首次使用固定值进行侦察，后续使用自适应指令
-        if self.turn_calibration_count == 1:
-            turn_distance = 30 if diff_x > 0 else -30
-            self.turn_calibration_count += 1
-        else:
-            turn_distance = int(diff_x * self.estimated_turn_ratio)
-
-        # 限制指令幅度，防止过小或过大
-        if 0 < abs(turn_distance) < min_turn:
-            turn_distance = min_turn if turn_distance > 0 else -min_turn
-        elif abs(turn_distance) > max_turn:
-            turn_distance = max_turn if turn_distance > 0 else -max_turn
-
+        # --- 执行转向并更新状态 ---
         if self.ctx.env_config.is_debug:
-            log.debug(f'转向指令: {turn_distance}, 当前比例: {self.estimated_turn_ratio:.4f}, 移动中: {is_moving}')
-        self.ctx.controller.turn_by_distance(turn_distance)
+            log.debug(f'转向指令: X={turn_distance_x}, Y={turn_distance_y}, 当前X比例: {self.estimated_turn_ratio:.4f}, 移动中: {is_moving}')
+
+        # 使用新的统一方法执行移动
+        self.ctx.controller.move_mouse_relative(turn_distance_x, turn_distance_y)
 
         self.total_turn_times += 1
 
-        # 更新状态，为下次校准做准备
+        # 只更新X轴的校准状态
         self.last_target_x = target.x
-        self.last_actual_turn_distance = turn_distance
+        self.last_actual_turn_distance = turn_distance_x
 
         return True
-
     def get_move_target(self, frame_result: DetectFrameResult) -> Optional[MoveTargetWrapper]:
         """
         获取移动目标
@@ -415,9 +430,8 @@ class LostVoidMoveByDet(ZOperation):
         脱困
         @return:
         """
-        # 在大世界 先切换到耀佳音以外的角色 防止进入状态无法移动
-        auto_battle_utils.check_astra_and_switch(self.ctx.lost_void.auto_op)
-
+        # 在大世界 先切换到移动最优角色
+        auto_battle_utils.switch_to_best_agent_for_moving(self.ctx.lost_void.auto_op)
         # 部分障碍物可以破坏 尝试攻击
         self.ctx.controller.normal_attack(press=True, press_time=0.2, release=True)
 

--- a/src/zzz_od/application/shiyu_defense/agent_selector.py
+++ b/src/zzz_od/application/shiyu_defense/agent_selector.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+from zzz_od.auto_battle.auto_battle_agent_context import TeamInfo, AgentInfo
+from zzz_od.game_data.agent import Agent, AgentEnum, AgentTypeEnum
+
+
+def get_best_agent_for_moving(team_info: TeamInfo) -> Optional[AgentInfo]:
+    """
+    从队伍中获取最适合移动的角色
+    :param team_info:
+    :return:
+    """
+    if team_info is None or len(team_info.agent_list) == 0:
+        return None
+
+    best_agent: Optional[AgentInfo] = None
+    best_priority = 99
+
+    for team_agent_info in team_info.agent_list:
+        agent = team_agent_info.agent
+        if agent is None:
+            continue
+
+        priority = _get_agent_priority(agent)
+
+        if priority < best_priority:
+            best_priority = priority
+            best_agent = team_agent_info
+
+    return best_agent
+
+
+def _get_agent_priority(agent: Agent) -> int:
+    """
+    获取角色的优先级
+    :param agent:
+    :return:
+    """
+    # -- 特殊角色判断 --
+    # 耀嘉音
+    if agent.agent_id == 'astra_yao':
+        return 5
+    # 雅, 仪玄, 青衣, 比利, 猫又
+    if agent.agent_id in ['hoshimi_miyabi', 'yixuan', 'qingyi', 'billy', 'nekomata']:
+        return 4
+    # 熊
+    if agent.agent_id in ['ben', 'panyinhu']:
+        return 0
+
+    # -- 类型判断 --
+    # 支援
+    if agent.agent_type == AgentTypeEnum.SUPPORT:
+        return 1
+    # 防护
+    if agent.agent_type == AgentTypeEnum.DEFENSE:
+        return 2
+
+    # -- 其他 --
+    return 3

--- a/src/zzz_od/application/shiyu_defense/shiyu_defense_battle.py
+++ b/src/zzz_od/application/shiyu_defense/shiyu_defense_battle.py
@@ -132,8 +132,7 @@ class ShiyuDefenseBattle(ZOperation):
         if not result2.is_success:
             # 交互和普通攻击都没有找到 说明战斗胜利了
             return self.round_success(ShiyuDefenseBattle.STATUS_TO_NEXT_PHASE)
-
-        auto_battle_utils.check_astra_and_switch(self.auto_op)  # 移动前如果是耀嘉音就切人
+        auto_battle_utils.switch_to_best_agent_for_moving(self.auto_op)  # 移动前切换到最佳角色
 
         self.check_distance(self.last_screenshot)
 

--- a/src/zzz_od/application/world_patrol/operation/world_patrol_run_route.py
+++ b/src/zzz_od/application/world_patrol/operation/world_patrol_run_route.py
@@ -167,10 +167,7 @@ class WorldPatrolRunRoute(ZOperation):
                                )
 
     def _get_rid_of_stuck(self):
-        # 在大世界，若当前前台为耀嘉音，先切换以避免进入状态无法移动
-        if getattr(self.ctx, 'auto_op', None) is not None:
-            auto_battle_utils.check_astra_and_switch(self.ctx.auto_op)
-
+        auto_battle_utils.switch_to_best_agent_for_moving(self.auto_op)  # 移动前切换到最佳角色
         log.info('本次脱困方向 %s' % self.stuck_move_direction)
         if self.stuck_move_direction == 0:  # 向左走
             self.ctx.controller.move_a(press=True, press_time=1, release=True)

--- a/src/zzz_od/controller/zzz_pc_controller.py
+++ b/src/zzz_od/controller/zzz_pc_controller.py
@@ -325,3 +325,13 @@ class ZPcController(PcControllerBase):
         :return:
         """
         ctypes.windll.user32.mouse_event(0x0001, 0, int(d))
+
+    def move_mouse_relative(self, dx: float, dy: float):
+        """
+        相对移动鼠标
+        :param dx: 横向移动距离，正数向右
+        :param dy: 纵向移动距离，正数向下
+        """
+        if dx == 0 and dy == 0:
+            return
+        ctypes.windll.user32.mouse_event(0x0001, int(dx), int(dy))

--- a/src/zzz_od/operation/challenge_mission/exit_in_battle.py
+++ b/src/zzz_od/operation/challenge_mission/exit_in_battle.py
@@ -20,19 +20,11 @@ class ExitInBattle(ZOperation):
 
     @operation_node(name='画面识别', is_start_node=True, node_max_retry_times=10)
     def check_screen(self) -> OperationRoundResult:
-        result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-普通攻击')
-        if result.is_success:
-            result2 = self.round_by_click_area('战斗画面', '菜单')
-            if result2.is_success:
-                return self.round_wait(result2.status, wait=1)
-            else:
-                return self.round_retry(result2.status, wait=1)
-
         # 点击直到出现 [退出战斗] 按钮
         result = self.round_by_find_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
         if result.is_success:
             return self.round_success(wait=1)  # 稍微等一下让按钮可按
-
+        result = self.round_by_click_area('战斗画面', '菜单')
         return self.round_retry(result.status, wait=1)
 
     @node_from(from_name='画面识别')

--- a/src/zzz_od/operation/challenge_mission/restart_in_battle.py
+++ b/src/zzz_od/operation/challenge_mission/restart_in_battle.py
@@ -17,19 +17,11 @@ class RestartInBattle(ZOperation):
 
     @operation_node(name='画面识别', is_start_node=True, node_max_retry_times=10)
     def check_screen(self) -> OperationRoundResult:
-        result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-普通攻击')
-        if result.is_success:
-            result2 = self.round_by_click_area('战斗画面', '菜单')
-            if result2.is_success:
-                return self.round_wait(result2.status, wait=1)
-            else:
-                return self.round_retry(result2.status, wait=1)
-
         # 点击直到出现 [退出战斗] 按钮
         result = self.round_by_find_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
         if result.is_success:
             return self.round_success(wait=1)  # 稍微等一下让按钮可按
-
+        result = self.round_by_click_area('战斗画面', '菜单')
         return self.round_retry(result.status, wait=1)
 
     @node_from(from_name='画面识别')
@@ -45,3 +37,19 @@ class RestartInBattle(ZOperation):
         return self.round_by_find_and_click_area(screen_name='战斗-菜单', area_name='按钮-退出战斗-确认',
                                                  until_not_find_all=[('战斗-菜单', '按钮-退出战斗-确认')],
                                                  success_wait=1, retry_wait=1)
+
+def __debug():
+    """
+    调试用
+    """
+    ctx = ZContext()
+    ctx.init_by_config()
+    ctx.init_ocr()
+    ctx.start_running()
+
+    op = RestartInBattle(ctx)
+    op.execute()
+
+
+if __name__ == "__main__":
+    __debug()


### PR DESCRIPTION
1、去掉了重开/退出中对普攻按钮的检测，因为邦布没有普攻，某个pr之后，修复因为wait是无法重新截图的，导致永远找不到
2、cvpipe新增绝对坐标返回，减少调用困难。
3、优化迷失之地武备鸣徽选择错误。
4、优化迷失之地转向效果。
5、新增换人优先级