### PR TITLE
feat: 更新锄大地路线名单

### DIFF
--- a/config/world_patrol_route/system/lemnian_hollow/former_research_center/01.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_research_center/01.yml
@@ -5,40 +5,28 @@ op_list:
   - '1092'
   op_type: move
 - data:
-  - '400'
-  - '1119'
+  - '386'
+  - '1123'
   op_type: move
 - data:
   - '480'
   - '1111'
   op_type: move
 - data:
-  - '583'
-  - '1082'
+  - '526'
+  - '1097'
   op_type: move
 - data:
-  - '622'
-  - '1035'
+  - '595'
+  - '1045'
   op_type: move
 - data:
-  - '584'
-  - '966'
+  - '595'
+  - '969'
   op_type: move
 - data:
-  - '542'
-  - '928'
-  op_type: move
-- data:
-  - '458'
-  - '930'
-  op_type: move
-- data:
-  - '344'
-  - '925'
-  op_type: move
-- data:
-  - '311'
-  - '863'
+  - '595'
+  - '950'
   op_type: move
 tp_area_id: former_research_center
 tp_name: 科研院西侧

--- a/config/world_patrol_route/system/lemnian_hollow/former_research_center/02.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_research_center/02.yml
@@ -13,8 +13,12 @@ op_list:
   - '342'
   op_type: move
 - data:
-  - '557'
-  - '338'
+  - '589'
+  - '342'
+  op_type: move
+- data:
+  - '568'
+  - '323'
   op_type: move
 - data:
   - '565'

--- a/config/world_patrol_route/system/lemnian_hollow/former_research_center/03.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_research_center/03.yml
@@ -33,12 +33,12 @@ op_list:
   - '661'
   op_type: move
 - data:
-  - '939'
-  - '621'
+  - '936'
+  - '629'
   op_type: move
 - data:
-  - '964'
-  - '563'
+  - '936'
+  - '606'
   op_type: move
 tp_area_id: former_research_center
 tp_name: 二楼平台

--- a/config/world_patrol_route/system/lemnian_hollow/former_research_center/04.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_research_center/04.yml
@@ -1,0 +1,20 @@
+idx: 4
+op_list:
+- data:
+  - '311'
+  - '750'
+  op_type: move
+- data:
+  - '311'
+  - '863'
+  op_type: move
+- data:
+  - '344'
+  - '925'
+  op_type: move
+- data:
+  - '352'
+  - '939'
+  op_type: move
+tp_area_id: former_research_center
+tp_name: 科研院仓库

--- a/config/world_patrol_route/system/lemnian_hollow/production_area_building_east_side/01.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/production_area_building_east_side/01.yml
@@ -9,16 +9,28 @@ op_list:
   - '1994'
   op_type: move
 - data:
-  - '552'
-  - '1965'
+  - '551'
+  - '1955'
   op_type: move
 - data:
-  - '552'
+  - '546'
+  - '1871'
+  op_type: move
+- data:
+  - '544'
+  - '1844'
+  op_type: move
+- data:
+  - '544'
   - '1810'
   op_type: move
 - data:
   - '626'
-  - '1810'
+  - '1804'
+  op_type: move
+- data:
+  - '634'
+  - '1807'
   op_type: move
 - data:
   - '634'
@@ -27,10 +39,6 @@ op_list:
 - data:
   - '650'
   - '1737'
-  op_type: move
-- data:
-  - '673'
-  - '1747'
   op_type: move
 tp_area_id: production_area_building_east_side
 tp_name: 中央制造区入口

--- a/config/world_patrol_route/system/lemnian_hollow/production_area_building_east_side/02.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/production_area_building_east_side/02.yml
@@ -6,7 +6,11 @@ op_list:
   op_type: move
 - data:
   - '867'
-  - '1356'
+  - '1336'
+  op_type: move
+- data:
+  - '866'
+  - '1236'
   op_type: move
 - data:
   - '867'
@@ -18,7 +22,7 @@ op_list:
   op_type: move
 - data:
   - '792'
-  - '1148'
+  - '1150'
   op_type: move
 tp_area_id: production_area_building_east_side
 tp_name: 物流通道

--- a/config/world_patrol_route_list/航天城_中央制造区.sample.yml
+++ b/config/world_patrol_route_list/航天城_中央制造区.sample.yml
@@ -1,5 +1,5 @@
 list_type: whitelist
-name: 
+name: 中央制造区
 route_items:
 - production_area_building_east_side_1
 - production_area_building_east_side_2

--- a/config/world_patrol_route_list/航天城_科研院旧址.sample.yml
+++ b/config/world_patrol_route_list/航天城_科研院旧址.sample.yml
@@ -1,0 +1,7 @@
+list_type: whitelist
+name: 科研院旧址
+route_items:
+- former_research_center_1
+- former_research_center_2
+- former_research_center_3
+- former_research_center_4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增“科研院旧址”巡逻路线 04。
  - 新增“科研院旧址”巡逻路线列表示例，包含 former_research_center_1 至 _4。
  - 为“中央制造区”巡逻路线列表示例补充名称（中央制造区）。

- Chores
  - 调整“科研院旧址”各条路线（含 01–03）及生产区东侧多处巡逻点位置与执行顺序，新增/合并/替换若干移动节点以优化路线一致性和执行顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->