### PR TITLE
fix: 修复迷失之地区域文本范围太小的问题

### DIFF
--- a/assets/game_data/screen_info/lost_void_normal_world.yml
+++ b/assets/game_data/screen_info/lost_void_normal_world.yml
@@ -131,10 +131,10 @@ area_list:
 - area_name: 区域-交互文本
   id_mark: false
   pc_rect:
-  - 726
-  - 10
-  - 1362
-  - 1070
+  - 480
+  - 100
+  - 1440
+  - 1058
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''


### PR DESCRIPTION
经常走到点了还来回跑，原因就是范围太小了