### PR TITLE
refactor(standalone_app_run): 隐藏不支持设置的应用的设置按钮

### DIFF
--- a/src/one_dragon_qt/view/standalone_app_run_interface.py
+++ b/src/one_dragon_qt/view/standalone_app_run_interface.py
@@ -141,6 +141,7 @@ class StandaloneRunInterface(SplitAppRunInterface):
             selected_ids = dialog.get_selected_ids()
             for app_id in selected_ids:
                 self.app_list_widget.add_app(app_id, all_apps[app_id])
+            self._update_setting_btn_visibility()
             self.ctx.standalone_app_config.app_list = self.app_list_widget.app_ids
 
             if not self.app_list_widget.selected_app_id and selected_ids:

--- a/src/one_dragon_qt/view/standalone_app_run_interface.py
+++ b/src/one_dragon_qt/view/standalone_app_run_interface.py
@@ -98,6 +98,7 @@ class StandaloneRunInterface(SplitAppRunInterface):
 
         app_list = [(aid, all_apps[aid]) for aid in valid_ids]
         self.app_list_widget.set_app_list(app_list)
+        self._update_setting_btn_visibility()
 
         active_id = config.active_app_id
         if active_id and active_id in valid_ids:
@@ -151,11 +152,25 @@ class StandaloneRunInterface(SplitAppRunInterface):
         dialog_fn = self.get_setting_dialog_map().get(app_id)
         if dialog_fn is None:
             return
+        target = self._find_setting_btn(app_id) or self.add_app_btn
         dialog_fn(
             parent=self,
             group_id=application_const.DEFAULT_GROUP_ID,
-            target=self.add_app_btn,
+            target=target,
         )
+
+    def _find_setting_btn(self, app_id: str) -> QWidget | None:
+        """找到对应 app_id 的卡片上的设置按钮"""
+        for card in self.app_list_widget._cards:
+            if card.app_id == app_id:
+                return card.setting_btn
+        return None
+
+    def _update_setting_btn_visibility(self) -> None:
+        """根据 get_setting_dialog_map 的注册信息，显示或隐藏卡片的设置按钮"""
+        settable = set(self.get_setting_dialog_map())
+        for card in self.app_list_widget._cards:
+            card.setting_btn.setVisible(card.app_id in settable)
 
     def get_setting_dialog_map(self) -> dict[str, Callable]:
         """返回 app_id -> 设置弹窗回调 的映射，由子类实现"""

--- a/src/zzz_od/gui/view/standalone/zzz_standalone_app_run_interface.py
+++ b/src/zzz_od/gui/view/standalone/zzz_standalone_app_run_interface.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from qfluentwidgets import FluentIcon
 
-from one_dragon_qt.view.standalone_run_interface import StandaloneRunInterface
+from one_dragon_qt.view.standalone_app_run_interface import StandaloneRunInterface
 from zzz_od.context.zzz_context import ZContext
 
 


### PR DESCRIPTION
- standalone_run_interface.py → standalone_app_run_interface.py，统一命名
- 刷新列表后根据 get_setting_dialog_map 隐藏无设置的卡片设置按钮
- Flyout 锚点改为卡片上的设置按钮而非添加按钮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复应用卡片的设置按钮可见性不同步的问题：新增或刷新应用后，设置按钮会立即根据是否存在对应设置对话框显示或隐藏，并在打开设置时优先定位到对应卡片的按钮，找不到时回退至“添加应用”按钮。

* **重构**
  * 调整界面类的继承来源，统一接口模块的结构与导入路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->