### PR TITLE
perf: 优化锄大地路线（职工社区旧址）

### DIFF
--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/01.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/01.yml
@@ -1,48 +1,16 @@
 idx: 1
 op_list:
 - data:
-  - '1578'
-  - '898'
+  - '1335'
+  - '304'
   op_type: move
 - data:
-  - '1538'
-  - '899'
+  - '1352'
+  - '353'
   op_type: move
 - data:
-  - '1501'
-  - '899'
-  op_type: move
-- data:
-  - '1451'
-  - '836'
-  op_type: move
-- data:
-  - '1480'
-  - '906'
-  op_type: move
-- data:
-  - '1403'
-  - '833'
-  op_type: move
-- data:
-  - '1404'
-  - '809'
-  op_type: move
-- data:
-  - '1330'
-  - '806'
-  op_type: move
-- data:
-  - '1285'
-  - '770'
-  op_type: move
-- data:
-  - '1233'
-  - '739'
-  op_type: move
-- data:
-  - '1173'
-  - '753'
+  - '1376'
+  - '340'
   op_type: move
 tp_area_id: former_employee_community
-tp_name: 旧商业楼
+tp_name: 职工宿舍北区

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/02.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/02.yml
@@ -1,20 +1,48 @@
 idx: 2
 op_list:
 - data:
-  - '1383'
-  - '1558'
+  - '1578'
+  - '898'
   op_type: move
 - data:
-  - '1315'
-  - '1565'
+  - '1538'
+  - '899'
   op_type: move
 - data:
-  - '1289'
-  - '1510'
+  - '1501'
+  - '899'
   op_type: move
 - data:
-  - '1246'
-  - '1506'
+  - '1451'
+  - '836'
+  op_type: move
+- data:
+  - '1480'
+  - '906'
+  op_type: move
+- data:
+  - '1405'
+  - '826'
+  op_type: move
+- data:
+  - '1407'
+  - '807'
+  op_type: move
+- data:
+  - '1330'
+  - '806'
+  op_type: move
+- data:
+  - '1285'
+  - '770'
+  op_type: move
+- data:
+  - '1233'
+  - '739'
+  op_type: move
+- data:
+  - '1173'
+  - '753'
   op_type: move
 tp_area_id: former_employee_community
-tp_name: 职工宿舍南区
+tp_name: 旧商业楼

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/03.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/03.yml
@@ -1,16 +1,20 @@
 idx: 3
 op_list:
 - data:
-  - '1335'
-  - '304'
+  - '1383'
+  - '1558'
   op_type: move
 - data:
-  - '1352'
-  - '353'
+  - '1315'
+  - '1565'
   op_type: move
 - data:
-  - '1376'
-  - '340'
+  - '1289'
+  - '1510'
+  op_type: move
+- data:
+  - '1246'
+  - '1506'
   op_type: move
 tp_area_id: former_employee_community
-tp_name: 职工宿舍北区
+tp_name: 职工宿舍南区

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/04.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/04.yml
@@ -1,52 +1,20 @@
 idx: 4
 op_list:
 - data:
-  - '1240'
-  - '1169'
+  - '409'
+  - '1254'
   op_type: move
 - data:
-  - '1151'
-  - '1165'
+  - '444'
+  - '1288'
   op_type: move
 - data:
-  - '1149'
-  - '1230'
+  - '503'
+  - '1299'
   op_type: move
 - data:
-  - '1090'
-  - '1220'
-  op_type: move
-- data:
-  - '1087'
-  - '1260'
-  op_type: move
-- data:
-  - '1032'
-  - '1234'
-  op_type: move
-- data:
-  - '1020'
-  - '1179'
-  op_type: move
-- data:
-  - '1015'
-  - '1126'
-  op_type: move
-- data:
-  - '964'
-  - '1112'
-  op_type: move
-- data:
-  - '943'
-  - '1063'
-  op_type: move
-- data:
-  - '940'
-  - '1015'
-  op_type: move
-- data:
-  - '959'
-  - '986'
+  - '423'
+  - '1292'
   op_type: move
 tp_area_id: former_employee_community
-tp_name: 中央广场
+tp_name: 职工宿舍西区

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/05.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/05.yml
@@ -1,52 +1,64 @@
 idx: 5
 op_list:
 - data:
-  - '600'
-  - '830'
+  - '677'
+  - '873'
   op_type: move
 - data:
