### PR TITLE
feat: 企业微信机器人推送新增图片

### DIFF
--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -1175,9 +1175,12 @@ class Push():
         log.error(f'指令[ 通知 ] {message}')
 
 
-    def get_config(self, key: str, default: str | None = None) -> Optional[str]:
+    def get_config(self, key: str, default: str = '') -> str:
         """获取推送配置值"""
-        return getattr(self.ctx.push_config, key.lower(), default)
+        value = getattr(self.ctx.push_config, key.lower(), default)
+        if value:
+            return str(value).strip()
+        return default
 
 
     def send(self, content: str, image: Optional[BytesIO] = None, test_method: Optional[str] = None) -> None:

--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -226,13 +226,14 @@ class Push():
 
         self.log_info("OneBot 服务启动")
 
-        url = self.get_config("ONEBOT_URL").rstrip("/")
+        url = self.get_config("ONEBOT_URL")
         user_id = self.get_config("ONEBOT_USER")
         group_id = self.get_config("ONEBOT_GROUP")
         token = self.get_config("ONEBOT_TOKEN")
 
-        if not url.endswith("/send_msg"):
-                url += "/send_msg"
+        if url:
+            url = url.rstrip("/")
+            url += "" if url.endswith("/send_msg") else "/send_msg"
 
         headers = {'Content-Type': "application/json"}
         message = [{"type": "text", "data": {"text": f"{title}\n{content}"}}]
@@ -1031,7 +1032,7 @@ class Push():
         self.log_info("通用 Webhook 服务启动")
 
         url = self.get_config("WEBHOOK_URL")
-        method = (self.get_config("WEBHOOK_METHOD")).upper()
+        method = self.get_config("WEBHOOK_METHOD")
         headers_str = self.get_config("WEBHOOK_HEADERS")
         body = self.get_config("WEBHOOK_BODY")
         content_type = self.get_config("WEBHOOK_CONTENT_TYPE")

--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -571,7 +571,7 @@ class Push():
 
     def wecom_bot(self, title: str, content: str, image: Optional[BytesIO]) -> None:
         """
-        通过 企业微信机器人推送消息,文字和图片分开发送,图片自动压缩为JPG/PNG,base64+md5,大小≤2MB。
+        通过 企业微信机器人推送消息，文字和图片分开发送；图片需压缩时仅压缩为 JPG,base64+md5,大小≤2MB。
         """
         self.log_info("企业微信机器人服务启动")
 
@@ -640,7 +640,7 @@ class Push():
 
     def _compress_image(self, image: BytesIO) -> tuple[bytes | None, str | None]:
         """
-        自动将图片压缩为 JPG 或 PNG, 优先 JPG, 确保 ≤2MB.
+        自动将图片压缩为 JPG,必要时降质为低质量 JPG,确保 ≤2MB。
         """
         try:
             import cv2
@@ -653,10 +653,6 @@ class Push():
             success, img_bytes = cv2.imencode('.jpg', img, encode_param)
             if success and len(img_bytes) <= 2 * 1024 * 1024:
                 return img_bytes.tobytes(), 'jpeg'
-            # 如果 JPEG 超过 2MB，则尝试 PNG
-            success, img_bytes = cv2.imencode('.png', img, [cv2.IMWRITE_PNG_COMPRESSION, 3])
-            if success and len(img_bytes) <= 2 * 1024 * 1024:
-                return img_bytes.tobytes(), 'png'
             # 兜底最低质量 JPEG
             encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), 10]
             success, img_bytes = cv2.imencode('.jpg', img, encode_param)

--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -1129,10 +1129,10 @@ class Push():
             notify_function.append(self.weplus_bot)
         if self.get_config("QMSG_KEY") and self.get_config("QMSG_TYPE"):
             notify_function.append(self.qmsg_bot)
-        if self.get_config("QYWX_AM"):
-            notify_function.append(self.wecom_app)
         if self.get_config("QYWX_KEY"):
             notify_function.append(self.wecom_bot)
+        if self.get_config("QYWX_AM"):
+            notify_function.append(self.wecom_app)
         if self.get_config("DISCORD_BOT_TOKEN") and self.get_config("DISCORD_USER_ID"):
             notify_function.append(self.discord_bot)
         if self.get_config("TG_BOT_TOKEN") and self.get_config("TG_USER_ID"):
@@ -1248,6 +1248,20 @@ class Push():
             'NTFY': 'ntfy',
             'WXPUSHER': 'wxpusher_bot',
         }
+
+        # 特殊处理企业微信，根据配置动态选择
+        if method == 'QYWX':
+            # 优先使用 wecom_bot (机器人)
+            if self.get_config("QYWX_KEY"):
+                for func in all_functions:
+                    if func.__name__ == 'wecom_bot':
+                        return [func]
+            # 其次使用 wecom_app (应用)
+            if self.get_config("QYWX_AM"):
+                for func in all_functions:
+                    if func.__name__ == 'wecom_app':
+                        return [func]
+            raise ValueError(f"QYWX 推送方式未正确配置，请检查 QYWX_KEY 或 QYWX_AM")
 
         target_function_name = method_to_function_name.get(method)
         if not target_function_name:


### PR DESCRIPTION
......-通知方式-企业微信-企业微信机器人key
功能升级：使得企业微信机器人推送的消息带有图片
原本功能：企业微信机器人推送的消息只有文字，没有图片
开发简述：推送图片要小于2mb、图文不能混发，是主要技术障碍，已应对！

影响结果：
1.只需填写企业微信机器人key，推送的消息既有消息，又有图片
2.不影响用户原本配置，该pr合并后，企业微信机器人使用者会拥获惊喜：欸？怎么今天的消息推送有图片

企业微信群机器人图文接收推送要求（来自网络）：

文字：≤2048字节，JSON里写"text"字段。
图片：≤2MB，仅JPG/PNG；先转base64字符串并算32位小写md5，JSON里写"image"字段。
一条消息只能选text或image，图文请分两次发。
第一代：
截图效果（视频展示）：
pr提交前在本地的测试，成功实现！！！
https://github.com/user-attachments/assets/b7b0bf1f-5a27-4965-999b-181d6915f5e1

一条龙的相关配置：
<img width="1643" height="1095" alt="image" src="https://github.com/user-attachments/assets/aa8ec120-0392-4f19-bab8-c435bad33b00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 企业微信推送改为先尝试文本再尝试图片；图片≤2MB 直传，>2MB 自动压缩重试；日志显示原始/压缩后大小与压缩质量。
  - 配置读取支持默认回退，未配置时更稳健。

- 修复
  - OneBot/Webhook URL 处理更稳健，避免重复路径或多余斜杠导致发送失败，增强错误处理。

- 重构
  - 推送通道行为统一，发送流程与异常处理更健壮，可观测性增强，QYWX 默认推送模式调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->