### PR TITLE
fix: 收敛网址硬编码为从ctx导入

### DIFF
--- a/config/project.yml
+++ b/config/project.yml
@@ -11,5 +11,8 @@ screen_standard_width: 1920
 screen_standard_height: 1080
 pip_source: "https://pypi.tuna.tsinghua.edu.cn/simple"
 notice_url: "https://one-dragon.com/notice/zzz/notice.json"
-qq_link: "https://qm.qq.com/q/wuVRYuZzkA"
-quick_start_link: "https://one-dragon.com/zzz/zh/quickstart.html"
+qq_link: "https://pd.qq.com/g/onedrag00n"
+quick_start_link: "http://one-dragon.com/zzz/zh/quickstart.html"
+home_page_link: "https://one-dragon.com/zzz/zh/home.html"
+chat_link: "https://pd.qq.com/g/onedrag00n"
+doc_link: "https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5"

--- a/src/one_dragon/envs/project_config.py
+++ b/src/one_dragon/envs/project_config.py
@@ -22,3 +22,6 @@ class ProjectConfig(YamlConfig):
         self.notice_url = self.get('notice_url')
         self.qq_link = self.get('qq_link')
         self.quick_start_link = self.get('quick_start_link')  # 链接 - 快速开始
+        self.home_page_link = self.get('home_page_link')  # 链接 - 主页
+        self.chat_link = self.get('chat_link')  # 链接 - 社群
+        self.doc_link = self.get('doc_link')  # 链接 - 文档

--- a/src/one_dragon_qt/view/installer_interface.py
+++ b/src/one_dragon_qt/view/installer_interface.py
@@ -329,10 +329,10 @@ class InstallStepWidget(QWidget):
                         ctx = card.ctx
                         break
             
-            if ctx and hasattr(ctx, 'project_config') and hasattr(ctx.project_config, 'doc_link'):
+            if ctx and hasattr(ctx, 'project_config'):
                 webbrowser.open(ctx.project_config.doc_link)
             else:
-                webbrowser.open(ctx.project_config.doc_link)
+                log.warning("未找到可用的 ctx，无法打开帮助文档")
             log.info("步骤安装失败，已自动打开帮助文档")
             
             self.step_completed.emit(False)

--- a/src/one_dragon_qt/view/installer_interface.py
+++ b/src/one_dragon_qt/view/installer_interface.py
@@ -322,7 +322,18 @@ class InstallStepWidget(QWidget):
             
             # 安装失败时自动打开帮助文档
             try:
-                webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
+                # 通过父级的ctx获取配置
+                ctx = None
+                if hasattr(self, 'install_cards') and self.install_cards:
+                    for card in self.install_cards:
+                        if hasattr(card, 'ctx'):
+                            ctx = card.ctx
+                            break
+                
+                if ctx and hasattr(ctx, 'project_config') and hasattr(ctx.project_config, 'doc_link'):
+                    webbrowser.open(ctx.project_config.doc_link)
+                else:
+                    webbrowser.open(ctx.project_config.doc_link)
                 log.info("步骤安装失败，已自动打开帮助文档")
             except Exception as e:
                 log.error(f"无法打开帮助文档: {e}")
@@ -655,7 +666,7 @@ class InstallerInterface(VerticalScrollInterface):
         else:
             # 安装失败时自动打开帮助文档
             try:
-                webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
+                webbrowser.open(self.ctx.project_config.doc_link)
                 log.info("安装失败，已自动打开帮助文档")
                 # 更新进度标签显示文档已打开的信息
                 self.progress_label.setText(gt('安装失败！已自动打开排障文档'))
@@ -961,7 +972,7 @@ class InstallerInterface(VerticalScrollInterface):
         if not success:
             # 资源解压失败时自动打开帮助文档
             try:
-                webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
+                webbrowser.open(self.ctx.project_config.doc_link)
                 log.info("资源解压失败，已自动打开帮助文档")
                 self.progress_label.setText(gt('资源解压失败！已自动打开排障文档'))
             except Exception as e:

--- a/src/one_dragon_qt/view/installer_interface.py
+++ b/src/one_dragon_qt/view/installer_interface.py
@@ -321,22 +321,19 @@ class InstallStepWidget(QWidget):
             self.installing_idx = -1
             
             # 安装失败时自动打开帮助文档
