### PR TITLE
fix:通知设置-测试通知方式（企业微信-测试当前方式）

### DIFF
--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -15,7 +15,7 @@ from io import BytesIO
 from email.mime.text import MIMEText
 from email.header import Header
 from email.utils import formataddr
-from typing import Optional
+from typing import Optional, Tuple
 
 from one_dragon.base.operation.one_dragon_context import OneDragonContext
 from one_dragon.utils.log_utils import log
@@ -566,28 +566,126 @@ class Push():
 
 
 
+
     def wecom_bot(self, title: str, content: str, image: Optional[BytesIO]) -> None:
         """
-        通过 企业微信机器人 推送消息。
+        通过 企业微信机器人推送消息，文字和图片分开发送，图片自动压缩为JPG/PNG，base64+md5，大小≤2MB。
         """
-
+        # 企业微信机器人推送主入口
         self.log_info("企业微信机器人服务启动")
 
-        origin = "https://qyapi.weixin.qq.com"
-        if self.get_config("QYWX_ORIGIN"):
-            origin = self.get_config("QYWX_ORIGIN")
+        # 获取 origin 和 key，校验 key 是否配置（去除末尾斜杠，避免双斜杠）
+        origin = (self.get_config("QYWX_ORIGIN") or "https://qyapi.weixin.qq.com").rstrip("/")
+        key = self.get_config('QYWX_KEY') or ""
+        if not key:
+            self.log_error("企业微信机器人 key 未配置!")
+            return
 
-        url = f"{origin}/cgi-bin/webhook/send?key={self.get_config('QYWX_KEY')}"
+        # 拼接 webhook url
+        url = f"{origin}/cgi-bin/webhook/send?key={key}"
         headers = {"Content-Type": "application/json;charset=utf-8"}
-        data = {"msgtype": "text", "text": {"content": f"{title}\n{content}"}}
-        response = requests.post(
-            url=url, data=json.dumps(data), headers=headers, timeout=15
-        ).json()
 
