### PR TITLE
fix: 添加或更新体力计划时tab_name错误

### DIFF
--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -86,7 +86,7 @@ class ChargePlanConfig(YamlConfig):
 
         for plan_item in self.plan_list:
             plan_data = {
-                'tab_name': '作战' if plan_item.category_name == '恶名狩猎' else '训练',
+                'tab_name': plan_item.tab_name,
                 'category_name': plan_item.category_name,
                 'mission_type_name': plan_item.mission_type_name,
                 'mission_name': plan_item.mission_name,
@@ -119,20 +119,7 @@ class ChargePlanConfig(YamlConfig):
 
         YamlConfig.save(self)
 
-    def add_plan(self, properties: dict) -> None:
-        plan = ChargePlanItem(
-            tab_name=properties.get('tab_name', '训练'),
-            category_name=properties.get('category_name', '实战模拟室'),
-            mission_type_name=properties.get('mission_type_name', '基础材料'),
-            mission_name=properties.get('mission_name', '调查专项'),
-            level=properties.get('level', '默认等级'),
-            auto_battle_config=properties.get('auto_battle_config', '全配队通用'),
-            run_times=properties.get('run_times', 0),
-            plan_times=properties.get('plan_times', 1),
-            card_num=properties.get('card_num', str(CardNumEnum.DEFAULT.value.value)),
-            predefined_team_idx=properties.get('predefined_team_idx', 0),
-            notorious_hunt_buff_num=properties.get('notorious_hunt_buff_num', 1),
-        )
+    def add_plan(self, plan: ChargePlanItem) -> None:
         self.plan_list.append(plan)
         self.save()
 

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_dialog.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_dialog.py
@@ -36,7 +36,7 @@ class ChargePlanDialog(MessageBoxBase):
             predefined_team_idx=0,
             notorious_hunt_buff_num=1,
         )
-        card = ChargePlanCard(self.ctx, idx=None, plan=self.plan)
+        card = ChargePlanCard(self.ctx, idx=-1, plan=self.plan)
         card.move_up_btn.hide()
         card.move_top_btn.hide()
         card.del_btn.hide()

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_dialog.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_dialog.py
@@ -23,7 +23,7 @@ class ChargePlanDialog(MessageBoxBase):
 
     def _setup_card(self):
         """设置体力计划卡片"""
-        plan = ChargePlanItem(
+        self.plan = ChargePlanItem(
             tab_name='训练',
             category_name='实战模拟室',
             mission_type_name='基础材料',
@@ -36,26 +36,9 @@ class ChargePlanDialog(MessageBoxBase):
             predefined_team_idx=0,
             notorious_hunt_buff_num=1,
         )
-        self.card = ChargePlanCard(self.ctx, idx=None, plan=plan)
-        self.card.move_up_btn.hide()
-        self.card.move_top_btn.hide()
-        self.card.del_btn.hide()
-        self.viewLayout.addWidget(self.card)
+        card = ChargePlanCard(self.ctx, idx=None, plan=self.plan)
+        card.move_up_btn.hide()
+        card.move_top_btn.hide()
+        card.del_btn.hide()
+        self.viewLayout.addWidget(card)
         self.viewLayout.addStretch(1)
-
-    def get_card_properties(self):
-        properties = {}
-        if hasattr(self, 'card'):
-            properties = {
-                'category_name': self.card.plan.category_name,
-                'mission_type_name': self.card.plan.mission_type_name,
-                'mission_name': self.card.plan.mission_name,
-                'level': self.card.plan.level,
-                'auto_battle_config': self.card.plan.auto_battle_config,
-                'run_times': self.card.plan.run_times,
-                'plan_times': self.card.plan.plan_times,
-                'card_num': self.card.plan.card_num,
-                'predefined_team_idx': self.card.plan.predefined_team_idx,
-                'notorious_hunt_buff_num': self.card.plan.notorious_hunt_buff_num,
-            }
-        return properties

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -27,7 +27,7 @@ class ChargePlanCard(MultiLineSettingCard):
     move_top = Signal(int)
 
     def __init__(self, ctx: ZContext,
-                 idx: Optional[int], plan: ChargePlanItem):
+                 idx: int, plan: ChargePlanItem):
         self.ctx: ZContext = ctx
         self.idx: int = idx
         self.plan: ChargePlanItem = plan

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -166,6 +166,7 @@ class ChargePlanCard(MultiLineSettingCard):
     def _on_category_changed(self, idx: int) -> None:
         category_name = self.category_combo_box.itemData(idx)
         self.plan.category_name = category_name
+        self.plan.tab_name = '作战' if category_name == '恶名狩猎' else '训练'
 
         self.init_mission_type_combo_box()
         self.init_mission_combo_box()
@@ -350,8 +351,7 @@ class ChargePlanInterface(VerticalScrollInterface):
         dialog = ChargePlanDialog(self.ctx, parent=self)
         result = dialog.exec()
         if result:
-            card_properties = dialog.get_card_properties()
-            self.ctx.charge_plan_config.add_plan(card_properties)
+            self.ctx.charge_plan_config.add_plan(dialog.plan)
         self.update_plan_list_display()
 
     def _on_plan_item_changed(self, idx: int, plan: ChargePlanItem) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能/改进
  - 依据所选类别自动设置计划所属页签：“恶名狩猎”归入“作战”，其余归入“训练”，新增后即按页签正确归类显示。

- Bug 修复
  - 修复新增充能计划时页签/分类可能不匹配，导致显示位置异常的问题。

- 重构
  - 对话框现在直接产出完整计划对象并用于新增流程，简化新增逻辑、提高稳定性并去除旧的属性访问方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->