### PR TITLE
feat: 单次副本结束后添加恢复电量流程

### DIFF
--- a/src/zzz_od/application/charge_plan/charge_plan_app.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_app.py
@@ -11,7 +11,6 @@ from zzz_od.application.charge_plan.charge_plan_config import (
     CardNumEnum,
     ChargePlanConfig,
     ChargePlanItem,
-    RestoreChargeEnum,
 )
 from zzz_od.application.zzz_application import ZApplication
 from zzz_od.context.zzz_context import ZContext
@@ -127,7 +126,7 @@ class ChargePlanApp(ZApplication):
             # 检查电量是否足够
             if not self.need_to_check_power_in_mission and self.charge_power < need_charge_power:
                 if (
-                    self.config.restore_charge == RestoreChargeEnum.NONE.value.value
+                    not self.config.is_restore_charge_enabled
                     or (self.node_status.get('恢复电量') and self.node_status.get('恢复电量').is_fail)
                 ):
                     if not self.config.skip_plan:

--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -310,3 +310,7 @@ class ChargePlanConfig(ApplicationConfig):
     @restore_charge.setter
     def restore_charge(self, new_value: str) -> None:
         self.update('restore_charge', new_value)
+
+    @property
+    def is_restore_charge_enabled(self) -> bool:
+        return self.restore_charge != RestoreChargeEnum.NONE.value.value

--- a/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
+++ b/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
@@ -3,6 +3,7 @@ from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
 from zzz_od.context.zzz_context import ZContext
+from zzz_od.operation.restore_charge import RestoreCharge
 from zzz_od.operation.zzz_operation import ZOperation
 
 
@@ -17,18 +18,33 @@ class ChooseNextOrFinishAfterBattle(ZOperation):
         ZOperation.__init__(self, ctx, op_name=gt('战斗后选择'))
         self.try_next: bool = try_next
 
+    @node_from(from_name='恢复电量', status='战斗结果-完成')
     @operation_node(name='判断再来一次', is_start_node=True)
     def check_next(self) -> OperationRoundResult:
         if self.try_next:
-            return self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-再来一次',
-                                                     success_wait=1, retry_wait=1)
-        else:
-            return self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-完成',
-                                                     success_wait=5, retry_wait=1)
+            result = self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-再来一次',
+                                                       success_wait=1, retry_wait=1)
+            if result.is_success:
+                return result
 
-    @node_from(from_name='判断再来一次', success=False)
-    @operation_node(name='无再来一次')
-    def finish(self) -> OperationRoundResult:
         return self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-完成',
                                                  success_wait=5, retry_wait=1)
 
+    @node_from(from_name='判断再来一次', status='战斗结果-再来一次')
+    @operation_node(name='恢复电量')
+    def restore_charge(self) -> OperationRoundResult:
+        # 检查是否在恢复电量界面
+        result = self.round_by_find_area(self.last_screenshot, '实战模拟室', '恢复电量')
+        if not result.is_success:
+            # 没有弹窗，直接返回再来一次的结果
+            return self.round_success(status='战斗结果-再来一次')
+
+        if self.ctx.charge_plan_config.is_restore_charge_enabled:
+            op = RestoreCharge(self.ctx)
+            result = self.round_by_op_result(op.execute())
+            self.try_next = result.is_success
+        else:
+            self.try_next = False
+
+        # 关闭弹窗之后重新点击
+        return self.round_by_click_area('战斗画面', '战斗结果-完成', success_wait=0.5)

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -372,7 +372,7 @@ class CombatSimulation(ZOperation):
     @node_from(from_name='战斗结束')
     @operation_node(name='判断下一次')
     def check_next(self) -> OperationRoundResult:
-        op = ChooseNextOrFinishAfterBattle(self.ctx, self.can_run_times > 0)
+        op = ChooseNextOrFinishAfterBattle(self.ctx, self.plan.plan_times > self.plan.run_times)
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='识别电量', success=False)

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -13,8 +13,7 @@ from one_dragon.utils import cv2_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 from zzz_od.application.charge_plan import charge_plan_const
-from zzz_od.application.charge_plan.charge_plan_config import ChargePlanItem, CardNumEnum, RestoreChargeEnum, \
-    ChargePlanConfig
+from zzz_od.application.charge_plan.charge_plan_config import ChargePlanItem, CardNumEnum, ChargePlanConfig
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
 from zzz_od.context.zzz_context import ZContext