-            try:
-                # 通过父级的ctx获取配置
-                ctx = None
-                if hasattr(self, 'install_cards') and self.install_cards:
-                    for card in self.install_cards:
-                        if hasattr(card, 'ctx'):
-                            ctx = card.ctx
-                            break
-                
-                if ctx and hasattr(ctx, 'project_config') and hasattr(ctx.project_config, 'doc_link'):
-                    webbrowser.open(ctx.project_config.doc_link)
-                else:
-                    webbrowser.open(ctx.project_config.doc_link)
-                log.info("步骤安装失败，已自动打开帮助文档")
-            except Exception as e:
-                log.error(f"无法打开帮助文档: {e}")
+            # 通过父级的ctx获取配置
+            ctx = None
+            if hasattr(self, 'install_cards') and self.install_cards:
+                for card in self.install_cards:
+                    if hasattr(card, 'ctx'):
+                        ctx = card.ctx
+                        break
+            
+            if ctx and hasattr(ctx, 'project_config') and hasattr(ctx.project_config, 'doc_link'):
+                webbrowser.open(ctx.project_config.doc_link)
+            else:
+                webbrowser.open(ctx.project_config.doc_link)
+            log.info("步骤安装失败，已自动打开帮助文档")
             
             self.step_completed.emit(False)
         else:
@@ -665,16 +662,11 @@ class InstallerInterface(VerticalScrollInterface):
                 self.show_completion_message()
         else:
             # 安装失败时自动打开帮助文档
-            try:
-                webbrowser.open(self.ctx.project_config.doc_link)
-                log.info("安装失败，已自动打开帮助文档")
-                # 更新进度标签显示文档已打开的信息
-                self.progress_label.setText(gt('安装失败！已自动打开排障文档'))
-                self.progress_label.setStyleSheet("color: #d13438;")
-            except Exception as e:
-                log.error(f"无法打开帮助文档: {e}")
-                self.progress_label.setText(gt('安装失败！请手动访问排障文档'))
-                self.progress_label.setStyleSheet("color: #d13438;")
+            webbrowser.open(self.ctx.project_config.doc_link)
+            log.info("安装失败，已自动打开帮助文档")
+            # 更新进度标签显示文档已打开的信息
+            self.progress_label.setText(gt('安装失败！已自动打开排障文档'))
+            self.progress_label.setStyleSheet("color: #d13438;")
             
             self.progress_label.setVisible(True)
             self.install_btn.setVisible(True)
@@ -971,13 +963,9 @@ class InstallerInterface(VerticalScrollInterface):
         self.progress_label.setVisible(not success)
         if not success:
             # 资源解压失败时自动打开帮助文档
-            try:
-                webbrowser.open(self.ctx.project_config.doc_link)
-                log.info("资源解压失败，已自动打开帮助文档")
-                self.progress_label.setText(gt('资源解压失败！已自动打开排障文档'))
-            except Exception as e:
-                log.error(f"无法打开帮助文档: {e}")
-                self.progress_label.setText(gt('资源解压失败！请手动访问排障文档'))
+            webbrowser.open(self.ctx.project_config.doc_link)
+            log.info("资源解压失败，已自动打开帮助文档")
+            self.progress_label.setText(gt('资源解压失败！已自动打开排障文档'))
             self.progress_label.setStyleSheet("color: #d13438;")
 
     def on_interface_shown(self) -> None:

--- a/src/one_dragon_qt/view/source_config_interface.py
+++ b/src/one_dragon_qt/view/source_config_interface.py
@@ -82,8 +82,8 @@ class SourceConfigInterface(VerticalScrollInterface):
         self.help_btn.clicked.connect(self._on_help_clicked)
         links_layout.addWidget(self.help_btn)
         
-        # QQ频道按钮
-        self.qq_channel_btn = PushButton('💬 QQ频道')
+        # 官方社区按钮
+        self.qq_channel_btn = PushButton('💬 官方社区')
         self.qq_channel_btn.setFixedSize(140, 35)
         self.qq_channel_btn.clicked.connect(self._on_qq_channel_clicked)
         links_layout.addWidget(self.qq_channel_btn)
@@ -224,27 +224,27 @@ class SourceConfigInterface(VerticalScrollInterface):
     def _on_help_clicked(self):
         """点击帮助按钮时打开排障文档"""
         try:
-            webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
+            webbrowser.open(self.ctx.project_config.doc_link)
         except Exception as e:
             print(f"无法打开浏览器: {e}")
 
     def _on_qq_channel_clicked(self):
-        """点击QQ频道按钮时打开QQ频道"""
+        """点击官方社区按钮时打开官方社区"""
         try:
-            webbrowser.open("https://pd.qq.com/g/onedrag00n")
+            webbrowser.open(self.ctx.project_config.chat_link)
         except Exception as e:
-            print(f"无法打开QQ频道: {e}")
+            print(f"无法打开官方社区: {e}")
 
     def _on_website_clicked(self):
         """点击官网按钮时打开官网"""
         try:
