### PR TITLE
feat(notify): 节点通知引入通知池机制

### DIFF
--- a/src/one_dragon/base/config/notify_config.py
+++ b/src/one_dragon/base/config/notify_config.py
@@ -5,6 +5,7 @@ class NotifyLevel:
     OFF = 0
     APP = 1
     ALL = 2
+    MERGE = 3
 
 
 class NotifyConfig(YamlConfig):
@@ -43,7 +44,8 @@ class NotifyConfig(YamlConfig):
         获取指定 app_id 的通知等级
         0: 关闭
         1: 仅应用
-        2: 全部（应用和节点）
+        2: 全部（应用和节点，逐条发送）
+        3: 合并（应用和节点，合并发送）
         """
         if not app_id:
             return NotifyLevel.ALL

--- a/src/one_dragon/base/operation/application/application_run_context.py
+++ b/src/one_dragon/base/operation/application/application_run_context.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 from one_dragon.base.operation.context_event_bus import ContextEventBus
+from one_dragon.base.operation.notify_pool import NotifyPool
 from one_dragon.utils import thread_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
@@ -81,6 +82,9 @@ class ApplicationRunContext:
         self.current_app_id: Optional[str] = None
         self.current_instance_idx: Optional[int] = None
         self.current_group_id: Optional[str] = None
+
+        # 通知池，应用开始时清空重用
+        self.notify_pool: NotifyPool = NotifyPool()
 
     def registry_application(
         self,

--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from one_dragon.base.config.notify_config import NotifyLevel
 from one_dragon.base.operation.application_run_record import AppRunRecord
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_base import OperationResult
@@ -69,6 +70,11 @@ class Application(Operation):
 
         if self.ctx.run_context.is_app_need_notify(self.app_id):
             send_application_notify(self, None)
+            # 清空通知池，根据通知等级设置图片保留数量
+            pool = self.ctx.run_context.notify_pool
+            pool.clear()
+            notify_level = self.ctx.notify_config.get_app_notify_level(self.app_id)
+            pool.max_images = 10 if notify_level >= NotifyLevel.ALL else 1
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_START.value, self.app_id)
 
@@ -82,6 +88,8 @@ class Application(Operation):
 
         if self.ctx.run_context.is_app_need_notify(self.app_id):
             send_application_notify(self, result.success)
+            # 清空通知池
+            self.ctx.run_context.notify_pool.clear()
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_STOP.value, self.app_id)
 

--- a/src/one_dragon/base/operation/notify_pool.py
+++ b/src/one_dragon/base/operation/notify_pool.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from cv2.typing import MatLike
+
+
+class NotifyPoolItem(NamedTuple):
+    """通知池中的一条消息"""
+    content: str
+    image: MatLike | None = None
+
+
+class NotifyPool:
+    """通知池，收集应用运行期间的节点通知消息。
+
+    每个应用实例化时创建，收集节点通知的图片和信息。
+    支持合并消息模式，将所有节点消息合并为一个列表送出。
+    池中仅保留最近 max_images 张图片以控制内存，文本始终保留。
+    """
+
+    def __init__(self):
+        self.items: list[NotifyPoolItem] = []
+        self._last_image: MatLike | None = None
+        self.max_images: int = 10
+        self._image_count: int = 0
+
+    def add(self, content: str, image: MatLike | None = None) -> None:
+        """添加一条通知到池中"""
+        if image is not None:
+            self._last_image = image
+            self._image_count += 1
+            # 超出图片上限时，移除最旧的图片以释放内存
+            if self._image_count > self.max_images:
+                self._strip_oldest_image()
+        self.items.append(NotifyPoolItem(content=content, image=image))
+
+    def _strip_oldest_image(self) -> None:
+        """将最旧的一张图片从池中移除（替换为 None），文本保留"""
+        for i, item in enumerate(self.items):
+            if item.image is not None:
+                self.items[i] = NotifyPoolItem(content=item.content)
+                self._image_count -= 1
+                return
+
+    @property
+    def last_image(self) -> MatLike | None:
+        """获取最后一张图片（独立追踪，不受池内图片淘汰影响）"""
+        return self._last_image
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def clear(self) -> None:
+        self.items.clear()
+        self._last_image = None
+        self._image_count = 0

--- a/src/one_dragon/base/operation/notify_pool.py
+++ b/src/one_dragon/base/operation/notify_pool.py
@@ -14,21 +14,21 @@ class NotifyPoolItem(NamedTuple):
 class NotifyPool:
     """通知池，收集应用运行期间的节点通知消息。
 
