### PR TITLE
fix: B服登录时会循环检测登录然后停止运行(因为有验证码,只考虑记住密码的情况)

### DIFF
--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -213,12 +213,21 @@ class EnterGame(ZOperation):
         # time.sleep(0.5)
 
         screen = self.screenshot()
-        self.already_login = True
 
-        # B服重输密码的话会有验证码, 故暂时只判断游戏记住密码的情况: 点击登录之后就开始查找 "进入游戏" 画面.
-        return self.round_by_find_and_click_area(screen, '打开游戏', '点击进入游戏')
-        # return self.round_by_find_and_click_area(screen, '打开游戏', 'B服-登陆',
-        #                                          success_wait=5, retry_wait=1)
+        # B服重输密码会触发验证码。优先处理“记住密码”场景：若已出现“点击进入游戏”，直接点击并等待页面跳转；
+        # 否则回退到点击“B服-登陆”（兼容未勾选记住密码的情况）。
+        result = self.round_by_find_area(screen, '打开游戏', '点击进入游戏')
+        if result.is_success:
+            self.already_login = True
+            return self.round_by_find_and_click_area(
+                screen, '打开游戏', '点击进入游戏',
+                success_wait=5, retry_wait=1
+            )
+        # 回退：仍在B服登录页时，点击“登陆”按钮
+        return self.round_by_find_and_click_area(
+            screen, '打开游戏', 'B服-登陆',
+            success_wait=5, retry_wait=1
+        )
 
     @node_from(from_name='画面识别', status='国际服-密码输入区域')
     @operation_node(name='国际服-输入账号密码')

--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -214,8 +214,11 @@ class EnterGame(ZOperation):
 
         screen = self.screenshot()
         self.already_login = True
-        return self.round_by_find_and_click_area(screen, '打开游戏', 'B服-登陆',
-                                                 success_wait=5, retry_wait=1)
+
+        # B服重输密码的话会有验证码, 故暂时只判断游戏记住密码的情况: 点击登录之后就开始查找 "进入游戏" 画面.
+        return self.round_by_find_and_click_area(screen, '打开游戏', '点击进入游戏')
+        # return self.round_by_find_and_click_area(screen, '打开游戏', 'B服-登陆',
+        #                                          success_wait=5, retry_wait=1)
 
     @node_from(from_name='画面识别', status='国际服-密码输入区域')
     @operation_node(name='国际服-输入账号密码')


### PR DESCRIPTION
更改动机: 目前我这边B服登录的状态是:
1. 如果没记住密码就输不了密码，原因是enter_game.yml中B服-密码输入区域位置不对(虽然输对了也点不了验证码)

2. 如果记住密码就会一直陷入循环，等到进游戏右下角邦布走路的时候就直接退出去了，我把那个循环切断就能登B服了，我不知道是不是就我一个人是这样

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“停止并切换账号”操作：在切换账号时可尝试关闭当前游戏进程再打开下一账号，提升跨账号切换的健壮性。
* **Bug 修复 / 行为改进**
  * 优化 B 服登录流程：优先识别并点击“进入游戏”以利用记住密码路径，减少因重复输入密码触发验证码的中断。
  * 关闭游戏操作现在返回明确状态码（成功/失败），便于上层流程判定与重试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->