### PR TITLE
fix: 区分测试版本tag

### DIFF
--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -412,11 +412,8 @@ class GitService:
                 # 形如：<sha>\trefs/tags/v1.2.3 或 refs/tags/v1.2.3-beta.1
                 if 'refs/tags/' not in line:
                     continue
-                tag_name = line.split('refs/tags/')[1]
-                # 跳过可能存在的解引用后缀（尽管 --refs 一般不会出现）
-                if tag_name.endswith('^{}'):
-                    tag_name = tag_name[:-3]
 
+                tag_name = line.split('refs/tags/')[1]
                 is_beta = '-beta' in tag_name
 
                 # 首个出现的标签决定通道优先级

--- a/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
+++ b/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
@@ -71,10 +71,18 @@ class LauncherInstallCard(BaseInstallCard):
 
     def check_launcher_update(self) -> Tuple[bool, str, str]:
         current_version = app_utils.get_launcher_version()
-        latest_version = self.ctx.git_service.get_latest_tag()
-        if current_version == latest_version:
-            return True, latest_version, current_version
-        return False, latest_version, current_version
+        latest_stable, latest_beta = self.ctx.git_service.get_latest_tag()
+        # 根据当前版本是否包含 -beta 来确定比较通道
+        if current_version and '-beta' in current_version:
+            # 测试通道：与最新测试版比较；若不存在测试版，则视为已最新
+            target_latest = latest_beta or current_version
+        else:
+            # 稳定通道：与最新稳定版比较；若不存在稳定版，则视为已最新
+            target_latest = latest_stable or current_version
+
+        if current_version == target_latest:
+            return True, target_latest, current_version
+        return False, target_latest, current_version
 
     def after_progress_done(self, success: bool, msg: str) -> None:
         """

--- a/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
+++ b/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
@@ -105,10 +105,12 @@ class LauncherInstallCard(BaseInstallCard):
         :return: 显示的图标、文本
         """
         if self.check_launcher_exist():
+            if os_utils.run_in_exe():  # 安装器中不检查更新
+                return FluentIcon.INFO.icon(color=FluentThemeColor.DEFAULT_BLUE.value), gt('已安装')
             self.install_btn.setText(gt('检查中...'))
             is_latest, latest_version, current_version = self.check_launcher_update()
             self.install_btn.setDisabled(is_latest)
-            if is_latest or os_utils.run_in_exe():  # 安装器中不检查更新
+            if is_latest:
                 icon = FluentIcon.INFO.icon(color=FluentThemeColor.DEFAULT_BLUE.value)
                 msg = f"{gt('已安装')} {current_version}"
                 self.install_btn.setText(gt('已安装'))

--- a/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
+++ b/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
@@ -31,7 +31,12 @@ class LauncherInstallCard(BaseInstallCard):
         for _ in range(2):
             zip_file_name = f'{self.ctx.project_config.project_name}-Launcher.zip'
             zip_file_path = os.path.join(DEFAULT_ENV_PATH, zip_file_name)
-            download_url = f'{self.ctx.project_config.github_homepage}/releases/{self.latest_version}/download/{zip_file_name}'
+            base = (
+                'latest/download'
+                if self.latest_version == 'latest'
+                else f'download/{self.latest_version}'
+            )
+            download_url = f'{self.ctx.project_config.github_homepage}/releases/{base}/{zip_file_name}'
             if not os.path.exists(zip_file_path):
                 success = self.ctx.download_service.download_file_from_url(download_url, zip_file_path, progress_callback=progress_callback)
                 if not success:

--- a/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
+++ b/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
@@ -78,6 +78,7 @@ class LauncherInstallCard(BaseInstallCard):
     def check_launcher_update(self) -> Tuple[bool, str, str]:
         current_version = app_utils.get_launcher_version()
         latest_stable, latest_beta = self.ctx.git_service.get_latest_tag()
+
         # 根据当前版本是否包含 -beta 来确定比较通道
         if current_version and '-beta' in current_version:
             # 测试通道：与最新测试版比较；若不存在测试版，则视为已最新
