### PR TITLE
feat: 添加Lark推送渠道

### DIFF
--- a/src/one_dragon/base/config/push_config.py
+++ b/src/one_dragon/base/config/push_config.py
@@ -13,7 +13,7 @@ class NotifyMethodEnum(Enum):
     ONEBOT = ConfigItem('OneBot', 'ONEBOT')
     QYWX = ConfigItem('企业微信', 'QYWX')
     DD_BOT = ConfigItem('钉钉机器人', 'DD_BOT')
-    FS =  ConfigItem('飞书机器人', 'FS')
+    FS =  ConfigItem('飞书/Lark 机器人', 'FS')
     DISCORD = ConfigItem('Discord', 'DISCORD')
     TELEGRAM = ConfigItem('Telegram', 'TG')
     BARK = ConfigItem('Bark', 'BARK')

--- a/src/one_dragon/base/notify/push.py
+++ b/src/one_dragon/base/notify/push.py
@@ -151,12 +151,15 @@ class Push():
 
         self.log_info("飞书 服务启动")
 
+        channel = self.get_config("FS_CHANNEL")
+        base_url = "open.feishu.cn" if channel == "飞书" else "open.larksuite.com"
+
         app_id = self.get_config("FS_APPID")
         app_secret = self.get_config("FS_APPSECRET")
         if image and app_id and app_secret and app_id != "" and app_secret != "":
             image.seek(0)
             # 获取飞书自建应用的tenant_access_token
-            auth_endpoint = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
+            auth_endpoint = f"https://{base_url}/open-apis/auth/v3/tenant_access_token/internal"
             auth_headers = {
                 "Content-Type": "application/json; charset=utf-8"
             }
@@ -167,7 +170,7 @@ class Push():
             auth_response.raise_for_status()
             tenant_access_token = auth_response.json()["tenant_access_token"]
             # 上传图片并获取图片的image_key
-            image_endpoint = "https://open.feishu.cn/open-apis/im/v1/images"
+            image_endpoint = f"https://{base_url}/open-apis/im/v1/images"
             image_headers = {
                 "Authorization": f"Bearer {tenant_access_token}"
             }
@@ -209,7 +212,7 @@ class Push():
                 "content": {"text": f"{title}\n{content}"}
             }
 
-        url = f'https://open.feishu.cn/open-apis/bot/v2/hook/{self.get_config("FS_KEY")}'
+        url = f'https://{base_url}/open-apis/bot/v2/hook/{self.get_config("FS_KEY")}'
         response = requests.post(url, data=json.dumps(data)).json()
 
         if response.get("StatusCode") == 0 or response.get("code") == 0:

--- a/src/one_dragon_qt/widgets/push_cards.py
+++ b/src/one_dragon_qt/widgets/push_cards.py
@@ -125,6 +125,15 @@ class PushCards:
     ],
     "FS": [
         {
+            "var_suffix": "CHANNEL",
+            "title": "服务类型",
+            "icon": "APPLICATION",
+            "type": "combo",
+            "options": ["飞书", "Lark"],
+            "default": "飞书",
+            "required": True
+        },
+        {
             "var_suffix": "KEY",
             "title": "密钥",
             "icon": "CERTIFICATE",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 飞书通道新增“服务类型”下拉，可在“飞书”和“Lark”切换（默认“飞书”），位于密钥前且为必填。
  * 系统依据所选服务类型自动选择对应域名，统一用于机器人推送、认证和图片上传，兼容两种平台。
  * 通知方式显示名更新为“飞书/Lark 机器人”，保持现有密钥与配置兼容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->