-  - '584'
-  - '776'
+  - '694'
+  - '835'
   op_type: move
 - data:
-  - '578'
-  - '723'
+  - '708'
+  - '908'
   op_type: move
 - data:
-  - '568'
-  - '672'
+  - '784'
+  - '918'
   op_type: move
 - data:
-  - '523'
-  - '658'
+  - '810'
+  - '919'
   op_type: move
 - data:
-  - '474'
-  - '660'
+  - '953'
+  - '944'
   op_type: move
 - data:
-  - '422'
-  - '669'
+  - '959'
+  - '986'
   op_type: move
 - data:
-  - '408'
-  - '704'
+  - '940'
+  - '1015'
   op_type: move
 - data:
-  - '390'
-  - '729'
+  - '943'
+  - '1063'
   op_type: move
 - data:
-  - '342'
-  - '736'
+  - '964'
+  - '1112'
   op_type: move
 - data:
-  - '300'
-  - '742'
+  - '1022'
+  - '1116'
   op_type: move
 - data:
-  - '263'
-  - '746'
+  - '1025'
+  - '1148'
+  op_type: move
+- data:
+  - '1020'
+  - '1179'
+  op_type: move
+- data:
+  - '1032'
+  - '1234'
+  op_type: move
+- data:
+  - '1087'
+  - '1260'
   op_type: move
 tp_area_id: former_employee_community
 tp_name: 西侧广场

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/05.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/05.yml
@@ -1,28 +1,36 @@
 idx: 5
 op_list:
 - data:
-  - '677'
-  - '873'
+  - '665'
+  - '857'
   op_type: move
 - data:
-  - '694'
-  - '835'
+  - '712'
+  - '863'
   op_type: move
 - data:
-  - '708'
-  - '908'
+  - '768'
+  - '864'
   op_type: move
 - data:
-  - '784'
-  - '918'
+  - '775'
+  - '889'
   op_type: move
 - data:
-  - '810'
+  - '768'
   - '919'
   op_type: move
 - data:
+  - '810'
+  - '917'
+  op_type: move
+- data:
+  - '870'
+  - '940'
+  op_type: move
+- data:
   - '953'
-  - '944'
+  - '940'
   op_type: move
 - data:
   - '959'

--- a/config/world_patrol_route/system/lemnian_hollow/former_employee_community/06.yml
+++ b/config/world_patrol_route/system/lemnian_hollow/former_employee_community/06.yml
@@ -1,20 +1,52 @@
 idx: 6
 op_list:
 - data:
-  - '409'
-  - '1254'
+  - '600'
+  - '830'
   op_type: move
 - data:
-  - '444'
-  - '1288'
+  - '584'
+  - '776'
   op_type: move
 - data:
-  - '503'
-  - '1299'
+  - '578'
+  - '723'
   op_type: move
 - data:
-  - '423'
-  - '1292'
+  - '568'
+  - '672'
+  op_type: move
+- data:
+  - '523'
+  - '658'
+  op_type: move
+- data:
+  - '474'
+  - '660'
+  op_type: move
+- data:
+  - '422'
+  - '669'
+  op_type: move
+- data:
+  - '408'
+  - '704'
+  op_type: move
+- data:
+  - '390'
+  - '729'
+  op_type: move
+- data:
+  - '342'
+  - '736'
+  op_type: move
+- data:
+  - '300'
+  - '742'
+  op_type: move
+- data:
+  - '263'
+  - '746'
   op_type: move
 tp_area_id: former_employee_community
-tp_name: 职工宿舍西区
+tp_name: 西侧广场

--- a/config/world_patrol_route_list/[空洞]职工社区旧址.sample.yml
+++ b/config/world_patrol_route_list/[空洞]职工社区旧址.sample.yml
@@ -1,0 +1,9 @@
+list_type: whitelist
+name: 职工社区旧址
+route_items:
+- former_employee_community_1
+- former_employee_community_2
+- former_employee_community_3
+- former_employee_community_4
+- former_employee_community_5
+- former_employee_community_6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 新增“职工社区旧址”白名单路线清单，包含6条子路线，便于快速启用相关巡逻线路。
* 杂务
  * 更新“前员工社区”多分区巡逻路径与坐标点：新增与替换多处移动节点、追加若干节点并调整路线顺序，同时更新若干区域显示名称（北区/南区/西区/西侧广场/旧商业楼），提升线路连贯性与定位准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->