-        if response["errcode"] == 0:
-            self.log_info("企业微信机器人推送成功！")
-        else:
-            self.log_error("企业微信机器人推送失败！")
+        # 1. 发送文本消息
+        try:
+            text_data = {"msgtype": "text", "text": {"content": f"{title}\n{content}"}}
+            resp = requests.post(url, json=text_data, headers=headers, timeout=15).json()
+            if resp and resp.get("errcode") == 0:
+                self.log_info("企业微信机器人文字推送成功!")
+            else:
+                self.log_error(f"企业微信机器人文字推送失败! {resp}")
+        except (requests.exceptions.RequestException, ValueError) as e:
+            self.log_error(f"企业微信机器人文字推送异常: {e}")
+
+        # 2. 发送图片消息（如有图片）
+        if image:
+            try:
+                image.seek(0)
+                img_bytes = image.getvalue()
+                # 判断图片格式与大小
+                img_format = self._detect_image_format(img_bytes)
+                if img_format in ('jpeg', 'png') and len(img_bytes) <= 2 * 1024 * 1024:
+                    # 图片无需压缩，直接推送
+                    img_base64 = base64.b64encode(img_bytes).decode('utf-8')
+                    img_md5 = self._md5(img_bytes)
+                    img_data = {
+                        "msgtype": "image",
+                        "image": {"base64": img_base64, "md5": img_md5}
+                    }
+                    resp = requests.post(url, json=img_data, headers=headers, timeout=15).json()
+                    if resp and resp.get("errcode") == 0:
+                        self.log_info("企业微信机器人图片推送成功! (无需压缩)")
+                    else:
+                        self.log_error(f"企业微信机器人图片推送失败! {resp}")
+                else:
+                    # 图片需压缩，优先压缩为 JPEG/PNG
+                    img_bytes_c, _ = self._compress_image(image)
+                    if not img_bytes_c:
+                        self.log_error("图片处理失败, 未发送图片!")
+                        return
+                    if len(img_bytes_c) > 2 * 1024 * 1024:
+                        self.log_error("图片压缩后仍超过2MB, 未发送图片!")
+                        return
+                    img_base64 = base64.b64encode(img_bytes_c).decode('utf-8')
+                    img_md5 = self._md5(img_bytes_c)
+                    img_data = {
+                        "msgtype": "image",
+                        "image": {"base64": img_base64, "md5": img_md5}
+                    }
+                    resp = requests.post(url, json=img_data, headers=headers, timeout=15).json()
+                    if resp and resp.get("errcode") == 0:
+                        self.log_info("企业微信机器人图片推送成功! (压缩后)")
+                    else:
+                        self.log_error(f"企业微信机器人图片推送失败! {resp}")
+            except (requests.exceptions.RequestException, ValueError, OSError) as e:
+                self.log_error(f"企业微信机器人图片推送异常: {e}")
+
+    def _compress_image(self, image: BytesIO) -> Tuple[Optional[bytes], Optional[str]]:
+        """
+        自动将图片压缩为 JPG 或 PNG, 优先 JPG, 确保 ≤2MB.
+        """
+        # 图片压缩核心逻辑，优先尝试 JPEG，其次 PNG，最后兜底低质量 JPEG
+        try:
+            import io
+            from PIL import Image
+            image.seek(0)
+            pil_img = Image.open(image)
+            # 优先压缩为 JPEG(仅此分支转 RGB)
+            with io.BytesIO() as output:
+                pil_img_rgb = pil_img.convert('RGB')
+                pil_img_rgb.save(output, format='JPEG', quality=85, optimize=True)
+                img_bytes = output.getvalue()
+                if len(img_bytes) <= 2 * 1024 * 1024:
+                    return img_bytes, 'jpeg'
+            # 如果 JPEG 超过 2MB, 则尝试 PNG(保留原透明度)
+            with io.BytesIO() as output:
+                pil_img.save(output, format='PNG', optimize=True)
+                img_bytes = output.getvalue()
+                if len(img_bytes) <= 2 * 1024 * 1024:
+                    return img_bytes, 'png'
+            # 兜底尝试, 最低质量 JPEG
+            with io.BytesIO() as output:
+                pil_img_rgb = pil_img.convert('RGB')
+                pil_img_rgb.save(output, format='JPEG', quality=10, optimize=True)
+                img_bytes = output.getvalue()
+                if len(img_bytes) <= 2 * 1024 * 1024:
+                    return img_bytes, 'jpeg'
+            return None, None
+        except (ImportError, OSError, ValueError) as e:
+            self.log_error(f"图片压缩异常: {e}")
+            return None, None
+
+    def _md5(self, b: bytes) -> str:
+        # 计算图片内容的 MD5，用于企业微信机器人图片推送
+        import hashlib
+        return hashlib.md5(b).hexdigest()
+
+    def _detect_image_format(self, b: bytes) -> Optional[str]:
+        # 轻量魔数判断，仅支持 jpeg/png
+        if len(b) >= 3 and b[:3] == b"\xFF\xD8\xFF":
+            return "jpeg"
+        if len(b) >= 8 and b[:8] == b"\x89PNG\r\n\x1a\n":
+            return "png"
+        return None
 
 
 


### PR DESCRIPTION
成功展示：
此pr独立，目的是顺便修复上一个pr  #1413  提及的虽毫不影响但关系紧密的远古bug
![feb929688b03f3dab395af23043e10ef](https://github.com/user-attachments/assets/d8ba7c6e-615b-4235-9729-8e3b6c96c046)

https://github.com/user-attachments/assets/3aa690e0-3418-4470-a050-b43de7ae9e31



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 企业微信机器人现支持文本+图片推送：先发送文本，若提供图片则自动发送图片。
  - 自动检测并压缩大图至2MB以内（JPEG/PNG），确保发送成功。
- 修复
  - 提升推送流程稳定性：网络或图片处理错误被安全捕获并记录，不再中断整体推送。
  - 校验配置项（如密钥）并给出明确错误日志，减少配置导致的失败。
- 文档
  - 更新企业微信推送说明，明确文本与图片发送逻辑及大小限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->