-    每个应用实例化时创建，收集节点通知的图片和信息。
+    在 ApplicationRunContext 中创建，每次应用开始运行时清空重用。
     支持合并消息模式，将所有节点消息合并为一个列表送出。
     池中仅保留最近 max_images 张图片以控制内存，文本始终保留。
+
+    last_image 属性从 items 尾部遍历获取，用于 APP 级别结束通知附带截图。
     """
 
     def __init__(self):
         self.items: list[NotifyPoolItem] = []
-        self._last_image: MatLike | None = None
         self.max_images: int = 10
         self._image_count: int = 0
 
     def add(self, content: str, image: MatLike | None = None) -> None:
         """添加一条通知到池中"""
         if image is not None:
-            self._last_image = image
             self._image_count += 1
             # 超出图片上限时，移除最旧的图片以释放内存
             if self._image_count > self.max_images:
@@ -43,15 +43,17 @@ class NotifyPool:
                 self._image_count -= 1
                 return
 
-    @property
-    def last_image(self) -> MatLike | None:
-        """获取最后一张图片（独立追踪，不受池内图片淘汰影响）"""
-        return self._last_image
-
     def __len__(self) -> int:
         return len(self.items)
 
+    @property
+    def last_image(self) -> MatLike | None:
+        """从池中获取最后一张图片"""
+        for item in reversed(self.items):
+            if item.image is not None:
+                return item.image
+        return None
+
     def clear(self) -> None:
         self.items.clear()
-        self._last_image = None
         self._image_count = 0

--- a/src/one_dragon/base/operation/notify_pool.py
+++ b/src/one_dragon/base/operation/notify_pool.py
@@ -28,12 +28,12 @@ class NotifyPool:
 
     def add(self, content: str, image: MatLike | None = None) -> None:
         """添加一条通知到池中"""
+        self.items.append(NotifyPoolItem(content=content, image=image))
         if image is not None:
             self._image_count += 1
             # 超出图片上限时，移除最旧的图片以释放内存
             if self._image_count > self.max_images:
                 self._strip_oldest_image()
-        self.items.append(NotifyPoolItem(content=content, image=image))
 
     def _strip_oldest_image(self) -> None:
         """将最旧的一张图片从池中移除（替换为 None），文本保留"""

--- a/src/one_dragon/base/operation/notify_pool.py
+++ b/src/one_dragon/base/operation/notify_pool.py
@@ -21,7 +21,7 @@ class NotifyPool:
     last_image 属性从 items 尾部遍历获取，用于 APP 级别结束通知附带截图。
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.items: list[NotifyPoolItem] = []
         self.max_images: int = 10
         self._image_count: int = 0

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -107,7 +107,7 @@ def send_application_notify(app: Application, status: bool | None) -> None:
 
     if notify_level == NotifyLevel.MERGE and len(pool) > 0:
         # 合并模式: 将结束消息放在开头，与池中消息合并送出
-        items = [NotifyPoolItem(content=message)] + pool.items
+        items = [NotifyPoolItem(content=message), *pool.items]
         app.ctx.push_service.push_merged_async(
             title=app.ctx.notify_config.title,
             items=items,

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -68,6 +68,11 @@ def _get_notify_level(operation: Operation) -> int:
 def send_application_notify(app: Application, status: bool | None) -> None:
     """向外部推送应用运行状态通知。
 
+    各通知等级的结束通知行为：
+        - APP: 发送结束通知，附带池中最后一张截图
+        - ALL: 发送结束通知，不附图（节点截图已逐条发送）
+        - MERGE: 将结束消息与池中节点消息合并发送
+
     Args:
         app: Application 实例
         status: True=成功, False=失败, None=开始
