### PR TITLE
fix: 修复体力计划配置恶名狩猎后, 必须重启脚本, 否则陷入 在作战页查找深度追猎节点的问题

### DIFF
--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -41,7 +41,8 @@ class ChargePlanItem:
             notorious_hunt_buff_num: int = 1,
             plan_id: Optional[str] = None,
     ):
-        self.tab_name: str = tab_name
+        # 如果是恶名狩猎类型，tab_name应该是作战
+        self.tab_name: str = '作战' if category_name == '恶名狩猎' else tab_name
         self.category_name: str = category_name
         self.mission_type_name: str = mission_type_name
         self.mission_name: str = mission_name


### PR DESCRIPTION
这里的问题是在保存时会根据 category_name 来决定 tab_name，如果 category_name 是 '恶名狩猎'，就会把 tab_name 设置为 '作战'。但是：

数据读取时并没有这个处理逻辑
在执行体力计划时，发生了如下错误：
尝试使用 "训练" 作为 tab_name
尝试在 "训练" tab下查找 "恶名狩猎" 分类
因为恶名狩猎不在训练tab下，所以找不到
建议修改如下：

在 ChargePlanItem 的 __init__ 方法中增加初始化时的处理：
charge_plan_config.py+2-1
这样修改后：

无论是从UI添加还是从配置文件读取，只要 category_name 是 "恶名狩猎"，就会自动把 tab_name 设为 "作战"
保持了和保存时相同的逻辑
避免了在游戏中查找错误的tab页的问题
这样应该能解决 "恶名狩猎" 任务找不到的问题。建议你重新启动后再试试看。

这个问题的根本原因是游戏中 "恶名狩猎" 任务在 "作战" tab页下，而不是在 "训练" tab页下。之前的代码在保存时会正确处理这个关系，但在读取和初始化时没有相应的处理，导致了这个问题。