@@ -111,10 +112,14 @@ class LauncherInstallCard(BaseInstallCard):
         """
         if self.check_launcher_exist():
             if os_utils.run_in_exe():  # 安装器中不检查更新
-                return FluentIcon.INFO.icon(color=FluentThemeColor.DEFAULT_BLUE.value), gt('已安装')
+                icon = FluentIcon.INFO.icon(color=FluentThemeColor.DEFAULT_BLUE.value)
+                msg = gt('已安装')
+                return icon, msg
+
             self.install_btn.setText(gt('检查中...'))
             is_latest, latest_version, current_version = self.check_launcher_update()
             self.install_btn.setDisabled(is_latest)
+
             if is_latest:
                 icon = FluentIcon.INFO.icon(color=FluentThemeColor.DEFAULT_BLUE.value)
                 msg = f"{gt('已安装')} {current_version}"
@@ -123,6 +128,7 @@ class LauncherInstallCard(BaseInstallCard):
                 icon = FluentIcon.INFO.icon(color=FluentThemeColor.GOLD.value)
                 msg = f"{gt('需更新')} {gt('当前版本')}: {current_version}; {gt('最新版本')}: {latest_version}"
                 self.install_btn.setText(gt('更新'))
+
         else:
             icon = FluentIcon.INFO.icon(color=FluentThemeColor.RED.value)
             msg = gt('需下载')

--- a/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
+++ b/src/one_dragon_qt/widgets/install_card/launcher_install_card.py
@@ -62,6 +62,7 @@ class LauncherInstallCard(BaseInstallCard):
             if not success:  # 解压失败的话 可能是之前下的zip包坏了 尝试删除重来
                 continue
             else:
+                self.window().titleBar.setLauncherVersion(app_utils.get_launcher_version())
                 return True, gt('安装启动器成功')
 
         # 重试之后还是失败了

--- a/src/one_dragon_qt/windows/window.py
+++ b/src/one_dragon_qt/windows/window.py
@@ -410,19 +410,27 @@ class PhosTitleBar(SplitTitleBar):
     def setTitle(self, title: str):
         self.titleLabel.setText(title)
 
-    def setVersion(self, launcher_version: str, code_version: str) -> None:
+    def setLauncherVersion(self, version: str) -> None:
         """
-        设置版本号 会更新UI
+        设置启动器版本号 会更新UI
         @param version: 版本号
         @return:
         """
-        self.launcher_version = launcher_version
-        self.code_version = code_version
-        self.launcherVersionButton.setText(f"ⓘ 启动器版本 {launcher_version}")
-        self.codeVersionButton.setText(f"ⓘ 代码版本 {code_version}")
-        if launcher_version:
+        self.launcher_version = version
+        self.launcherVersionButton.setText(f"ⓘ 启动器版本 {version}")
+        if version:
             self.launcherVersionButton.setVisible(True)
-        self.codeVersionButton.setVisible(True)
+
+    def setCodeVersion(self, version: str) -> None:
+        """
+        设置代码版本号 会更新UI
+        @param version: 版本号
+        @return:
+        """
+        self.code_version = version
+        self.codeVersionButton.setText(f"ⓘ 代码版本 {version}")
+        if version:
+            self.codeVersionButton.setVisible(True)
 
     def setInstallerVersion(self, version: str) -> None:
         """

--- a/src/zzz_od/gui/app.py
+++ b/src/zzz_od/gui/app.py
@@ -232,7 +232,8 @@ try:
             @param ver:
             @return:
             """
-            self.titleBar.setVersion(versions[0], versions[1])
+            self.titleBar.setLauncherVersion(versions[0])
+            self.titleBar.setCodeVersion(versions[1])
 
         def _check_first_run(self):
             """首次运行时显示防倒卖弹窗"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 更新检查支持分别返回稳定版与测试版最新标签；安装卡片依据当前通道选择目标版本并更新显示与下载路径。
  - 窗口标题栏可分别设置启动器与代码版本，分别显示与更新。

- 改进
  - 优化远程标签解析与版本选择逻辑；下载链接在“latest”与具体版本间切换。
  - 安装卡片在检查中显示“检查中…”，按结果更新按钮文字、图标与版本信息，EXE 已安装即时显示。

- 修复
  - 修正测试版与稳定版比较与提示不一致的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->