### PR TITLE
feat: 存在多账号但是只激活了一个账号时,  打开游戏进程时也重新登录

### DIFF
--- a/src/zzz_od/operation/enter_game/enter_game.py
+++ b/src/zzz_od/operation/enter_game/enter_game.py
@@ -24,8 +24,10 @@ class EnterGame(ZOperation):
                             op_name=gt('进入游戏')
                             )
 
+        # 既然在脚本上创建过多个账号, 那么在游戏中也可能会登多个账号吧(偶尔帮朋友打个深渊之类的), 重新上下号避免登错号而没发现
         self.force_login: bool = (self.ctx.one_dragon_config.instance_run == InstanceRun.ALL.value.value
-            and len(self.ctx.one_dragon_config.instance_list_in_od) > 1)
+            and len(self.ctx.one_dragon_config.instance_list) > 1
+            and len(self.ctx.one_dragon_config.instance_list_in_od) > 0)
 
         # 切换账号的情况下 一定需要登录
         if switch:


### PR DESCRIPTION
既然在脚本上创建过多个账号, 那么在游戏中也可能会登多个账号吧(偶尔帮朋友打个深渊之类的), 重新上一下号, 避免一直运行一条龙但事实啥都没干然后发现是登错号了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug 修复
  - 优化强制登录判定：仅当存在多个总账号且 OD 列表中至少包含一个账号时才触发，避免单账号场景误触发登录/切换，减少不必要的中断。原有账号切换行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->