### PR TITLE
:recycle: 优化yaml缓存, 解决GUI卡顿

### DIFF
--- a/src/one_dragon/base/config/yaml_operator.py
+++ b/src/one_dragon/base/config/yaml_operator.py
@@ -6,8 +6,76 @@ import yaml
 
 from one_dragon.utils.log_utils import log
 
+
+import concurrent.futures
+import threading
+
+# 自定义守护线程池
+class DaemonThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
+    def _adjust_thread_count(self):
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+        while len(self._threads) < self._max_workers:
+            t = threading.Thread(target=self._worker, args=(weakref_cb,))
+            t.daemon = True  # 守护线程
+            t.start()
+            self._threads.add(t)
+
+# 全局单例池对象
+class GlobalDaemonPool:
+    _instance = None
+
+    @classmethod
+    def instance(cls, max_workers=4):
+        if cls._instance is None:
+            cls._instance = DaemonThreadPoolExecutor(max_workers=max_workers)
+        return cls._instance
+
+
+storeable_cache_config_prefixes = [
+    "assets/",
+    "config/",
+]
+
 cached_yaml_data: dict[str, tuple[float, dict]] = {}
 
+def flush_cache_to_file():
+    """
+    将缓存中符合前缀要求的配置存储到文件中，供下次启动时加载
+    """
+    cache_to_store = {}
+    for key, value in cached_yaml_data.items():
+        if any(key.startswith(prefix) for prefix in storeable_cache_config_prefixes):
+            cache_to_store[key] = value
+    if cache_to_store:
+        import json
+        with open('.cache_store.json', 'w', encoding='utf-8') as f:
+            json.dump(cache_to_store, f, ensure_ascii=False, indent=4)
+
+def walk_and_clear_cache():
+    """
+    遍历，若文件被修改则清除缓存
+    """
+    for str, (last_modify, _) in list(cached_yaml_data.items()):
+        try:
+            if not os.path.getmtime(str) == last_modify:
+                del cached_yaml_data[str]
+        except FileNotFoundError:
+            del cached_yaml_data[str]
+
+def reload_cache_from_file():
+    """
+    从存储的缓存文件中加载缓存
+    """
+    import json
+    if os.path.exists('.cache_store.json'):
+        with open('.cache_store.json', 'r', encoding='utf-8') as f:
+            cache_from_file = json.load(f)
+            for key, value in cache_from_file.items():
+                cached_yaml_data[key] = (value[0], value[1])
+        walk_and_clear_cache()
+
+reload_cache_from_file()
 
 def get_temp_config_path(file_path: str) -> str:
     """
@@ -22,16 +90,28 @@ def get_temp_config_path(file_path: str) -> str:
 
 def read_cache_or_load(file_path: str):
     cached = cached_yaml_data.get(file_path)
-    last_modify = os.path.getmtime(file_path)
-    if cached is not None and cached[0] == last_modify:
-        return cached[1]
+    if cached is not None:
+        _, data = cached
+        return data
 
     with open(file_path, 'r', encoding='utf-8') as file:
         log.debug(f"加载yaml: {file_path}")
+        last_modify = os.path.getmtime(file_path)
         data = yaml.safe_load(file)
         cached_yaml_data[file_path] = (last_modify, data)
         return data
 
+def write_file_and_flush_cache(file_path: str, data: dict, sync: bool = False):
+    cached_yaml_data[file_path] = (0.0, data)
+    def write_to_file_and_load_modify_time():
+        with open(file_path, 'w', encoding='utf-8') as file:
+            yaml.dump(data, file, allow_unicode=True, sort_keys=False)
+        last_modify = os.path.getmtime(file_path)
+        cached_yaml_data[file_path] = (last_modify, data)
+    if sync:
+        write_to_file_and_load_modify_time()
+    else:
+        GlobalDaemonPool.instance().submit(write_to_file_and_load_modify_time)
 
 class YamlOperator:
 


### PR DESCRIPTION
0. pr的主要修改内容：每次读取配置文件缓存时，取消重新拿取文件modify_time，完全不与磁盘交互。写入配置文件时，先刷缓存, 之后使用后台守护线程写入文件，不占gui线程。解决gui卡顿。
1. pr的额外改动：将配置文件进行json文件缓存，增加启动速度 （实验性，预期能略快）
2. pr的槽点与解决：这项改进认为通常用户不会在GUI开启的时候修改配置文件 (这也许会对战斗模版的debug不友好），以下是优化方案, 我更倾向于后者
      0.) 增加启动参数或者gui设置不走缓存
      1). 增加窗口焦点事件, 回到zzz焦点时使用守护线程刷配置文件缓存
3. 进一步优化:  1) mutex: 尽量不同时读写一个文件, 2) shutdown hook等待线程池结束