-            webbrowser.open("https://one-dragon.com/zzz/zh/home.html")
+            webbrowser.open(self.ctx.project_config.home_page_link)
         except Exception as e:
             print(f"无法打开官网: {e}")
 
     def _on_github_clicked(self):
         """点击GitHub按钮时打开GitHub仓库"""
         try:
-            webbrowser.open("https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon")
+            webbrowser.open(self.ctx.project_config.github_homepage)
         except Exception as e:
             print(f"无法打开GitHub仓库: {e}")

--- a/src/one_dragon_qt/view/source_config_interface.py
+++ b/src/one_dragon_qt/view/source_config_interface.py
@@ -223,28 +223,16 @@ class SourceConfigInterface(VerticalScrollInterface):
 
     def _on_help_clicked(self):
         """点击帮助按钮时打开排障文档"""
-        try:
-            webbrowser.open(self.ctx.project_config.doc_link)
-        except Exception as e:
-            print(f"无法打开浏览器: {e}")
+        webbrowser.open(self.ctx.project_config.doc_link)
 
     def _on_qq_channel_clicked(self):
         """点击官方社区按钮时打开官方社区"""
-        try:
-            webbrowser.open(self.ctx.project_config.chat_link)
-        except Exception as e:
-            print(f"无法打开官方社区: {e}")
+        webbrowser.open(self.ctx.project_config.chat_link)
 
     def _on_website_clicked(self):
         """点击官网按钮时打开官网"""
-        try:
-            webbrowser.open(self.ctx.project_config.home_page_link)
-        except Exception as e:
-            print(f"无法打开官网: {e}")
+        webbrowser.open(self.ctx.project_config.home_page_link)
 
     def _on_github_clicked(self):
         """点击GitHub按钮时打开GitHub仓库"""
-        try:
-            webbrowser.open(self.ctx.project_config.github_homepage)
-        except Exception as e:
-            print(f"无法打开GitHub仓库: {e}")
+        webbrowser.open(self.ctx.project_config.github_homepage)

--- a/src/zzz_od/gui/app.py
+++ b/src/zzz_od/gui/app.py
@@ -309,10 +309,7 @@ except Exception as e:
     _init_error = f"启动一条龙失败，报错信息如下:\n{stack_trace}"
     
     # 自动打开浏览器访问错误排障文档
-    try:
-        webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
-    except Exception:
-        pass  # 如果打开浏览器失败，不影响错误弹窗的显示
+    webbrowser.open("https://docs.qq.com/doc/p/7add96a4600d363b75d2df83bb2635a7c6a969b5")
 
 
 # 初始化应用程序，并启动主窗口

--- a/src/zzz_od/gui/zzz_installer.py
+++ b/src/zzz_od/gui/zzz_installer.py
@@ -17,7 +17,12 @@ if __name__ == '__main__':
     else:
         icon_path = Path.cwd() / 'assets/ui/logo.ico'
     installer_dir = Path(sys.argv[0]).resolve().parent
-    picker_window = DirectoryPickerWindow(icon_path=icon_path)
+    # 延迟导入获取项目配置
+    from one_dragon.base.operation.one_dragon_env_context import OneDragonEnvContext
+    
+    _ctx = OneDragonEnvContext()
+    
+    picker_window = DirectoryPickerWindow(icon_path=icon_path, project_config=_ctx.project_config)
     picker_window.exec()
     work_dir = picker_window.selected_directory
     if not work_dir:
@@ -31,10 +36,8 @@ if __name__ == '__main__':
 
     # 延迟导入
     from zzz_od.gui.zzz_installer_window import ZInstallerWindow
-    from one_dragon.base.operation.one_dragon_env_context import OneDragonEnvContext
     from one_dragon.utils.i18_utils import gt, detect_and_set_default_language
 
-    _ctx = OneDragonEnvContext()
     _ctx.installer_dir = installer_dir
     _ctx.async_update_gh_proxy()
     detect_and_set_default_language()


### PR DESCRIPTION
- 暗檬特调
- 为安装器的翻译按钮添加了一个对称的帮助按钮
- 修复了主页悬浮显示时鼠标划过导致浮标不能消失的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 目录选择器在有配置时新增“帮助”按钮，可一键打开引导/文档。

- 改进
  - 全局外部链接统一为可配置项并更新为最新地址（主页、文档、社区/聊天、QQ、GitHub）。
  - 安装器、源配置界面与首页按钮均改为使用配置化链接打开对应页面。
  - 首页工具提示演示优化：演示期间禁用悬停干扰，结束后恢复。

- 文案
  - “QQ频道”文案更新为“官方社区”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->