@@ -113,12 +118,12 @@ def send_application_notify(app: Application, status: bool | None) -> None:
             items=items,
         )
     else:
-        # 普通模式: 发送结束通知，附带池中最后一张图片
-        last_image = pool.last_image
+        # 普通模式: 发送结束通知，APP 级别附带最后一张截图
+        image = pool.last_image if notify_level == NotifyLevel.APP else None
         app.ctx.push_service.push_async(
             title=app.ctx.notify_config.title,
             content=message,
-            image=last_image,
+            image=image,
         )
 
 
@@ -199,8 +204,8 @@ def send_node_notify(
     """
     发送节点级通知，并收集到通知池中。
 
-    当通知池存在时，始终收集消息到池中（用于合并通知和最后一张图片）。
-    仅在通知等级为 ALL 且未启用合并通知时，才立即发送单条节点通知。
+    始终收集消息到通知池中（用于合并通知和最后一张图片）。
+    ALL 等级时逐条立即发送；MERGE 等级时仅收集，但节点失败时也立即发送。
 
     Args:
         operation: Operation 实例

--- a/src/one_dragon/base/operation/operation_notify.py
+++ b/src/one_dragon/base/operation/operation_notify.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from one_dragon.base.config.notify_config import NotifyLevel
+from one_dragon.base.operation.notify_pool import NotifyPoolItem
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
 
@@ -79,24 +80,46 @@ def send_application_notify(app: Application, status: bool | None) -> None:
     if status is None and not app.ctx.notify_config.enable_before_notify:
         return
 
-    # 确定状态和图片来源
+    # 确定状态文本
     if status is True:
-        status = gt('成功')
+        status_text = gt('成功')
     elif status is False:
-        status = gt('失败')
+        status_text = gt('失败')
     else:  # status is None
-        status = gt('开始')
+        status_text = gt('开始')
 
     # 构建消息
     _, app_name = _get_app_info(app)
     app_name = gt(app_name)
-    message = f"{gt('任务')}「{app_name}」{gt('运行')}{status}"
+    message = f"{gt('任务')}「{app_name}」{gt('运行')}{status_text}"
 
-    # 异步推送
-    app.ctx.push_service.push_async(
-        title=app.ctx.notify_config.title,
-        content=message,
-    )
+    if status is None:
+        # 开始通知 - 直接推送
+        app.ctx.push_service.push_async(
+            title=app.ctx.notify_config.title,
+            content=message,
+        )
+        return
+
+    # 结束通知
+    pool = app.ctx.run_context.notify_pool
+    notify_level = _get_notify_level(app)
+
+    if notify_level == NotifyLevel.MERGE and len(pool) > 0:
+        # 合并模式: 将结束消息放在开头，与池中消息合并送出
+        items = [NotifyPoolItem(content=message)] + pool.items
+        app.ctx.push_service.push_merged_async(
+            title=app.ctx.notify_config.title,
+            items=items,
+        )
+    else:
+        # 普通模式: 发送结束通知，附带池中最后一张图片
+        last_image = pool.last_image
+        app.ctx.push_service.push_async(
+            title=app.ctx.notify_config.title,
+            content=message,
+            image=last_image,
+        )
 
 
 class NodeNotifyDesc:
@@ -174,7 +197,10 @@ def send_node_notify(
     next_node: OperationNode | None = None
 ):
     """
-    发送节点级通知
+    发送节点级通知，并收集到通知池中。
+
+    当通知池存在时，始终收集消息到池中（用于合并通知和最后一张图片）。
+    仅在通知等级为 ALL 且未启用合并通知时，才立即发送单条节点通知。
 
     Args:
         operation: Operation 实例
@@ -182,7 +208,13 @@ def send_node_notify(
         current_node: 当前正在执行的节点
         next_node: 下一个要执行的节点
     """
-    if _get_notify_level(operation) < NotifyLevel.ALL or current_node is None:
+    pool = operation.ctx.run_context.notify_pool
+    notify_level = _get_notify_level(operation)
+
+    # OFF 等级不处理任何节点通知
+    if notify_level < NotifyLevel.APP:
+        return
+    if current_node is None:
         return
 
     # 初始化通知列表
@@ -254,9 +286,15 @@ def send_node_notify(
     if custom_message:
         message += custom_message
 
-    # 异步推送
-    operation.ctx.push_service.push_async(
-        title=operation.ctx.notify_config.title,
-        content=message,
-        image=operation.last_screenshot if send_image else None,
-    )
+    image = operation.last_screenshot if send_image else None
+
+    # 收集到通知池
+    pool.add(content=message, image=image)
+
+    # ALL 等级时逐条发送；MERGE 等级时仅收集，但失败时也立即发送
+    if notify_level == NotifyLevel.ALL or (notify_level == NotifyLevel.MERGE and not is_success):
+        operation.ctx.push_service.push_async(
+            title=operation.ctx.notify_config.title,
+            content=message,
+            image=image,
+        )

--- a/src/one_dragon/base/push/channel/one_bot.py
+++ b/src/one_dragon/base/push/channel/one_bot.py
@@ -4,8 +4,12 @@ from typing import Any
 import requests
 from cv2.typing import MatLike
 
+from one_dragon.base.operation.notify_pool import NotifyPoolItem
 from one_dragon.base.push.push_channel import PushChannel
-from one_dragon.base.push.push_channel_config import PushChannelConfigField, FieldTypeEnum
+from one_dragon.base.push.push_channel_config import (
+    FieldTypeEnum,
+    PushChannelConfigField,
+)
 from one_dragon.utils.log_utils import log
 
 
@@ -177,3 +181,104 @@ class OneBot(PushChannel):
             return False, "QQ 号和群号至少需要配置一个"
 
         return True, "配置验证通过"
+
+    def push_merged(
+        self,
+        config: dict[str, str],
+        title: str,
+        items: list[NotifyPoolItem],
+        proxy_url: str | None = None,
+    ) -> tuple[bool, str]:
+        """
+        使用 OneBot 合并转发 API 推送合并消息
+
+        Args:
+            config: 配置字典
+            title: 消息标题（用作转发节点的发送者名称）
+            items: 消息列表
+            proxy_url: 代理地址
+
+        Returns:
+            tuple[bool, str]: 是否成功、错误信息
+        """
+        try:
+            ok, msg = self.validate_config(config)
+            if not ok:
+                return False, msg
+
+            base_url = config.get('URL', '').rstrip('/')
+            if base_url.endswith('/send_msg'):
+                base_url = base_url[:-len('/send_msg')]
+
+            user_id = config.get('USER', '')
+            group_id = config.get('GROUP', '')
+            token = config.get('TOKEN', '')
+
+            headers = {'Content-Type': 'application/json'}
+            if token and len(token) > 0:
+                headers['Authorization'] = f'Bearer {token}'
+
+            # 构建合并转发节点
+            nodes = []
+            for item in items:
+                msg_content: list[dict] = [{'type': 'text', 'data': {'text': item.content}}]
+                if item.image is not None:
+                    image_base64 = self.image_to_base64(item.image)
+                    if image_base64 is not None:
+                        msg_content.append({'type': 'image', 'data': {'file': f'base64://{image_base64}'}})
+                nodes.append({
+                    'type': 'node',
+                    'data': {
+                        'name': title,
+                        'uin': user_id or '10086',
+                        'content': msg_content,
+                    }
+                })
+
+            success_count = 0
+            error_messages = []
+
+            # 私聊合并转发
+            if user_id and len(user_id) > 0:
+                fwd_url = base_url + '/send_private_forward_msg'
+                data = {'user_id': user_id, 'messages': nodes}
+                try:
+                    resp = requests.post(fwd_url, data=json.dumps(data), headers=headers, timeout=30)
+                    resp.raise_for_status()
+                    result = resp.json()
+                    if result.get('status') == 'ok':
+                        success_count += 1
+                        log.info('OneBot 私聊合并转发成功！')
+                    else:
+                        error_messages.append(f'OneBot 私聊合并转发失败: {result}')
+                        log.error(f'OneBot 私聊合并转发失败: {result}')
+                except Exception as e:
+                    error_messages.append(f'OneBot 私聊合并转发异常: {str(e)}')
+                    log.error(f'OneBot 私聊合并转发异常: {str(e)}')
+
+            # 群聊合并转发
+            if group_id and len(group_id) > 0:
+                fwd_url = base_url + '/send_group_forward_msg'
+                data = {'group_id': group_id, 'messages': nodes}
+                try:
+                    resp = requests.post(fwd_url, data=json.dumps(data), headers=headers, timeout=30)
+                    resp.raise_for_status()
+                    result = resp.json()
+                    if result.get('status') == 'ok':
+                        success_count += 1
+                        log.info('OneBot 群聊合并转发成功！')
+                    else:
+                        error_messages.append(f'OneBot 群聊合并转发失败: {result}')
+                        log.error(f'OneBot 群聊合并转发失败: {result}')
+                except Exception as e:
+                    error_messages.append(f'OneBot 群聊合并转发异常: {str(e)}')
+                    log.error(f'OneBot 群聊合并转发异常: {str(e)}')
+
+            if success_count > 0:
+                if len(error_messages) > 0:
+                    return True, f"部分推送成功: {'; '.join(error_messages)}"
+                return True, '合并转发成功'
+            return False, f"推送失败: {'; '.join(error_messages)}" if error_messages else '未配置有效的接收者'
+
+        except Exception as e:
+            return False, f'OneBot 合并转发异常: {str(e)}'

--- a/src/one_dragon/base/push/channel/smtp.py
+++ b/src/one_dragon/base/push/channel/smtp.py
@@ -8,6 +8,7 @@ from email.utils import formataddr
 
 from cv2.typing import MatLike
 
+from one_dragon.base.operation.notify_pool import NotifyPoolItem
 from one_dragon.base.push.push_channel import PushChannel
 from one_dragon.base.push.push_channel_config import PushChannelConfigField, FieldTypeEnum
 from one_dragon.utils.log_utils import log
@@ -228,3 +229,91 @@ class Smtp(PushChannel):
             return False, "端口号必须为数字"
 
         return True, "配置验证通过"
+
+    def push_merged(
+        self,
+        config: dict[str, str],
+        title: str,
+        items: list[NotifyPoolItem],
+        proxy_url: str | None = None,
+    ) -> tuple[bool, str]:
+        """
+        推送合并消息到SMTP邮件，使用 <hr> 分隔每条消息
+
+        Args:
+            config: 配置字典
+            title: 邮件标题
+            items: 消息列表
+            proxy_url: 代理地址
+
+        Returns:
+            tuple[bool, str]: 是否成功、错误信息
+        """
+        try:
+            ok, msg = self.validate_config(config)
+            if not ok:
+                return False, msg
+
+            server = config.get('SERVER', '')
+            use_ssl = config.get('SSL', 'true').lower() == 'true'
+            use_starttls = config.get('STARTTLS', 'false').lower() == 'true'
+            email_addr = config.get('EMAIL', '')
+            password = config.get('PASSWORD', '')
+            name = config.get('NAME', 'OneDragon')
+
+            message = MIMEMultipart('related')
+
+            html_parts: list[str] = []
+            img_attachments: list[MIMEImage] = []
+            img_idx = 0
+
+            for item in items:
+                part_html = '<p>{}</p>'.format(html.escape(item.content).replace('\n', '<br>\n'))
+                if item.image is not None:
+                    cid = f'screenshot_{img_idx}'
+                    img_data = self.image_to_bytes(item.image)
+                    if img_data is not None:
+                        img_part = MIMEImage(img_data.getvalue())
+                        img_part.add_header('Content-ID', f'<{cid}>')
+                        img_part.add_header('Content-Disposition', 'inline', filename=f'{cid}.jpg')
+                        img_attachments.append(img_part)
+                        part_html += f'<br><img src="cid:{cid}">'
+                        img_idx += 1
+                html_parts.append(part_html)
+
+            full_html = '<hr>\n'.join(html_parts)
+            text_part = MIMEText(full_html, 'html', 'utf-8')
+            message.attach(text_part)
+            for img in img_attachments:
+                message.attach(img)
+
+            message['From'] = formataddr(
+                (Header(name, 'utf-8').encode(), email_addr)
+            )
+            message['To'] = formataddr(
+                (Header(name, 'utf-8').encode(), email_addr)
+            )
+            message['Subject'] = Header(title, 'utf-8')
+
+            host, port = server.split(':')
+            port_int = int(port) if port else None
+            smtp_server = (
+                smtplib.SMTP_SSL(host, port_int) if use_ssl
+                else smtplib.SMTP(host, port_int)
+            )
+
+            try:
+                if use_starttls and not use_ssl:
+                    smtp_server.starttls()
+                smtp_server.login(email_addr, password)
+                smtp_server.sendmail(email_addr, email_addr, message.as_bytes())
+                return True, 'SMTP邮件合并推送成功'
+            except Exception as e:
+                log.error('SMTP邮件合并推送异常', exc_info=True)
+                return False, f'SMTP邮件合并推送异常: {str(e)}'
+            finally:
+                smtp_server.close()
+
+        except Exception as e:
+            log.error('SMTP邮件合并推送异常', exc_info=True)
+            return False, f'SMTP邮件合并推送异常: {str(e)}'

--- a/src/one_dragon/base/push/push_channel.py
+++ b/src/one_dragon/base/push/push_channel.py
@@ -1,10 +1,11 @@
 import base64
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from io import BytesIO
 
 import cv2
 from cv2.typing import MatLike
 
+from one_dragon.base.operation.notify_pool import NotifyPoolItem
 from one_dragon.base.push.push_channel_config import PushChannelConfigField
 
 
@@ -43,6 +44,35 @@ class PushChannel(ABC):
             tuple[bool, str]: 是否成功、错误信息
         """
         pass
+
+    def push_merged(
+        self,
+        config: dict[str, str],
+        title: str,
+        items: list[NotifyPoolItem],
+        proxy_url: str | None = None,
+    ) -> tuple[bool, str]:
+        """
+        推送合并消息。默认实现：将所有文本用分隔符拼接，使用最后一张图片。
+        子类可覆盖此方法以实现特定的合并消息格式（如 OneBot 合并转发）。
+
+        Args:
+            config: 配置
+            title: 标题
+            items: 消息列表
+            proxy_url: 代理地址
+
+        Returns:
+            tuple[bool, str]: 是否成功、错误信息
+        """
+        texts = []
+        last_image = None
+        for item in items:
+            texts.append(item.content)
+            if item.image is not None:
+                last_image = item.image
+        combined = '\n---\n'.join(texts)
+        return self.push(config, title, combined, last_image, proxy_url)
 
     @abstractmethod
     def validate_config(self, config: dict[str, str]) -> tuple[bool, str]:

--- a/src/one_dragon/base/push/push_service.py
+++ b/src/one_dragon/base/push/push_service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from cv2.typing import MatLike
 
+from one_dragon.base.operation.notify_pool import NotifyPoolItem
 from one_dragon.base.push.channel.ai_botk import AiBotK
 from one_dragon.base.push.channel.bark import Bark
 from one_dragon.base.push.channel.chronocat import Chronocat
@@ -239,6 +240,93 @@ class PushService:
             title,
             content,
             image,
+            channel_id,
+        )
+        future.add_done_callback(thread_utils.handle_future_result)
+
+    def push_merged(
+        self,
+        title: str,
+        items: list[NotifyPoolItem],
+        channel_id: str | None = None,
+    ) -> tuple[bool, str]:
+        """
+        推送合并消息
+
+        Args:
+            title: 标题
+            items: 消息列表
+            channel_id: 推送渠道ID 未传入时使用所有能通过配置校验的渠道
+
+        Returns:
+            tuple[bool, str]: 是否成功、错误信息
+        """
+        if not self.push_config.send_image:
+            items = [NotifyPoolItem(content=item.content) for item in items]
+
+        any_ok: bool = False
+        err_msg: str = ''
+        if channel_id is None:
+            any_push = False
+            for cid, channel in self._id_2_channels.items():
+                channel_config = self.get_channel_config(cid)
+                ok, msg = channel.validate_config(channel_config)
+                if not ok:
+                    continue
+
+                any_push = True
+
+                ok, msg = channel.push_merged(
+                    config=channel_config,
+                    title=title,
+                    items=items,
+                    proxy_url=self.get_proxy(),
+                )
+                if not ok:
+                    log.error(f'合并推送失败: {cid} {msg}')
+                    err_msg += f'{cid} {msg}\n'
+                    continue
+
+                any_ok = True
+                log.info(f'合并推送成功: {cid}')
+
+            if not any_push:
+                return False, '没有可用的推送渠道'
+        else:
+            channel = self._id_2_channels.get(channel_id)
+            if channel is None:
+                return False, f'推送渠道不存在: {channel_id}'
+            channel_config = self.get_channel_config(channel_id)
+            ok, msg = channel.validate_config(channel_config)
+            if not ok:
+                return False, msg
+            any_ok, err_msg = channel.push_merged(
+                config=channel_config,
+                title=title,
+                items=items,
+                proxy_url=self.get_proxy(),
+            )
+
+        return any_ok, err_msg
+
+    def push_merged_async(
+        self,
+        title: str,
+        items: list[NotifyPoolItem],
+        channel_id: str | None = None,
+    ) -> None:
+        """
+        异步推送合并消息
+
+        Args:
+            title: 标题
+            items: 消息列表
+            channel_id: 推送渠道ID 未传入时使用所有能通过配置校验的渠道
+        """
+        future = self._executor.submit(
+            self.push_merged,
+            title,
+            items,
             channel_id,
         )
         future.add_done_callback(thread_utils.handle_future_result)

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -240,7 +240,7 @@ class OneDragonRunInterface(SplitAppRunInterface):
         """
         显示通知设置对话框。配置更新由对话框内部处理。
         """
-        dialog = NotifyDialog(self, self.ctx)
+        dialog = NotifyDialog(self.ctx, self.window())
         dialog.exec()
 
     def on_app_setting_clicked(self, app_id: str) -> None:

--- a/src/one_dragon_qt/widgets/notify_dialog.py
+++ b/src/one_dragon_qt/widgets/notify_dialog.py
@@ -1,8 +1,8 @@
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QGridLayout, QWidget
 from qfluentwidgets import (
     BodyLabel,
-    CheckBox,
+    CaptionLabel,
+    ComboBox,
     MessageBoxBase,
     SubtitleLabel,
     SwitchButton,
@@ -16,7 +16,7 @@ from one_dragon.utils.i18_utils import gt
 class NotifyDialog(MessageBoxBase):
     """通知配置对话框"""
 
-    def __init__(self, parent=None, ctx=OneDragonContext):
+    def __init__(self, ctx: OneDragonContext, parent=None):
         super().__init__(parent)
         self.ctx: OneDragonContext = ctx
 
@@ -34,53 +34,57 @@ class NotifyDialog(MessageBoxBase):
         self.before_notify_switch.label.setText(gt('开始前通知'))
         self.viewLayout.addWidget(self.before_notify_switch)
 
-        self.viewLayout.addWidget(BodyLabel(gt('未选 = 关闭；半选 = 应用级通知；全选 = 应用+节点级通知')))
+        # 存储所有应用的 ComboBox
+        self.app_combos: dict[str, ComboBox] = {}
 
-        # 存储所有应用的复选框
-        self.app_checkboxes = {}
-
-        # 使用网格布局放置复选框
-        checkbox_container = QWidget()
-        grid_layout = QGridLayout(checkbox_container)
+        # 网格布局: [label0][combo0][spacer][label1][combo1]
+        #  列号:      0       1       2       3       4
+        combo_container = QWidget()
+        grid_layout = QGridLayout(combo_container)
         grid_layout.setContentsMargins(0, 10, 0, 10)
         grid_layout.setSpacing(10)
+        # label 列紧贴文字，combo 列均匀填充，spacer 列固定间距
+        grid_layout.setColumnStretch(0, 0)
+        grid_layout.setColumnStretch(1, 1)
+        grid_layout.setColumnMinimumWidth(2, 20)
+        grid_layout.setColumnStretch(2, 0)
+        grid_layout.setColumnStretch(3, 0)
+        grid_layout.setColumnStretch(4, 1)
 
-        # 每行放置3个复选框
-        column_count = 3
-        # 使用 enumerate 和 items() 遍历字典获取索引、键和值
+        column_group_count = 2
         for i, (app_id, app_name) in enumerate(self.ctx.notify_config.app_map.items()):
-            row = i // column_count
-            col = i % column_count
+            row = i // column_group_count
+            group = i % column_group_count
+            col = group * 3  # 第一组: 0,1  第二组: 3,4
 
-            # 使用 app_name 作为 CheckBox 的文本
-            checkbox = CheckBox(gt(app_name), self)
-            checkbox.setTristate(True)
+            label = BodyLabel(gt(app_name), self)
+            combo = ComboBox(self)
+            combo.addItem(gt('关闭'), userData=NotifyLevel.OFF)
+            combo.addItem(gt('仅应用'), userData=NotifyLevel.APP)
+            combo.addItem(gt('全部（逐条）'), userData=NotifyLevel.ALL)
+            combo.addItem(gt('全部（合并）'), userData=NotifyLevel.MERGE)
 
             level = self.ctx.notify_config.get_app_notify_level(app_id)
-            if level == NotifyLevel.OFF:
-                checkbox.setCheckState(Qt.CheckState.Unchecked)
-            elif level == NotifyLevel.APP:
-                checkbox.setCheckState(Qt.CheckState.PartiallyChecked)
-            else:
-                checkbox.setCheckState(Qt.CheckState.Checked)
+            # 根据 userData 匹配当前等级
+            for j in range(combo.count()):
+                if combo.itemData(j) == level:
+                    combo.setCurrentIndex(j)
+                    break
 
-            # 保存复选框引用，使用 app_id 作为键
-            self.app_checkboxes[app_id] = checkbox
+            self.app_combos[app_id] = combo
+            grid_layout.addWidget(label, row, col)
+            grid_layout.addWidget(combo, row, col + 1)
 
-            grid_layout.addWidget(checkbox, row, col)
+        self.viewLayout.addWidget(combo_container)
 
-        self.viewLayout.addWidget(checkbox_container)
+        hint = CaptionLabel(gt('逐条 = 每个节点单独推送；合并 = 所有节点合并推送'), self)
+        hint.setWordWrap(True)
+        self.viewLayout.addWidget(hint)
 
     def accept(self):
         """点击确定时，更新配置"""
         self.ctx.notify_config.enable_before_notify = self.before_notify_switch.isChecked()
-        for app_id, checkbox in self.app_checkboxes.items():
-            state = checkbox.checkState()
-            if state == Qt.CheckState.Unchecked:
-                level = NotifyLevel.OFF
-            elif state == Qt.CheckState.PartiallyChecked:
-                level = NotifyLevel.APP
-            else:
-                level = NotifyLevel.ALL
+        for app_id, combo in self.app_combos.items():
+            level = combo.currentData()
             setattr(self.ctx.notify_config, app_id, level)
         super().accept()


### PR DESCRIPTION
 - 应用级合并消息后统一发送
 - 节点失败时直接发送失败消息
 - 恢复应用级通知的最后一张图片
 - 通知基类默认实现：字符串拼接消息，并附带最后一张图片。子类可重写合并通知方法
 - OneBot使用合并转发消息
 - SMTP使用分割符

closes: #1740
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“合并(MERGE)”通知级别，支持将多条通知合并为一次转发或邮件发送
  * 新增通知池用于累积通知内容与可选截图，并限制保留截图数量
  * 为推送渠道（OneBot、SMTP 等）及推送服务新增合并发送接口（同步/异步）

* **重构**
  * 优化通知发送流程：按通知级别决定即时推送或收集合并推送，启动与结束时会重置通知池

* **界面**
  * 通知设置界面改为下拉选择四档级别（关闭/仅应用/全部/合并）；修正通知对话框的父窗口/上下文传参顺序
<!-- end of auto-generated comment: release notes by coderabbit.ai -->