@@ -268,7 +267,7 @@ class CombatSimulation(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if self.config.restore_charge == RestoreChargeEnum.NONE.value.value:
+        if not self.config.is_restore_charge_enabled:
             return self.round_success(CombatSimulation.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/expert_challenge.py
+++ b/src/zzz_od/operation/compendium/expert_challenge.py
@@ -14,7 +14,6 @@ from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     ChargePlanItem,
-    RestoreChargeEnum,
 )
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
@@ -126,7 +125,7 @@ class ExpertChallenge(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if self.config.restore_charge == RestoreChargeEnum.NONE.value.value:
+        if not self.config.is_restore_charge_enabled:
             return self.round_success(ExpertChallenge.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/expert_challenge.py
+++ b/src/zzz_od/operation/compendium/expert_challenge.py
@@ -215,7 +215,7 @@ class ExpertChallenge(ZOperation):
     @node_from(from_name='战斗结束')
     @operation_node(name='判断下一次')
     def check_next(self) -> OperationRoundResult:
-        op = ChooseNextOrFinishAfterBattle(self.ctx, self.can_run_times > 0)
+        op = ChooseNextOrFinishAfterBattle(self.ctx, self.plan.plan_times > self.plan.run_times)
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='识别电量', success=False)

--- a/src/zzz_od/operation/compendium/notorious_hunt.py
+++ b/src/zzz_od/operation/compendium/notorious_hunt.py
@@ -16,7 +16,6 @@ from one_dragon.yolo.detect_utils import DetectFrameResult
 from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanItem,
-    RestoreChargeEnum,
     ChargePlanConfig,
 )
 from zzz_od.application.notorious_hunt import notorious_hunt_const
@@ -265,7 +264,7 @@ class NotoriousHunt(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if self.charge_plan_config.restore_charge == RestoreChargeEnum.NONE.value.value:
+        if not self.charge_plan_config.is_restore_charge_enabled:
             return self.round_success(NotoriousHunt.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/routine_cleanup.py
+++ b/src/zzz_od/operation/compendium/routine_cleanup.py
@@ -242,7 +242,7 @@ class RoutineCleanup(ZOperation):
     @node_from(from_name='战斗结束')
     @operation_node(name='判断下一次')
     def check_next(self) -> OperationRoundResult:
-        op = ChooseNextOrFinishAfterBattle(self.ctx, self.can_run_times > 0)
+        op = ChooseNextOrFinishAfterBattle(self.ctx, self.plan.plan_times > self.plan.run_times)
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='识别电量', success=False)

--- a/src/zzz_od/operation/compendium/routine_cleanup.py
+++ b/src/zzz_od/operation/compendium/routine_cleanup.py
@@ -14,7 +14,6 @@ from zzz_od.application.charge_plan import charge_plan_const
 from zzz_od.application.charge_plan.charge_plan_config import (
     ChargePlanConfig,
     ChargePlanItem,
-    RestoreChargeEnum,
 )
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
@@ -152,7 +151,7 @@ class RoutineCleanup(ZOperation):
     @node_from(from_name='下一步', status=STATUS_CHARGE_NOT_ENOUGH)
     @operation_node(name='恢复电量')
     def restore_charge(self) -> OperationRoundResult:
-        if self.config.restore_charge == RestoreChargeEnum.NONE.value.value:
+        if not self.config.is_restore_charge_enabled:
             return self.round_success(RoutineCleanup.STATUS_CHARGE_NOT_ENOUGH)
         op = RestoreCharge(self.ctx)
         result = self.round_by_op_result(op.execute())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 暴露并使用可配置的“恢复电量”开关，战斗结算界面优先识别并处理恢复流程以便在开启时尝试补充电量。

- Bug 修复
  - 统一各玩法中恢复电量的判定与战后是否继续的决策逻辑，修正因判断不一致导致的误结束回合或未能恢复的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->