### PR TITLE
feat(screen): 添加 Screen Scope 机制，支持全局/局部/插件 screen 分层管理

### DIFF
--- a/assets/game_data/screen_info/3d_map.yml
+++ b/assets/game_data/screen_info/3d_map.yml
@@ -1,5 +1,6 @@
 screen_id: 3d_map
 screen_name: 3D地图
+app_id: world_patrol
 pc_alt: false
 area_list:
 - area_name: 按钮-快捷导航

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1,5 +1,6 @@
 - screen_id: 3d_map
   screen_name: 3D地图
+  app_id: world_patrol
   pc_alt: false
   area_list:
   - area_name: 按钮-快捷导航
@@ -824,6 +825,7 @@
     goto_list: []
 - screen_id: city_fund
   screen_name: 丽都城募
+  app_id: city_fund
   pc_alt: false
   area_list:
   - area_name: 成长任务
@@ -912,6 +914,7 @@
     goto_list: []
 - screen_id: coffee_shop
   screen_name: 咖啡店
+  app_id: coffee
   pc_alt: false
   area_list:
   - area_name: 点单
@@ -1284,6 +1287,7 @@
     goto_list: []
 - screen_id: commission_assistant
   screen_name: 委托助手
+  app_id: commission_assistant
   pc_alt: false
   area_list:
   - area_name: 对话框标题
@@ -2355,6 +2359,7 @@
     goto_list: []
 - screen_id: drive_disc_dismantle
   screen_name: 仓库-驱动仓库-驱动盘拆解
+  app_id: drive_disc_dismantle
   pc_alt: false
   area_list:
   - area_name: 标题-驱动盘拆解
@@ -2485,6 +2490,7 @@
     goto_list: []
 - screen_id: email
   screen_name: 邮件
+  app_id: email
   pc_alt: false
   area_list:
   - area_name: 全部领取
@@ -3128,6 +3134,7 @@
     goto_list: []
 - screen_id: fishing
   screen_name: 钓鱼
+  app_id: commission_assistant
   pc_alt: false
   area_list:
   - area_name: 指令文本区域
@@ -3402,6 +3409,7 @@
     goto_list: []
 - screen_id: hollow_zero_battle
   screen_name: 零号空洞-战斗
+  app_id: withered_domain
   pc_alt: false
   area_list:
   - area_name: 鸣徽-确定
@@ -3504,6 +3512,7 @@
     goto_list: []
 - screen_id: hollow_zero_entry
   screen_name: 零号空洞-入口
+  app_id: withered_domain
   pc_alt: false
   area_list:
   - area_name: 街区
@@ -3634,6 +3643,7 @@
     goto_list: []
 - screen_id: hollow_zero_event
   screen_name: 零号空洞-事件
+  app_id: withered_domain
   pc_alt: false
   area_list:
   - area_name: 事件文本
@@ -4002,6 +4012,7 @@
     goto_list: []
 - screen_id: hollow_zero_merchant
   screen_name: 零号空洞-商店
+  app_id: withered_domain
   pc_alt: false
   area_list:
   - area_name: 右上角-返回
@@ -4160,6 +4171,7 @@
     goto_list: []
 - screen_id: intel_board
   screen_name: 情报板
+  app_id: intel_board
   pc_alt: false
   area_list:
   - area_name: 点数兑换
@@ -4262,6 +4274,7 @@
     goto_list: []
 - screen_id: inter_knot
   screen_name: 绳网
+  app_id: world_patrol
   pc_alt: false
   area_list:
   - area_name: 按钮-GO
@@ -4322,6 +4335,7 @@
     goto_list: []
 - screen_id: life_on_line
   screen_name: 真拿命验收
+  app_id: life_on_line
   pc_alt: false
   area_list:
   - area_name: 第二章间章
@@ -4382,6 +4396,7 @@
     goto_list: []
 - screen_id: lostvoid_indexpanel
   screen_name: 迷失之地-藏品面板
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 返回按钮
@@ -4470,6 +4485,7 @@
     goto_list: []
 - screen_id: lostvoid_investigativeStrategy
   screen_name: 迷失之地-调查战略选择
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 战略等级
@@ -4488,6 +4504,7 @@
     goto_list: []
 - screen_id: lost_void_bangboo_store
   screen_name: 迷失之地-邦布商店
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 文本-详情
@@ -4666,6 +4683,7 @@
     goto_list: []
 - screen_id: lost_void_battle_fail
   screen_name: 迷失之地-战斗失败
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-撤退
@@ -4712,6 +4730,7 @@
     goto_list: []
 - screen_id: lost_void_battle_result
   screen_name: 迷失之地-挑战结果
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 标题-挑战结果
@@ -4786,6 +4805,7 @@
     goto_list: []
 - screen_id: lost_void_choose_common
   screen_name: 迷失之地-通用选择
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 文本-详情
@@ -4937,6 +4957,7 @@
     goto_list: []
 - screen_id: lost_void_entry
   screen_name: 迷失之地-入口
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-更新弹窗-关闭
@@ -5109,6 +5130,7 @@
     goto_list: []
 - screen_id: lost_void_entry_task_force
   screen_name: 迷失之地-特遣调查
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-街区
@@ -5199,6 +5221,7 @@
     goto_list: []
 - screen_id: lost_void_gear
   screen_name: 迷失之地-武备选择
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-携带
@@ -5287,6 +5310,7 @@
     goto_list: []
 - screen_id: lost_void_lottery
   screen_name: 迷失之地-抽奖机
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-返回
@@ -5361,6 +5385,7 @@
     goto_list: []
 - screen_id: lost_void_normal_world
   screen_name: 迷失之地-大世界
+  app_id: lost_void
   pc_alt: true
   area_list:
   - area_name: 区域-文本提示
@@ -5535,6 +5560,7 @@
     goto_list: []
 - screen_id: lost_void_purge
   screen_name: 迷失之地-战线肃清
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 标题-战线肃清
@@ -5652,6 +5678,7 @@
     goto_list: []
 - screen_id: lost_void_route_change
   screen_name: 迷失之地-路径迭换
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 按钮-返回
@@ -5730,6 +5757,7 @@
     goto_list: []
 - screen_id: matrix_action
   screen_name: 迷失之地-矩阵行动
+  app_id: lost_void
   pc_alt: false
   area_list:
   - area_name: 预备编队
@@ -6140,6 +6168,7 @@
     goto_list: []
 - screen_id: news_stand
   screen_name: 报刊亭
+  app_id: scratch_card
   pc_alt: false
   area_list:
   - area_name: 刮刮卡
@@ -7024,6 +7053,7 @@
     goto_list: []
 - screen_id: random_play
   screen_name: 影像店营业
+  app_id: random_play
   pc_alt: false
   area_list:
   - area_name: 昨日账本
@@ -7494,6 +7524,7 @@
     goto_list: []
 - screen_id: ridu_weekly
   screen_name: 丽都周纪
+  app_id: ridu_weekly
   pc_alt: false
   area_list:
   - area_name: 丽都周纪
@@ -7638,6 +7669,7 @@
     goto_list: []
 - screen_id: shiyu_defense
   screen_name: 式舆防卫战
+  app_id: shiyu_defense
   pc_alt: false
   area_list:
   - area_name: 节点区域
@@ -8048,6 +8080,7 @@
     goto_list: []
 - screen_id: shiyu_defense_new
   screen_name: 新式舆防卫战
+  app_id: shiyu_defense
   pc_alt: false
   area_list:
   - area_name: 节点区域
@@ -8332,6 +8365,7 @@
     goto_list: []
 - screen_id: storage_drive_disc
   screen_name: 仓库-驱动仓库
+  app_id: drive_disc_dismantle
   pc_alt: false
   area_list:
   - area_name: 标题-驱动仓库
@@ -8380,6 +8414,7 @@
     - 大世界-普通
 - screen_id: storage_wengine
   screen_name: 仓库-音擎仓库
+  app_id: drive_disc_dismantle
   pc_alt: false
   area_list:
   - area_name: 标题-音擎仓库
@@ -8442,6 +8477,7 @@
     - 仓库-驱动仓库
 - screen_id: suibian_temple_adventure
   screen_name: 随便观-游历
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 按钮-游历小队
@@ -8586,6 +8622,7 @@
     goto_list: []
 - screen_id: suibian_temple_boobox
   screen_name: 随便观-邦巢
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 按钮-跳过
@@ -8730,6 +8767,7 @@
     goto_list: []
 - screen_id: suibian_temple_craft
   screen_name: 随便观-制造坊
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 标题-制造坊
@@ -8931,6 +8969,7 @@
     goto_list: []
 - screen_id: suibian_temple_entry
   screen_name: 随便观-入口
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 按钮-邻里街坊
@@ -9047,6 +9086,7 @@
     goto_list: []
 - screen_id: suibian_temple_pawnshop
   screen_name: 随便观-德丰大押
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 按钮-返回
@@ -9178,6 +9218,7 @@
     goto_list: []
 - screen_id: suibian_temple_sales_stall
   screen_name: 随便观-售卖铺
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 标题-售卖铺
@@ -9281,6 +9322,7 @@
     goto_list: []
 - screen_id: suibian_temple_yumchaxian
   screen_name: 随便观-饮茶仙
+  app_id: suibian_temple
   pc_alt: false
   area_list:
   - area_name: 按钮-定期采办
@@ -9481,6 +9523,7 @@
     goto_list: []
 - screen_id: trigrams_collection
   screen_name: 卦象集录
+  app_id: trigrams_collection
   pc_alt: false
   area_list:
   - area_name: 区域-获取卦象

--- a/assets/game_data/screen_info/city_fund.yml
+++ b/assets/game_data/screen_info/city_fund.yml
@@ -1,5 +1,6 @@
 screen_id: city_fund
 screen_name: 丽都城募
+app_id: city_fund
 pc_alt: false
 area_list:
 - area_name: 成长任务

--- a/assets/game_data/screen_info/coffee_shop.yml
+++ b/assets/game_data/screen_info/coffee_shop.yml
@@ -1,5 +1,6 @@
 screen_id: coffee_shop
 screen_name: 咖啡店
+app_id: coffee
 pc_alt: false
 area_list:
 - area_name: 点单

--- a/assets/game_data/screen_info/commission_assistant.yml
+++ b/assets/game_data/screen_info/commission_assistant.yml
@@ -1,5 +1,6 @@
 screen_id: commission_assistant
 screen_name: 委托助手
+app_id: commission_assistant
 pc_alt: false
 area_list:
 - area_name: 对话框标题

--- a/assets/game_data/screen_info/drive_disc_dismantle.yml
+++ b/assets/game_data/screen_info/drive_disc_dismantle.yml
@@ -1,5 +1,6 @@
 screen_id: drive_disc_dismantle
 screen_name: 仓库-驱动仓库-驱动盘拆解
+app_id: drive_disc_dismantle
 pc_alt: false
 area_list:
 - area_name: 标题-驱动盘拆解

--- a/assets/game_data/screen_info/email.yml
+++ b/assets/game_data/screen_info/email.yml
@@ -1,5 +1,6 @@
 screen_id: email
 screen_name: 邮件
+app_id: email
 pc_alt: false
 area_list:
 - area_name: 全部领取

--- a/assets/game_data/screen_info/fishing.yml
+++ b/assets/game_data/screen_info/fishing.yml
@@ -1,5 +1,6 @@
 screen_id: fishing
 screen_name: 钓鱼
+app_id: commission_assistant
 pc_alt: false
 area_list:
 - area_name: 指令文本区域

--- a/assets/game_data/screen_info/hollow_zero_battle.yml
+++ b/assets/game_data/screen_info/hollow_zero_battle.yml
@@ -1,5 +1,6 @@
 screen_id: hollow_zero_battle
 screen_name: 零号空洞-战斗
+app_id: withered_domain
 pc_alt: false
 area_list:
 - area_name: 鸣徽-确定

--- a/assets/game_data/screen_info/hollow_zero_entry.yml
+++ b/assets/game_data/screen_info/hollow_zero_entry.yml
@@ -1,5 +1,6 @@
 screen_id: hollow_zero_entry
 screen_name: 零号空洞-入口
+app_id: withered_domain
 pc_alt: false
 area_list:
 - area_name: 街区

--- a/assets/game_data/screen_info/hollow_zero_event.yml
+++ b/assets/game_data/screen_info/hollow_zero_event.yml
@@ -1,5 +1,6 @@
 screen_id: hollow_zero_event
 screen_name: 零号空洞-事件
+app_id: withered_domain
 pc_alt: false
 area_list:
 - area_name: 事件文本

--- a/assets/game_data/screen_info/hollow_zero_merchant.yml
+++ b/assets/game_data/screen_info/hollow_zero_merchant.yml
@@ -1,5 +1,6 @@
 screen_id: hollow_zero_merchant
 screen_name: 零号空洞-商店
+app_id: withered_domain
 pc_alt: false
 area_list:
 - area_name: 右上角-返回

--- a/assets/game_data/screen_info/intel_board.yml
+++ b/assets/game_data/screen_info/intel_board.yml
@@ -1,5 +1,6 @@
 screen_id: intel_board
 screen_name: 情报板
+app_id: intel_board
 pc_alt: false
 area_list:
 - area_name: 点数兑换

--- a/assets/game_data/screen_info/inter_knot.yml
+++ b/assets/game_data/screen_info/inter_knot.yml
@@ -1,5 +1,6 @@
 screen_id: inter_knot
 screen_name: 绳网
+app_id: world_patrol
 pc_alt: false
 area_list:
 - area_name: 按钮-GO

--- a/assets/game_data/screen_info/life_on_line.yml
+++ b/assets/game_data/screen_info/life_on_line.yml
@@ -1,5 +1,6 @@
 screen_id: life_on_line
 screen_name: 真拿命验收
+app_id: life_on_line
 pc_alt: false
 area_list:
 - area_name: 第二章间章

--- a/assets/game_data/screen_info/lost_void_bangboo_store.yml
+++ b/assets/game_data/screen_info/lost_void_bangboo_store.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_bangboo_store
 screen_name: 迷失之地-邦布商店
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 文本-详情

--- a/assets/game_data/screen_info/lost_void_battle_fail.yml
+++ b/assets/game_data/screen_info/lost_void_battle_fail.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_battle_fail
 screen_name: 迷失之地-战斗失败
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-撤退

--- a/assets/game_data/screen_info/lost_void_battle_result.yml
+++ b/assets/game_data/screen_info/lost_void_battle_result.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_battle_result
 screen_name: 迷失之地-挑战结果
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 标题-挑战结果

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_choose_common
 screen_name: 迷失之地-通用选择
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 文本-详情

--- a/assets/game_data/screen_info/lost_void_entry.yml
+++ b/assets/game_data/screen_info/lost_void_entry.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_entry
 screen_name: 迷失之地-入口
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-更新弹窗-关闭

--- a/assets/game_data/screen_info/lost_void_entry_task_force.yml
+++ b/assets/game_data/screen_info/lost_void_entry_task_force.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_entry_task_force
 screen_name: 迷失之地-特遣调查
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-街区

--- a/assets/game_data/screen_info/lost_void_gear.yml
+++ b/assets/game_data/screen_info/lost_void_gear.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_gear
 screen_name: 迷失之地-武备选择
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-携带

--- a/assets/game_data/screen_info/lost_void_lottery.yml
+++ b/assets/game_data/screen_info/lost_void_lottery.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_lottery
 screen_name: 迷失之地-抽奖机
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-返回

--- a/assets/game_data/screen_info/lost_void_normal_world.yml
+++ b/assets/game_data/screen_info/lost_void_normal_world.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_normal_world
 screen_name: 迷失之地-大世界
+app_id: lost_void
 pc_alt: true
 area_list:
 - area_name: 区域-文本提示

--- a/assets/game_data/screen_info/lost_void_purge.yml
+++ b/assets/game_data/screen_info/lost_void_purge.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_purge
 screen_name: 迷失之地-战线肃清
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 标题-战线肃清

--- a/assets/game_data/screen_info/lost_void_route_change.yml
+++ b/assets/game_data/screen_info/lost_void_route_change.yml
@@ -1,5 +1,6 @@
 screen_id: lost_void_route_change
 screen_name: 迷失之地-路径迭换
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 按钮-返回

--- a/assets/game_data/screen_info/lostvoid_indexpanel.yml
+++ b/assets/game_data/screen_info/lostvoid_indexpanel.yml
@@ -1,5 +1,6 @@
 screen_id: lostvoid_indexpanel
 screen_name: 迷失之地-藏品面板
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 返回按钮

--- a/assets/game_data/screen_info/lostvoid_investigativeStrategy.yml
+++ b/assets/game_data/screen_info/lostvoid_investigativeStrategy.yml
@@ -1,5 +1,6 @@
 screen_id: lostvoid_investigativeStrategy
 screen_name: 迷失之地-调查战略选择
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 战略等级

--- a/assets/game_data/screen_info/matrix_action.yml
+++ b/assets/game_data/screen_info/matrix_action.yml
@@ -1,5 +1,6 @@
 screen_id: matrix_action
 screen_name: 迷失之地-矩阵行动
+app_id: lost_void
 pc_alt: false
 area_list:
 - area_name: 预备编队

--- a/assets/game_data/screen_info/news_stand.yml
+++ b/assets/game_data/screen_info/news_stand.yml
@@ -1,5 +1,6 @@
 screen_id: news_stand
 screen_name: 报刊亭
+app_id: scratch_card
 pc_alt: false
 area_list:
 - area_name: 刮刮卡

--- a/assets/game_data/screen_info/random_play.yml
+++ b/assets/game_data/screen_info/random_play.yml
@@ -1,5 +1,6 @@
 screen_id: random_play
 screen_name: 影像店营业
+app_id: random_play
 pc_alt: false
 area_list:
 - area_name: 昨日账本

--- a/assets/game_data/screen_info/ridu_weekly.yml
+++ b/assets/game_data/screen_info/ridu_weekly.yml
@@ -1,5 +1,6 @@
 screen_id: ridu_weekly
 screen_name: 丽都周纪
+app_id: ridu_weekly
 pc_alt: false
 area_list:
 - area_name: 丽都周纪

--- a/assets/game_data/screen_info/shiyu_defense.yml
+++ b/assets/game_data/screen_info/shiyu_defense.yml
@@ -1,5 +1,6 @@
 screen_id: shiyu_defense
 screen_name: 式舆防卫战
+app_id: shiyu_defense
 pc_alt: false
 area_list:
 - area_name: 节点区域

--- a/assets/game_data/screen_info/shiyu_defense_new.yml
+++ b/assets/game_data/screen_info/shiyu_defense_new.yml
@@ -1,5 +1,6 @@
 screen_id: shiyu_defense_new
 screen_name: 新式舆防卫战
+app_id: shiyu_defense
 pc_alt: false
 area_list:
 - area_name: 节点区域

--- a/assets/game_data/screen_info/storage_drive_disc.yml
+++ b/assets/game_data/screen_info/storage_drive_disc.yml
@@ -1,5 +1,6 @@
 screen_id: storage_drive_disc
 screen_name: 仓库-驱动仓库
+app_id: drive_disc_dismantle
 pc_alt: false
 area_list:
 - area_name: 标题-驱动仓库

--- a/assets/game_data/screen_info/storage_wengine.yml
+++ b/assets/game_data/screen_info/storage_wengine.yml
@@ -1,5 +1,6 @@
 screen_id: storage_wengine
 screen_name: 仓库-音擎仓库
+app_id: drive_disc_dismantle
 pc_alt: false
 area_list:
 - area_name: 标题-音擎仓库

--- a/assets/game_data/screen_info/suibian_temple_adventure.yml
+++ b/assets/game_data/screen_info/suibian_temple_adventure.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_adventure
 screen_name: 随便观-游历
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 按钮-游历小队

--- a/assets/game_data/screen_info/suibian_temple_boobox.yml
+++ b/assets/game_data/screen_info/suibian_temple_boobox.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_boobox
 screen_name: 随便观-邦巢
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 按钮-跳过

--- a/assets/game_data/screen_info/suibian_temple_craft.yml
+++ b/assets/game_data/screen_info/suibian_temple_craft.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_craft
 screen_name: 随便观-制造坊
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 标题-制造坊

--- a/assets/game_data/screen_info/suibian_temple_entry.yml
+++ b/assets/game_data/screen_info/suibian_temple_entry.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_entry
 screen_name: 随便观-入口
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 按钮-邻里街坊

--- a/assets/game_data/screen_info/suibian_temple_pawnshop.yml
+++ b/assets/game_data/screen_info/suibian_temple_pawnshop.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_pawnshop
 screen_name: 随便观-德丰大押
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 按钮-返回

--- a/assets/game_data/screen_info/suibian_temple_sales_stall.yml
+++ b/assets/game_data/screen_info/suibian_temple_sales_stall.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_sales_stall
 screen_name: 随便观-售卖铺
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 标题-售卖铺

--- a/assets/game_data/screen_info/suibian_temple_yumchaxian.yml
+++ b/assets/game_data/screen_info/suibian_temple_yumchaxian.yml
@@ -1,5 +1,6 @@
 screen_id: suibian_temple_yumchaxian
 screen_name: 随便观-饮茶仙
+app_id: suibian_temple
 pc_alt: false
 area_list:
 - area_name: 按钮-定期采办

--- a/assets/game_data/screen_info/trigrams_collection.yml
+++ b/assets/game_data/screen_info/trigrams_collection.yml
@@ -1,5 +1,6 @@
 screen_id: trigrams_collection
 screen_name: 卦象集录
+app_id: trigrams_collection
 pc_alt: false
 area_list:
 - area_name: 区域-获取卦象

--- a/docs/develop/screen_scope_design.md
+++ b/docs/develop/screen_scope_design.md
@@ -1,0 +1,190 @@
+# Screen Scope 设计方案
+
+## 1. 背景与问题
+
+### 现状
+- 所有 70 个 screen 注册在全局 `ScreenContext` 中
+- 应用通过硬编码字符串引用 screen（如 `'迷失之地-入口'`）
+- `round_by_goto_screen` 调用 `get_match_screen_name` 时，BFS 遍历可能扫描全部 70 个 screen
+- 每次 screen 匹配涉及 OCR 或模板匹配，开销大
+
+### 三个核心问题
+
+| 问题 | 原因 | 影响 |
+|------|------|------|
+| 插件无法管理 screen | screen 只从 `assets/game_data/screen_info/` 加载，无注入点 | 第三方插件无法定义画面 |
+| 全局污染 | 所有 screen 同一命名空间，BFS 搜索和路由计算混杂不相关 screen | 识别变慢 |
+| 全局跳转慢 | `round_by_goto_screen` 无范围限制，BFS 可能检查大量无关 screen | 每轮匹配耗时高 |
+
+## 2. 设计方案
+
+### 核心概念：全局 screen 与局部 screen
+
+```
+┌─────────────────────────────────────────────┐
+│              ScreenContext                   │
+│                                              │
+│  ┌────────────────────┐  ┌───────────────┐  │
+│  │   全局 screen       │  │  局部 screen   │  │
+│  │   (app_id 为空)     │  │  (app_id 非空) │  │
+│  │                    │  │               │  │
+│  │  菜单              │  │  迷失之地-入口  │  │
+│  │  大世界-普通        │  │  迷失之地-大世界│  │
+│  │  快捷手册-训练      │  │  零号空洞-入口  │  │
+│  │  快捷手册-作战      │  │  随便观-入口    │  │
+│  │  ...               │  │  ...           │  │
+│  └────────────────────┘  └───────────────┘  │
+│                                              │
+│  活跃范围 = 全局 ∪ 当前应用的局部              │
+└─────────────────────────────────────────────┘
+```
+
+- **全局 screen**：YAML 中 `app_id` 为空。始终参与匹配，如菜单、大世界、快捷手册等导航骨架
+- **局部 screen**：YAML 中 `app_id` 非空。仅在对应应用运行时参与匹配
+
+### 自动推导机制
+
+1. **`reload()`** 后自动计算全局集合：`_global_screen_names = {无 app_id 的 screen}`
+2. **应用启动** 时 `enter_scope(app_id)`，自动收集 `app_id` 匹配的局部 screen
+3. **应用停止** 时 `exit_scope()`，恢复全量匹配
+
+无需代码中手动维护字符串列表。
+
+## 3. 数据模型变更
+
+### ScreenInfo 新增 `app_id` 字段
+
+```yaml
+# 全局 screen（不设 app_id 或为空）
+- screen_id: menu
+  screen_name: 菜单
+  pc_alt: false
+  area_list: ...
+
+# 局部 screen（设置 app_id）
+- screen_id: lost_void_entry
+  screen_name: 迷失之地-入口
+  app_id: lost_void            # ← 与 Application.app_id 一致
+  pc_alt: false
+  area_list: ...
+```
+
+`app_id` 默认为空字符串，完全向后兼容。
+
+## 4. API 设计
+
+### ScreenContext
+
+```python
+class ScreenContext:
+    # ---- Screen Scope 管理 ----
+
+    def enter_scope(self, app_id: str) -> None:
+        """进入应用 scope
+        活跃范围 = 全局 screen + 该 app_id 的局部 screen
+        仅当存在匹配的局部 screen 时才启用 scope
+        """
+
+    def exit_scope(self) -> None:
+        """退出应用 scope，恢复全量匹配"""
+
+    @property
+    def active_screen_names(self) -> set[str] | None:
+        """当前活跃的 screen 名称集合。None 表示全部活跃"""
+
+    @property
+    def active_screen_info_list(self) -> list[ScreenInfo]:
+        """当前活跃的 ScreenInfo 列表"""
+
+    def is_screen_active(self, screen_name: str) -> bool:
+        """判断某个 screen 是否在活跃范围内"""
+```
+
+### Application 生命周期集成
+
+```python
+class Application(Operation):
+    def handle_init(self):
+        # 自动进入 scope（基于 self.app_id）
+        self.ctx.screen_loader.enter_scope(self.app_id)
+        ...
+
+    def after_operation_done(self, result):
+        # 自动退出 scope
+        self.ctx.screen_loader.exit_scope()
+        ...
+```
+
+应用无需额外代码，scope 通过 `app_id` + YAML `app_id` 字段自动匹配。
+
+## 5. 匹配优化
+
+### BFS 搜索优化
+
+`get_match_screen_name_from_last` 中：
+- 非活跃 screen **跳过匹配**（避免 OCR/模板匹配开销）
+- 非活跃 screen **仍展开邻居**（保持图连通性，确保能找到活跃 screen）
+- fallback 遍历仅搜索活跃 screen
+
+### 效果估算
+
+| 场景 | 改动前 | 改动后 |
+|------|--------|--------|
+| 迷失之地运行时 BFS 匹配范围 | ~70 screen | ~30 screen（全局 ~16 + 局部 ~14） |
+| 每轮 OCR/模板匹配次数（最坏） | ~70 次 | ~30 次 |
+| Floyd 路由计算 | O(70³) ≈ 34万次 | 不变（全局路由表共用） |
+
+### 路由不变
+
+全局路由表（Floyd）仅在 `reload()` 时计算一次，scope 不影响。
+`round_by_goto_screen` 使用全局路由表查找路径，scope 仅影响 screen 识别的搜索范围。
+
+## 6. 向后兼容性
+
+| 场景 | 行为 |
+|------|------|
+| 所有 YAML 未设 `app_id`（当前现状） | 全部为全局 → `enter_scope` 无匹配 → 不启用 scope → 行为不变 |
+| 部分 YAML 设了 `app_id` | 该应用启用 scope，其他应用不受影响 |
+| 应用本身无匹配 screen | `enter_scope` 跳过 → 行为不变 |
+
+**零风险渐进迁移**：全部不改 YAML 时与现在一模一样，改一个应用的 YAML 只影响该应用。
+
+## 7. 迁移指南
+
+### 步骤 1：给局部 screen 的 YAML 添加 `app_id`
+
+以迷失之地为例，给 14 个 screen 各加一行：
+
+```yaml
+- screen_id: lost_void_entry
+  screen_name: 迷失之地-入口
+  app_id: lost_void              # ← 新增
+  pc_alt: false
+  area_list: ...
+```
+
+### 步骤 2：完成
+
+无需修改任何 Python 代码。`Application.handle_init` 自动调用 `enter_scope(self.app_id)`，
+匹配到 YAML 中 `app_id: lost_void` 的 screen，scope 自动生效。
+
+### 建议迁移顺序
+
+1. 迷失之地（14 screen，收益最大）
+2. 随便观（7 screen）
+3. 零号空洞（4 screen）
+4. 仓库系统（3 screen）
+
+## 8. 插件支持
+
+第三方插件在自己的 `screen_info/` 目录中定义 YAML screen，设置 `app_id` 为自己的应用 ID。
+插件的 screen 加载到 `ScreenContext` 后，通过 `app_id` 自动归入局部命名空间，不污染其他应用。
+
+## 9. 文件变更清单
+
+| 文件 | 变更 |
+|------|------|
+| `src/one_dragon/base/screen/screen_info.py` | `ScreenInfo` 新增 `app_id` 字段 |
+| `src/one_dragon/base/screen/screen_loader.py` | `ScreenContext` 新增 scope 管理 API |
+| `src/one_dragon/base/screen/screen_utils.py` | BFS 匹配适配活跃范围 |
+| `src/one_dragon/base/operation/application_base.py` | `Application` 生命周期自动 enter/exit scope |

--- a/docs/develop/screen_scope_design.md
+++ b/docs/develop/screen_scope_design.md
@@ -175,9 +175,61 @@ class Application(Operation):
 3. 零号空洞（4 screen）
 4. 仓库系统（3 screen）
 
-## 8. 插件支持
+## 8. 插件 Screen 加载
 
-第三方插件在自己的 `screen_info/` 目录中定义 YAML screen，设置 `app_id` 为自己的应用 ID。
+### 加载机制
+
+插件的 screen 通过 `OneDragonContext._load_plugin_screens()` 自动加载：
+
+```
+OneDragonContext.init()
+├── register_application_factory()    ← 扫描插件，填充 plugin_infos
+├── screen_loader.reload()            ← 加载主 screen YAML
+└── _load_plugin_screens()            ← 遍历 plugin_infos → load_extra_screen_dir()
+    └── 对每个插件的 screen_info/ 目录加载 YAML
+        └── 未设 app_id 的 screen 自动使用插件的 app_id
+
+refresh_application_registration()    ← 运行时刷新插件
+├── clear_applications + discover_factories    ← 重新扫描
+├── screen_loader.reload()            ← 重新加载主 YAML
+└── _load_plugin_screens()            ← 重新加载插件 screen
+```
+
+### 插件目录结构
+
+```
+plugins/
+  my_plugin/
+    __init__.py
+    my_plugin_const.py       # APP_ID = 'my_plugin'
+    my_plugin_factory.py
+    my_plugin.py
+    screen_info/             # ← 新增，放 screen YAML
+      my_screen.yml
+```
+
+### 插件 Screen YAML 示例
+
+```yaml
+# plugins/my_plugin/screen_info/my_screen.yml
+screen_id: my_plugin_main
+screen_name: 我的插件-主界面
+# app_id 可省略，自动使用插件的 APP_ID
+pc_alt: false
+area_list:
+  - area_name: 返回按钮
+    id_mark: true
+    pc_rect: [82, 13, 150, 90]
+    template_id: back
+    template_sub_dir: menu
+    goto_list:
+      - 大世界-普通
+```
+
+### 冲突处理
+
+- 插件 screen_name 与主 YAML 或其他插件冲突时，跳过并输出警告日志
+- `default_app_id` 仅在 YAML 未显式设置 `app_id` 时使用
 插件的 screen 加载到 `ScreenContext` 后，通过 `app_id` 自动归入局部命名空间，不污染其他应用。
 
 ## 9. 文件变更清单
@@ -185,6 +237,7 @@ class Application(Operation):
 | 文件 | 变更 |
 |------|------|
 | `src/one_dragon/base/screen/screen_info.py` | `ScreenInfo` 新增 `app_id` 字段 |
-| `src/one_dragon/base/screen/screen_loader.py` | `ScreenContext` 新增 scope 管理 API |
+| `src/one_dragon/base/screen/screen_loader.py` | `ScreenContext` 新增 scope 管理 API 和 `load_extra_screen_dir` |
 | `src/one_dragon/base/screen/screen_utils.py` | BFS 匹配适配活跃范围 |
 | `src/one_dragon/base/operation/application_base.py` | `Application` 生命周期自动 enter/exit scope |
+| `src/one_dragon/base/operation/one_dragon_context.py` | 新增 `_load_plugin_screens()`，init 和 refresh 时加载插件 screen |

--- a/docs/develop/screen_scope_design.md
+++ b/docs/develop/screen_scope_design.md
@@ -1,0 +1,243 @@
+# Screen Scope 设计方案
+
+## 1. 背景与问题
+
+### 现状
+- 所有 70 个 screen 注册在全局 `ScreenContext` 中
+- 应用通过硬编码字符串引用 screen（如 `'迷失之地-入口'`）
+- `round_by_goto_screen` 调用 `get_match_screen_name` 时，BFS 遍历可能扫描全部 70 个 screen
+- 每次 screen 匹配涉及 OCR 或模板匹配，开销大
+
+### 三个核心问题
+
+| 问题 | 原因 | 影响 |
+|------|------|------|
+| 插件无法管理 screen | screen 只从 `assets/game_data/screen_info/` 加载，无注入点 | 第三方插件无法定义画面 |
+| 全局污染 | 所有 screen 同一命名空间，BFS 搜索和路由计算混杂不相关 screen | 识别变慢 |
+| 全局跳转慢 | `round_by_goto_screen` 无范围限制，BFS 可能检查大量无关 screen | 每轮匹配耗时高 |
+
+## 2. 设计方案
+
+### 核心概念：全局 screen 与局部 screen
+
+```
+┌─────────────────────────────────────────────┐
+│              ScreenContext                   │
+│                                              │
+│  ┌────────────────────┐  ┌───────────────┐  │
+│  │   全局 screen       │  │  局部 screen   │  │
+│  │   (app_id 为空)     │  │  (app_id 非空) │  │
+│  │                    │  │               │  │
+│  │  菜单              │  │  迷失之地-入口  │  │
+│  │  大世界-普通        │  │  迷失之地-大世界│  │
+│  │  快捷手册-训练      │  │  零号空洞-入口  │  │
+│  │  快捷手册-作战      │  │  随便观-入口    │  │
+│  │  ...               │  │  ...           │  │
+│  └────────────────────┘  └───────────────┘  │
+│                                              │
+│  活跃范围 = 全局 ∪ 当前应用的局部              │
+└─────────────────────────────────────────────┘
+```
+
+- **全局 screen**：YAML 中 `app_id` 为空。始终参与匹配，如菜单、大世界、快捷手册等导航骨架
+- **局部 screen**：YAML 中 `app_id` 非空。仅在对应应用运行时参与匹配
+
+### 自动推导机制
+
+1. **`reload()`** 后自动计算全局集合：`_global_screen_names = {无 app_id 的 screen}`
+2. **应用启动** 时 `enter_scope(app_id)`，自动收集 `app_id` 匹配的局部 screen
+3. **应用停止** 时 `exit_scope()`，恢复全量匹配
+
+无需代码中手动维护字符串列表。
+
+## 3. 数据模型变更
+
+### ScreenInfo 新增 `app_id` 字段
+
+```yaml
+# 全局 screen（不设 app_id 或为空）
+- screen_id: menu
+  screen_name: 菜单
+  pc_alt: false
+  area_list: ...
+
+# 局部 screen（设置 app_id）
+- screen_id: lost_void_entry
+  screen_name: 迷失之地-入口
+  app_id: lost_void            # ← 与 Application.app_id 一致
+  pc_alt: false
+  area_list: ...
+```
+
+`app_id` 默认为空字符串，完全向后兼容。
+
+## 4. API 设计
+
+### ScreenContext
+
+```python
+class ScreenContext:
+    # ---- Screen Scope 管理 ----
+
+    def enter_scope(self, app_id: str) -> None:
+        """进入应用 scope
+        活跃范围 = 全局 screen + 该 app_id 的局部 screen
+        仅当存在匹配的局部 screen 时才启用 scope
+        """
+
+    def exit_scope(self) -> None:
+        """退出应用 scope，恢复全量匹配"""
+
+    @property
+    def active_screen_names(self) -> set[str] | None:
+        """当前活跃的 screen 名称集合。None 表示全部活跃"""
+
+    @property
+    def active_screen_info_list(self) -> list[ScreenInfo]:
+        """当前活跃的 ScreenInfo 列表"""
+
+    def is_screen_active(self, screen_name: str) -> bool:
+        """判断某个 screen 是否在活跃范围内"""
+```
+
+### Application 生命周期集成
+
+```python
+class Application(Operation):
+    def handle_init(self):
+        # 自动进入 scope（基于 self.app_id）
+        self.ctx.screen_loader.enter_scope(self.app_id)
+        ...
+
+    def after_operation_done(self, result):
+        # 自动退出 scope
+        self.ctx.screen_loader.exit_scope()
+        ...
+```
+
+应用无需额外代码，scope 通过 `app_id` + YAML `app_id` 字段自动匹配。
+
+## 5. 匹配优化
+
+### BFS 搜索优化
+
+`get_match_screen_name_from_last` 中：
+- 非活跃 screen **跳过匹配**（避免 OCR/模板匹配开销）
+- 非活跃 screen **仍展开邻居**（保持图连通性，确保能找到活跃 screen）
+- fallback 遍历仅搜索活跃 screen
+
+### 效果估算
+
+| 场景 | 改动前 | 改动后 |
+|------|--------|--------|
+| 迷失之地运行时 BFS 匹配范围 | ~70 screen | ~30 screen（全局 ~16 + 局部 ~14） |
+| 每轮 OCR/模板匹配次数（最坏） | ~70 次 | ~30 次 |
+| Floyd 路由计算 | O(70³) ≈ 34万次 | 不变（全局路由表共用） |
+
+### 路由不变
+
+全局路由表（Floyd）仅在 `reload()` 时计算一次，scope 不影响。
+`round_by_goto_screen` 使用全局路由表查找路径，scope 仅影响 screen 识别的搜索范围。
+
+## 6. 向后兼容性
+
+| 场景 | 行为 |
+|------|------|
+| 所有 YAML 未设 `app_id`（当前现状） | 全部为全局 → `enter_scope` 无匹配 → 不启用 scope → 行为不变 |
+| 部分 YAML 设了 `app_id` | 该应用启用 scope，其他应用不受影响 |
+| 应用本身无匹配 screen | `enter_scope` 跳过 → 行为不变 |
+
+**零风险渐进迁移**：全部不改 YAML 时与现在一模一样，改一个应用的 YAML 只影响该应用。
+
+## 7. 迁移指南
+
+### 步骤 1：给局部 screen 的 YAML 添加 `app_id`
+
+以迷失之地为例，给 14 个 screen 各加一行：
+
+```yaml
+- screen_id: lost_void_entry
+  screen_name: 迷失之地-入口
+  app_id: lost_void              # ← 新增
+  pc_alt: false
+  area_list: ...
+```
+
+### 步骤 2：完成
+
+无需修改任何 Python 代码。`Application.handle_init` 自动调用 `enter_scope(self.app_id)`，
+匹配到 YAML 中 `app_id: lost_void` 的 screen，scope 自动生效。
+
+### 建议迁移顺序
+
+1. 迷失之地（14 screen，收益最大）
+2. 随便观（7 screen）
+3. 零号空洞（4 screen）
+4. 仓库系统（3 screen）
+
+## 8. 插件 Screen 加载
+
+### 加载机制
+
+插件的 screen 通过 `OneDragonContext._load_plugin_screens()` 自动加载：
+
+```
+OneDragonContext.init()
+├── register_application_factory()    ← 扫描插件，填充 plugin_infos
+├── screen_loader.reload()            ← 加载主 screen YAML
+└── _load_plugin_screens()            ← 遍历 plugin_infos → load_extra_screen_dir()
+    └── 对每个插件的 screen_info/ 目录加载 YAML
+        └── 未设 app_id 的 screen 自动使用插件的 app_id
+
+refresh_application_registration()    ← 运行时刷新插件
+├── clear_applications + discover_factories    ← 重新扫描
+├── screen_loader.reload()            ← 重新加载主 YAML
+└── _load_plugin_screens()            ← 重新加载插件 screen
+```
+
+### 插件目录结构
+
+```
+plugins/
+  my_plugin/
+    __init__.py
+    my_plugin_const.py       # APP_ID = 'my_plugin'
+    my_plugin_factory.py
+    my_plugin.py
+    screen_info/             # ← 新增，放 screen YAML
+      my_screen.yml
+```
+
+### 插件 Screen YAML 示例
+
+```yaml
+# plugins/my_plugin/screen_info/my_screen.yml
+screen_id: my_plugin_main
+screen_name: 我的插件-主界面
+# app_id 可省略，自动使用插件的 APP_ID
+pc_alt: false
+area_list:
+  - area_name: 返回按钮
+    id_mark: true
+    pc_rect: [82, 13, 150, 90]
+    template_id: back
+    template_sub_dir: menu
+    goto_list:
+      - 大世界-普通
+```
+
+### 冲突处理
+
+- 插件 screen_name 与主 YAML 或其他插件冲突时，跳过并输出警告日志
+- `default_app_id` 仅在 YAML 未显式设置 `app_id` 时使用
+插件的 screen 加载到 `ScreenContext` 后，通过 `app_id` 自动归入局部命名空间，不污染其他应用。
+
+## 9. 文件变更清单
+
+| 文件 | 变更 |
+|------|------|
+| `src/one_dragon/base/screen/screen_info.py` | `ScreenInfo` 新增 `app_id` 字段 |
+| `src/one_dragon/base/screen/screen_loader.py` | `ScreenContext` 新增 scope 管理 API 和 `load_extra_screen_dir` |
+| `src/one_dragon/base/screen/screen_utils.py` | BFS 匹配适配活跃范围 |
+| `src/one_dragon/base/operation/application_base.py` | `Application` 生命周期自动 enter/exit scope |
+| `src/one_dragon/base/operation/one_dragon_context.py` | 新增 `_load_plugin_screens()`，init 和 refresh 时加载插件 screen |

--- a/docs/develop/screen_scope_design.md
+++ b/docs/develop/screen_scope_design.md
@@ -170,10 +170,8 @@ class Application(Operation):
 
 ### 建议迁移顺序
 
-1. 迷失之地（14 screen，收益最大）
-2. 随便观（7 screen）
-3. 零号空洞（4 screen）
-4. 仓库系统（3 screen）
+实际业务 screen 的 local 化范围与分层迁移顺序见
+[screen_scope_rollout.md](screen_scope_rollout.md)。
 
 ## 8. 插件 Screen 加载
 

--- a/docs/develop/screen_scope_rollout.md
+++ b/docs/develop/screen_scope_rollout.md
@@ -1,0 +1,68 @@
+# Screen Scope 分层迁移清单
+
+本文档记录主工程 `assets/game_data/screen_info/` 的 screen local 化落地范围。
+
+`app_id` 为空的 screen 保持全局，所有应用都能参与自动识别；`app_id` 非空的 screen 只在对应 `Application.app_id` scope 内参与自动识别。直接通过 `get_area`、`round_by_find_area`、`round_by_click_area` 指定 screen 名称的调用不受 scope 过滤影响。
+
+## 保持全局
+
+以下 screen 是基础导航、共享路由或跨应用复用入口，暂不 local 化：
+
+| screen | 原因 |
+| --- | --- |
+| `打开游戏` | 启动流程基础 screen |
+| `菜单` | 多应用打开入口和返回链路 |
+| `菜单-更多功能` | 仍属于菜单功能集合，不绑定单个配置检查 app |
+| `画面-通用` | 通用弹窗和确认区域 |
+| `通用-出战` | 多个战斗/副本入口共用 |
+| `大世界`, `大世界-普通`, `大世界-勘域` | 传送、返回、等待大世界等基础流程共用 |
+| `地图` | 传送和地图操作共用 |
+| `HDD` | 录像店副本入口，保留给后续更多 HDD 业务复用 |
+| `战斗画面`, `战斗-菜单`, `战斗-挑战结果-失败` | 自动战斗和多个应用共享 |
+| `快捷手册`, `快捷手册-日常`, `快捷手册-作战`, `快捷手册-目标`, `快捷手册-训练`, `快捷手册-战术` | `TransportByCompendium` 共享导航链路 |
+| `区域巡防`, `实战模拟室`, `专业挑战室`, `恶名狩猎`, `恢复电量` | 体力计划、情报板、咖啡、周常等多业务复用 |
+| `电玩店`, `拉面店`, `家政券` | 当前更像通用 operation 或尚无明确独立 app owner |
+
+## 第一层：独立日常类
+
+这层 screen 业务边界最清晰，只被对应 app 自动识别或操作。
+
+| app_id | screen |
+| --- | --- |
+| `city_fund` | `丽都城募` |
+| `email` | `邮件` |
+| `intel_board` | `情报板` |
+| `random_play` | `影像店营业` |
+| `ridu_weekly` | `丽都周纪` |
+| `scratch_card` | `报刊亭` |
+| `trigrams_collection` | `卦象集录` |
+
+## 第二层：路线链路/业务组
+
+这层需要保持一组 screen 同时 local 化，避免路由过程中只识别到局部链路的一部分。
+
+| app_id | screen |
+| --- | --- |
+| `world_patrol` | `3D地图`, `绳网` |
+| `coffee` | `咖啡店` |
+| `commission_assistant` | `委托助手`, `钓鱼` |
+| `drive_disc_dismantle` | `仓库-音擎仓库`, `仓库-驱动仓库`, `仓库-驱动仓库-驱动盘拆解` |
+| `life_on_line` | `真拿命验收` |
+| `suibian_temple` | `随便观-入口`, `随便观-游历`, `随便观-邦巢`, `随便观-制造坊`, `随便观-德丰大押`, `随便观-售卖铺`, `随便观-饮茶仙` |
+
+## 第三层：空洞/战斗域
+
+这层 screen 数量多、链路深，需要整组迁移并重点回归入口识别、战斗后结算、事件交互。
+
+| app_id | screen |
+| --- | --- |
+| `lost_void` | `迷失之地-入口`, `迷失之地-特遣调查`, `迷失之地-战线肃清`, `迷失之地-矩阵行动`, `迷失之地-大世界`, `迷失之地-武备选择`, `迷失之地-通用选择`, `迷失之地-邦布商店`, `迷失之地-抽奖机`, `迷失之地-路径迭换`, `迷失之地-挑战结果`, `迷失之地-战斗失败`, `迷失之地-藏品面板`, `迷失之地-调查战略选择` |
+| `withered_domain` | `零号空洞-入口`, `零号空洞-事件`, `零号空洞-战斗`, `零号空洞-商店` |
+| `shiyu_defense` | `式舆防卫战`, `新式舆防卫战` |
+
+## 回归重点
+
+- 加载默认 `_od_merged.yml` 与分文件加载 `from_separated_files=True` 时，`app_id` 数量应一致。
+- `HDD` 与 `菜单-更多功能` 必须仍保持全局。
+- 逐层验证 `enter_scope(app_id)` 后的活跃范围为 `全局 screen + 当前 app 局部 screen`。
+- 优先 smoke test：`email`, `drive_disc_dismantle`, `lost_void`, `withered_domain`, `suibian_temple`, `shiyu_defense`。

--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -64,6 +64,10 @@ class Application(Operation):
         运行前初始化
         """
         Operation.handle_init(self)
+
+        # 进入 screen scope（基于 app_id 自动推导）
+        self.ctx.screen_loader.enter_scope(self.app_id)
+
         if self.run_record is not None:
             self.run_record.check_and_update_status()  # 先判断是否重置记录
             self.run_record.update_status(AppRunRecord.STATUS_RUNNING)
@@ -84,6 +88,10 @@ class Application(Operation):
         :return:
         """
         Operation.after_operation_done(self, result)
+
+        # 退出 screen scope
+        self.ctx.screen_loader.exit_scope()
+
         self._update_record_after_stop(result)
 
         if self.ctx.run_context.is_app_need_notify(self.app_id):

--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -82,7 +82,16 @@ class Application(Operation):
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_START.value, self.app_id)
 
-    def after_operation_done(self, result: OperationResult):
+    def execute(self) -> OperationResult:
+        """
+        执行应用，并确保异常路径也退出 screen scope。
+        """
+        try:
+            return Operation.execute(self)
+        finally:
+            self.ctx.screen_loader.exit_scope()
+
+    def after_operation_done(self, result: OperationResult) -> None:
         """
         停止后的处理
         :return:

--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -64,6 +64,7 @@ class Application(Operation):
         运行前初始化
         """
         Operation.handle_init(self)
+
         if self.run_record is not None:
             self.run_record.check_and_update_status()  # 先判断是否重置记录
             self.run_record.update_status(AppRunRecord.STATUS_RUNNING)
@@ -78,12 +79,23 @@ class Application(Operation):
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_START.value, self.app_id)
 
-    def after_operation_done(self, result: OperationResult):
+    def execute(self) -> OperationResult:
+        """
+        执行应用，并确保异常路径也退出 screen scope。
+        """
+        self.ctx.screen_loader.enter_scope(self.app_id)
+        try:
+            return Operation.execute(self)
+        finally:
+            self.ctx.screen_loader.exit_scope()
+
+    def after_operation_done(self, result: OperationResult) -> None:
         """
         停止后的处理
         :return:
         """
         Operation.after_operation_done(self, result)
+
         self._update_record_after_stop(result)
 
         if self.ctx.run_context.is_app_need_notify(self.app_id):

--- a/src/one_dragon/base/operation/one_dragon_context.py
+++ b/src/one_dragon/base/operation/one_dragon_context.py
@@ -201,6 +201,21 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
         if default_factories:
             self.run_context.registry_application(default_factories, default_group=True)
 
+    def _load_plugin_screens(self) -> None:
+        """加载插件的 screen_info
+
+        遍历所有已注册插件，从其 screen_info/ 子目录加载 screen YAML。
+        未设 app_id 的 screen 自动使用插件的 app_id。
+        应在 screen_loader.reload() 之后调用。
+        """
+        for plugin_info in self.factory_manager.plugin_infos:
+            if plugin_info.plugin_dir is None:
+                continue
+            screen_dir = plugin_info.plugin_dir / 'screen_info'
+            self.screen_loader.load_extra_screen_dir(
+                str(screen_dir), default_app_id=plugin_info.app_id
+            )
+
     def refresh_application_registration(self) -> None:
         """刷新应用注册
 
@@ -220,6 +235,10 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
 
         if default_factories:
             self.run_context.registry_application(default_factories, default_group=True)
+
+        # 重新加载插件 screen
+        self.screen_loader.reload()
+        self._load_plugin_screens()
 
         # 更新默认应用组
         self.app_group_manager.set_default_apps(self.run_context.default_group_apps)
@@ -257,6 +276,7 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
             self.init_ocr()
 
             self.screen_loader.reload()
+            self._load_plugin_screens()
 
             # 账号实例层级的配置 不是应用特有的配置
             self.reload_instance_config()

--- a/src/one_dragon/base/operation/one_dragon_context.py
+++ b/src/one_dragon/base/operation/one_dragon_context.py
@@ -196,6 +196,21 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
         if default_factories:
             self.run_context.registry_application(default_factories, default_group=True)
 
+    def _load_plugin_screens(self) -> None:
+        """加载插件的 screen_info
+
+        遍历所有已注册插件，从其 screen_info/ 子目录加载 screen YAML。
+        未设 app_id 的 screen 自动使用插件的 app_id。
+        应在 screen_loader.reload() 之后调用。
+        """
+        for plugin_info in self.factory_manager.plugin_infos:
+            if plugin_info.plugin_dir is None:
+                continue
+            screen_dir = plugin_info.plugin_dir / 'screen_info'
+            self.screen_loader.load_extra_screen_dir(
+                str(screen_dir), default_app_id=plugin_info.app_id
+            )
+
     def refresh_application_registration(self) -> None:
         """刷新应用注册
 
@@ -215,6 +230,10 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
 
         if default_factories:
             self.run_context.registry_application(default_factories, default_group=True)
+
+        # 重新加载插件 screen
+        self.screen_loader.reload()
+        self._load_plugin_screens()
 
         # 更新默认应用组
         self.app_group_manager.set_default_apps(self.run_context.default_group_apps)
@@ -252,6 +271,7 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
             self.init_ocr()
 
             self.screen_loader.reload()
+            self._load_plugin_screens()
 
             # 账号实例层级的配置 不是应用特有的配置
             self.reload_instance_config()

--- a/src/one_dragon/base/screen/screen_info.py
+++ b/src/one_dragon/base/screen/screen_info.py
@@ -13,6 +13,7 @@ class ScreenInfo:
         self.old_screen_id: str = data.get('screen_id', '')  # 旧的画面ID 用于保存时删掉旧文件
         self.screen_id: str = data.get('screen_id', '')  # 画面ID 用于加载文件
         self.screen_name: str = data.get('screen_name', '')  # 画面名称 用于显示
+        self.app_id: str = data.get('app_id', '')  # 所属应用ID 空字符串表示全局 screen
 
         self.screen_image: MatLike | None = None
 
@@ -96,6 +97,8 @@ class ScreenInfo:
         data: dict[str, Any] = {}
         data['screen_id'] = self.screen_id
         data['screen_name'] = self.screen_name
+        if self.app_id:
+            data['app_id'] = self.app_id
         data['pc_alt'] = self.pc_alt
         data['area_list'] = [area.to_dict() for area in self.area_list]
 

--- a/src/one_dragon/base/screen/screen_loader.py
+++ b/src/one_dragon/base/screen/screen_loader.py
@@ -138,6 +138,53 @@ class ScreenContext:
         self._global_screen_names = {
             s.screen_name for s in self.screen_info_list if not s.app_id
         }
+
+    def load_extra_screen_dir(self, dir_path: str, default_app_id: str = '') -> None:
+        """从额外目录加载 screen YAML 并注册（用于插件 screen 注入）
+
+        加载后会重新计算路由和全局 screen 集合。
+
+        Args:
+            dir_path: 包含 screen YAML 文件的目录路径
+            default_app_id: 如果 YAML 中未设置 app_id，使用此默认值
+        """
+        screen_dir = Path(dir_path)
+        if not screen_dir.is_dir():
+            return
+
+        added = False
+        for file_path in screen_dir.iterdir():
+            if file_path.suffix != '.yml':
+                continue
+            with file_path.open(encoding='utf-8') as file:
+                log.debug(f"加载插件画面: {file_path}")
+                data = yaml_utils.safe_load(file)
+            if not isinstance(data, dict):
+                log.warning(f"插件画面配置格式错误，已跳过: {file_path}")
+                continue
+
+            if default_app_id and not data.get('app_id'):
+                data['app_id'] = default_app_id
+
+            screen_info = ScreenInfo(data)
+            if screen_info.screen_name in self.screen_info_map:
+                log.warning(f"插件画面名称冲突，已跳过: {screen_info.screen_name}")
+                continue
+
+            self.screen_info_list.append(screen_info)
+            self.screen_info_map[screen_info.screen_name] = screen_info
+            self._id_2_screen[screen_info.screen_id] = screen_info
+
+            for screen_area in screen_info.area_list:
+                self._screen_area_map[f'{screen_info.screen_name}.{screen_area.area_name}'] = screen_area
+            added = True
+
+        if added:
+            self.init_screen_route()
+            self._global_screen_names = {
+                s.screen_name for s in self.screen_info_list if not s.app_id
+            }
+
     def get_screen(self, screen_name: str, copy: bool = False) -> ScreenInfo:
         """
         获取某个画面

--- a/src/one_dragon/base/screen/screen_loader.py
+++ b/src/one_dragon/base/screen/screen_loader.py
@@ -1,5 +1,4 @@
-import os
-from typing import Optional
+from pathlib import Path
 
 import yaml
 
@@ -52,19 +51,24 @@ class ScreenContext:
         self._id_2_screen: dict[str, ScreenInfo] = {}
         self.screen_route_map: dict[str, dict[str, ScreenRoute]] = {}
 
-        self.last_screen_name: Optional[str] = None  # 上一个画面名字
-        self.current_screen_name: Optional[str] = None  # 当前的画面名字
+        self.last_screen_name: str | None = None  # 上一个画面名字
+        self.current_screen_name: str | None = None  # 当前的画面名字
+
+        # Screen scope management
+        self._global_screen_names: set[str] = set()
+        self._local_screen_names: set[str] = set()
+        self._scoped: bool = False
 
     @property
-    def yml_file_dir(self) -> str:
-        return os_utils.get_path_under_work_dir('assets', 'game_data', 'screen_info')
+    def yml_file_dir(self) -> Path:
+        return Path(os_utils.get_path_under_work_dir('assets', 'game_data', 'screen_info'))
 
     @property
-    def merge_yml_file_path(self) -> str:
-        return os.path.join(self.yml_file_dir, '_od_merged.yml')
+    def merge_yml_file_path(self) -> Path:
+        return self.yml_file_dir / '_od_merged.yml'
 
-    def get_yml_file_path(self, screen_id: str) -> str:
-        return os.path.join(self.yml_file_dir, f'{screen_id}.yml')
+    def get_yml_file_path(self, screen_id: str) -> Path:
+        return self.yml_file_dir / f'{screen_id}.yml'
 
     def reload(self, from_memory: bool = False, from_separated_files: bool = False) -> None:
         """
@@ -87,13 +91,12 @@ class ScreenContext:
                     self._screen_area_map[f'{screen_info.screen_name}.{screen_area.area_name}'] = screen_area
         elif from_separated_files:
             self._id_2_screen.clear()
-            for file_name in os.listdir(self.yml_file_dir):
-                if not file_name.endswith('.yml'):
+            for file_path in self.yml_file_dir.iterdir():
+                if file_path.suffix != '.yml':
                     continue
-                if file_name == '_od_merged.yml':
+                if file_path.name == '_od_merged.yml':
                     continue
-                file_path = os.path.join(self.yml_file_dir, file_name)
-                with open(file_path, 'r', encoding='utf-8') as file:
+                with file_path.open(encoding='utf-8') as file:
                     log.debug(f"加载yaml: {file_path}")
                     data = yaml_utils.safe_load(file)
                 if not isinstance(data, dict):
@@ -110,7 +113,7 @@ class ScreenContext:
         else:
             self._id_2_screen.clear()
             file_path = self.merge_yml_file_path
-            with open(file_path, 'r', encoding='utf-8') as file:
+            with file_path.open(encoding='utf-8') as file:
                 log.debug(f"加载yaml: {file_path}")
                 yaml_data = yaml_utils.safe_load(file)
             if not isinstance(yaml_data, list):
@@ -131,6 +134,10 @@ class ScreenContext:
 
         self.init_screen_route()
 
+        # 自动计算全局 screen：没有 app_id 的 screen 为全局
+        self._global_screen_names = {
+            s.screen_name for s in self.screen_info_list if not s.app_id
+        }
     def get_screen(self, screen_name: str, copy: bool = False) -> ScreenInfo:
         """
         获取某个画面
@@ -182,8 +189,8 @@ class ScreenContext:
             del self._id_2_screen[screen_id]
 
             file_path = self.get_yml_file_path(screen_id)
-            if os.path.exists(file_path):
-                os.remove(file_path)
+            if file_path.exists():
+                file_path.unlink()
 
         if save:
             self.save(screen_id=screen_id)
@@ -206,11 +213,11 @@ class ScreenContext:
             all_data.append(data)
 
             if screen_id is not None and screen_id == screen_info.screen_id:
-                with open(self.get_yml_file_path(screen_id), 'w', encoding='utf-8') as file:
+                with self.get_yml_file_path(screen_id).open('w', encoding='utf-8') as file:
                     yaml.safe_dump(data, file, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
         # 保存到合并文件
-        with open(self.merge_yml_file_path, 'w', encoding='utf-8') as file:
+        with self.merge_yml_file_path.open('w', encoding='utf-8') as file:
             yaml.safe_dump(all_data, file, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
         if reload_after_save:
@@ -284,9 +291,9 @@ class ScreenContext:
                         for node_kj in route_kj.node_list:
                             route_ij.node_list.append(node_kj)
 
-    def get_screen_route(self, from_screen: str, to_screen: str) -> Optional[ScreenRoute]:
+    def get_screen_route(self, from_screen: str, to_screen: str) -> ScreenRoute | None:
         """
-        获取两个画面之间的
+        获取两个画面之间的路径
         :param from_screen:
         :param to_screen:
         :return:
@@ -302,3 +309,54 @@ class ScreenContext:
         """
         self.last_screen_name = self.current_screen_name
         self.current_screen_name = screen_name
+
+    # ---- Screen Scope 管理 ----
+    # 通过 ScreenInfo.app_id 自动区分全局/局部 screen：
+    #   - app_id 为空 → 全局 screen，始终参与匹配
+    #   - app_id 非空 → 局部 screen，仅在对应应用 scope 内参与匹配
+    # reload() 后自动计算全局集合，Application 启动/停止时自动 enter/exit scope
+
+    def enter_scope(self, app_id: str) -> None:
+        """进入应用 scope，活跃范围 = 全局 screen + 该 app_id 的局部 screen
+
+        仅当 YAML 中存在 app_id 匹配的 screen 时才真正启用 scope，否则保持全量匹配。
+
+        Args:
+            app_id: 当前应用的唯一标识符（与 ScreenInfo.app_id 对应）
+        """
+        if not self._global_screen_names:
+            return  # 所有 screen 都没有 app_id，不启用 scope
+
+        local_names = {s.screen_name for s in self.screen_info_list if s.app_id == app_id}
+        if not local_names:
+            return  # 该应用没有专属 screen，不启用 scope
+
+        self._local_screen_names = local_names
+        self._scoped = True
+
+    def exit_scope(self) -> None:
+        """退出应用 scope，恢复全量 screen 匹配"""
+        self._local_screen_names.clear()
+        self._scoped = False
+
+    @property
+    def active_screen_names(self) -> set[str] | None:
+        """当前活跃的 screen 名称集合。None 表示全部活跃（未启用 scope）。"""
+        if not self._scoped:
+            return None
+        return self._global_screen_names | self._local_screen_names
+
+    @property
+    def active_screen_info_list(self) -> list[ScreenInfo]:
+        """当前活跃的 ScreenInfo 列表"""
+        names = self.active_screen_names
+        if names is None:
+            return self.screen_info_list
+        return [s for s in self.screen_info_list if s.screen_name in names]
+
+    def is_screen_active(self, screen_name: str) -> bool:
+        """判断某个 screen 是否在当前活跃范围内"""
+        names = self.active_screen_names
+        if names is None:
+            return True
+        return screen_name in names

--- a/src/one_dragon/base/screen/screen_loader.py
+++ b/src/one_dragon/base/screen/screen_loader.py
@@ -104,6 +104,10 @@ class ScreenContext:
                     continue
 
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_id in self._id_2_screen:
+                    log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
+                    continue
+
                 self.screen_info_list.append(screen_info)
                 self.screen_info_map[screen_info.screen_name] = screen_info
                 self._id_2_screen[screen_info.screen_id] = screen_info
@@ -125,6 +129,10 @@ class ScreenContext:
                     log.warning(f"合并画面配置中存在非字典条目，已跳过: {file_path}")
                     continue
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_id in self._id_2_screen:
+                    log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
+                    continue
+
                 self.screen_info_list.append(screen_info)
                 self.screen_info_map[screen_info.screen_name] = screen_info
                 self._id_2_screen[screen_info.screen_id] = screen_info
@@ -169,6 +177,9 @@ class ScreenContext:
             screen_info = ScreenInfo(data)
             if screen_info.screen_name in self.screen_info_map:
                 log.warning(f"插件画面名称冲突，已跳过: {screen_info.screen_name}")
+                continue
+            if screen_info.screen_id in self._id_2_screen:
+                log.warning(f"插件画面ID冲突，已跳过: {screen_info.screen_id}")
                 continue
 
             self.screen_info_list.append(screen_info)
@@ -275,6 +286,8 @@ class ScreenContext:
         初始化画面间的跳转路径
         :return:
         """
+        self.screen_route_map.clear()
+
         # 先对任意两个画面之间做初始化
         for screen_1 in self.screen_info_list:
             self.screen_route_map[screen_1.screen_name] = {}

--- a/src/one_dragon/base/screen/screen_loader.py
+++ b/src/one_dragon/base/screen/screen_loader.py
@@ -104,6 +104,9 @@ class ScreenContext:
                     continue
 
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_name in self.screen_info_map:
+                    log.warning(f"画面名称冲突，已跳过: {screen_info.screen_name}")
+                    continue
                 if screen_info.screen_id in self._id_2_screen:
                     log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
                     continue
@@ -129,6 +132,9 @@ class ScreenContext:
                     log.warning(f"合并画面配置中存在非字典条目，已跳过: {file_path}")
                     continue
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_name in self.screen_info_map:
+                    log.warning(f"画面名称冲突，已跳过: {screen_info.screen_name}")
+                    continue
                 if screen_info.screen_id in self._id_2_screen:
                     log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
                     continue
@@ -384,6 +390,8 @@ class ScreenContext:
         Args:
             app_id: 当前应用的唯一标识符（与 ScreenInfo.app_id 对应）
         """
+        self.exit_scope()
+
         if not self._global_screen_names:
             return  # 所有 screen 都没有 app_id，不启用 scope
 

--- a/src/one_dragon/base/screen/screen_loader.py
+++ b/src/one_dragon/base/screen/screen_loader.py
@@ -1,5 +1,4 @@
-import os
-from typing import Optional
+from pathlib import Path
 
 import yaml
 
@@ -50,21 +49,28 @@ class ScreenContext:
         self.screen_info_map: dict[str, ScreenInfo] = {}
         self._screen_area_map: dict[str, ScreenArea] = {}
         self._id_2_screen: dict[str, ScreenInfo] = {}
+        self._extra_screen_ids: set[str] = set()
+        self._extra_screen_file_path_map: dict[str, Path] = {}
         self.screen_route_map: dict[str, dict[str, ScreenRoute]] = {}
 
-        self.last_screen_name: Optional[str] = None  # 上一个画面名字
-        self.current_screen_name: Optional[str] = None  # 当前的画面名字
+        self.last_screen_name: str | None = None  # 上一个画面名字
+        self.current_screen_name: str | None = None  # 当前的画面名字
+
+        # 屏幕作用域管理
+        self._global_screen_names: set[str] = set()
+        self._local_screen_names: set[str] = set()
+        self._scoped: bool = False
 
     @property
-    def yml_file_dir(self) -> str:
-        return os_utils.get_path_under_work_dir('assets', 'game_data', 'screen_info')
+    def yml_file_dir(self) -> Path:
+        return Path(os_utils.get_path_under_work_dir('assets', 'game_data', 'screen_info'))
 
     @property
-    def merge_yml_file_path(self) -> str:
-        return os.path.join(self.yml_file_dir, '_od_merged.yml')
+    def merge_yml_file_path(self) -> Path:
+        return self.yml_file_dir / '_od_merged.yml'
 
-    def get_yml_file_path(self, screen_id: str) -> str:
-        return os.path.join(self.yml_file_dir, f'{screen_id}.yml')
+    def get_yml_file_path(self, screen_id: str) -> Path:
+        return self.yml_file_dir / f'{screen_id}.yml'
 
     def reload(self, from_memory: bool = False, from_separated_files: bool = False) -> None:
         """
@@ -77,6 +83,9 @@ class ScreenContext:
         self.screen_info_list.clear()
         self.screen_info_map.clear()
         self._screen_area_map.clear()
+        if not from_memory:
+            self._extra_screen_ids.clear()
+            self._extra_screen_file_path_map.clear()
 
         if from_memory:
             for screen_info in self._id_2_screen.values():
@@ -87,13 +96,12 @@ class ScreenContext:
                     self._screen_area_map[f'{screen_info.screen_name}.{screen_area.area_name}'] = screen_area
         elif from_separated_files:
             self._id_2_screen.clear()
-            for file_name in os.listdir(self.yml_file_dir):
-                if not file_name.endswith('.yml'):
+            for file_path in self.yml_file_dir.iterdir():
+                if file_path.suffix != '.yml':
                     continue
-                if file_name == '_od_merged.yml':
+                if file_path.name == '_od_merged.yml':
                     continue
-                file_path = os.path.join(self.yml_file_dir, file_name)
-                with open(file_path, 'r', encoding='utf-8') as file:
+                with file_path.open(encoding='utf-8') as file:
                     log.debug(f"加载yaml: {file_path}")
                     data = yaml_utils.safe_load(file)
                 if not isinstance(data, dict):
@@ -101,6 +109,13 @@ class ScreenContext:
                     continue
 
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_name in self.screen_info_map:
+                    log.warning(f"画面名称冲突，已跳过: {screen_info.screen_name}")
+                    continue
+                if screen_info.screen_id in self._id_2_screen:
+                    log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
+                    continue
+
                 self.screen_info_list.append(screen_info)
                 self.screen_info_map[screen_info.screen_name] = screen_info
                 self._id_2_screen[screen_info.screen_id] = screen_info
@@ -110,9 +125,13 @@ class ScreenContext:
         else:
             self._id_2_screen.clear()
             file_path = self.merge_yml_file_path
-            with open(file_path, 'r', encoding='utf-8') as file:
-                log.debug(f"加载yaml: {file_path}")
-                yaml_data = yaml_utils.safe_load(file)
+            if file_path.exists():
+                with file_path.open(encoding='utf-8') as file:
+                    log.debug(f"加载yaml: {file_path}")
+                    yaml_data = yaml_utils.safe_load(file)
+            else:
+                log.info(f"合并画面配置文件不存在，按空配置加载: {file_path}")
+                yaml_data = []
             if not isinstance(yaml_data, list):
                 if yaml_data is not None:
                     log.warning(f"合并画面配置格式错误，已忽略: {file_path}")
@@ -122,6 +141,13 @@ class ScreenContext:
                     log.warning(f"合并画面配置中存在非字典条目，已跳过: {file_path}")
                     continue
                 screen_info = ScreenInfo(data)
+                if screen_info.screen_name in self.screen_info_map:
+                    log.warning(f"画面名称冲突，已跳过: {screen_info.screen_name}")
+                    continue
+                if screen_info.screen_id in self._id_2_screen:
+                    log.warning(f"画面ID冲突，已跳过: {screen_info.screen_id}")
+                    continue
+
                 self.screen_info_list.append(screen_info)
                 self.screen_info_map[screen_info.screen_name] = screen_info
                 self._id_2_screen[screen_info.screen_id] = screen_info
@@ -130,6 +156,62 @@ class ScreenContext:
                     self._screen_area_map[f'{screen_info.screen_name}.{screen_area.area_name}'] = screen_area
 
         self.init_screen_route()
+
+        # 自动计算全局 screen：没有 app_id 的 screen 为全局
+        self._global_screen_names = {
+            s.screen_name for s in self.screen_info_list if not s.app_id
+        }
+
+    def load_extra_screen_dir(self, dir_path: str, default_app_id: str = '') -> None:
+        """从额外目录加载 screen YAML 并注册（用于插件 screen 注入）
+
+        加载后会重新计算路由和全局 screen 集合。
+
+        Args:
+            dir_path: 包含 screen YAML 文件的目录路径
+            default_app_id: 如果 YAML 中未设置 app_id，使用此默认值
+        """
+        screen_dir = Path(dir_path)
+        if not screen_dir.is_dir():
+            return
+
+        added = False
+        for file_path in screen_dir.iterdir():
+            if file_path.suffix != '.yml':
+                continue
+            with file_path.open(encoding='utf-8') as file:
+                log.debug(f"加载插件画面: {file_path}")
+                data = yaml_utils.safe_load(file)
+            if not isinstance(data, dict):
+                log.warning(f"插件画面配置格式错误，已跳过: {file_path}")
+                continue
+
+            if default_app_id and not data.get('app_id'):
+                data['app_id'] = default_app_id
+
+            screen_info = ScreenInfo(data)
+            if screen_info.screen_name in self.screen_info_map:
+                log.warning(f"插件画面名称冲突，已跳过: {screen_info.screen_name}")
+                continue
+            if screen_info.screen_id in self._id_2_screen:
+                log.warning(f"插件画面ID冲突，已跳过: {screen_info.screen_id}")
+                continue
+
+            self.screen_info_list.append(screen_info)
+            self.screen_info_map[screen_info.screen_name] = screen_info
+            self._id_2_screen[screen_info.screen_id] = screen_info
+            self._extra_screen_ids.add(screen_info.screen_id)
+            self._extra_screen_file_path_map[screen_info.screen_id] = file_path
+
+            for screen_area in screen_info.area_list:
+                self._screen_area_map[f'{screen_info.screen_name}.{screen_area.area_name}'] = screen_area
+            added = True
+
+        if added:
+            self.init_screen_route()
+            self._global_screen_names = {
+                s.screen_name for s in self.screen_info_list if not s.app_id
+            }
 
     def get_screen(self, screen_name: str, copy: bool = False) -> ScreenInfo:
         """
@@ -166,10 +248,15 @@ class ScreenContext:
         Args:
             screen_info: 画面信息
         """
-        if screen_info.old_screen_id != screen_info.screen_id:
+        if screen_info.old_screen_id in self._extra_screen_file_path_map:
+            self._save_extra_screen(screen_info)
+            return
+
+        if screen_info.old_screen_id and screen_info.old_screen_id != screen_info.screen_id:
             self.delete_screen(screen_info.old_screen_id, save=False)
         self._id_2_screen[screen_info.screen_id] = screen_info
         self.save(screen_id=screen_info.screen_id)
+        screen_info.old_screen_id = screen_info.screen_id
 
     def delete_screen(self, screen_id: str, save: bool = True) -> None:
         """
@@ -178,17 +265,48 @@ class ScreenContext:
             screen_id: 画面ID
             save: 是否触发保存
         """
+        extra_file_path = self._extra_screen_file_path_map.get(screen_id)
         if screen_id in self._id_2_screen:
             del self._id_2_screen[screen_id]
+            self._extra_screen_ids.discard(screen_id)
+            self._extra_screen_file_path_map.pop(screen_id, None)
 
-            file_path = self.get_yml_file_path(screen_id)
-            if os.path.exists(file_path):
-                os.remove(file_path)
+            if extra_file_path is not None:
+                if extra_file_path.exists():
+                    extra_file_path.unlink()
+            else:
+                file_path = self.get_yml_file_path(screen_id)
+                if file_path.exists():
+                    file_path.unlink()
 
-        if save:
+        if save and extra_file_path is None:
             self.save(screen_id=screen_id)
         else:
             self.reload(from_memory=True)
+
+    def _save_extra_screen(self, screen_info: ScreenInfo) -> None:
+        """保存插件 screen 到原插件目录的独立 YAML。"""
+        old_screen_id = screen_info.old_screen_id
+        old_file_path = self._extra_screen_file_path_map[old_screen_id]
+        file_path = old_file_path
+
+        if old_screen_id != screen_info.screen_id:
+            self._id_2_screen.pop(old_screen_id, None)
+            self._extra_screen_ids.discard(old_screen_id)
+            self._extra_screen_file_path_map.pop(old_screen_id, None)
+            if old_file_path.exists():
+                old_file_path.unlink()
+            file_path = old_file_path.with_name(f'{screen_info.screen_id}.yml')
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open('w', encoding='utf-8') as file:
+            yaml.safe_dump(screen_info.to_dict(), file, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+        screen_info.old_screen_id = screen_info.screen_id
+        self._id_2_screen[screen_info.screen_id] = screen_info
+        self._extra_screen_ids.add(screen_info.screen_id)
+        self._extra_screen_file_path_map[screen_info.screen_id] = file_path
+        self.reload(from_memory=True)
 
     def save(self, screen_id: str | None = None, reload_after_save: bool = True) -> None:
         """
@@ -201,16 +319,20 @@ class ScreenContext:
         all_data = []
 
         # 保存到单个文件
-        for screen_info in self._id_2_screen.values():
+        target_screen_id = screen_id
+        for current_screen_id, screen_info in self._id_2_screen.items():
+            if current_screen_id in self._extra_screen_ids:
+                continue
+
             data = screen_info.to_dict()
             all_data.append(data)
 
-            if screen_id is not None and screen_id == screen_info.screen_id:
-                with open(self.get_yml_file_path(screen_id), 'w', encoding='utf-8') as file:
+            if target_screen_id is not None and target_screen_id == screen_info.screen_id:
+                with self.get_yml_file_path(target_screen_id).open('w', encoding='utf-8') as file:
                     yaml.safe_dump(data, file, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
         # 保存到合并文件
-        with open(self.merge_yml_file_path, 'w', encoding='utf-8') as file:
+        with self.merge_yml_file_path.open('w', encoding='utf-8') as file:
             yaml.safe_dump(all_data, file, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
         if reload_after_save:
@@ -221,6 +343,8 @@ class ScreenContext:
         初始化画面间的跳转路径
         :return:
         """
+        self.screen_route_map.clear()
+
         # 先对任意两个画面之间做初始化
         for screen_1 in self.screen_info_list:
             self.screen_route_map[screen_1.screen_name] = {}
@@ -284,9 +408,9 @@ class ScreenContext:
                         for node_kj in route_kj.node_list:
                             route_ij.node_list.append(node_kj)
 
-    def get_screen_route(self, from_screen: str, to_screen: str) -> Optional[ScreenRoute]:
+    def get_screen_route(self, from_screen: str, to_screen: str) -> ScreenRoute | None:
         """
-        获取两个画面之间的
+        获取两个画面之间的路径
         :param from_screen:
         :param to_screen:
         :return:
@@ -302,3 +426,56 @@ class ScreenContext:
         """
         self.last_screen_name = self.current_screen_name
         self.current_screen_name = screen_name
+
+    # ---- Screen Scope 管理 ----
+    # 通过 ScreenInfo.app_id 自动区分全局/局部 screen：
+    #   - app_id 为空 → 全局 screen，始终参与匹配
+    #   - app_id 非空 → 局部 screen，仅在对应应用 scope 内参与匹配
+    # reload() 后自动计算全局集合，Application 启动/停止时自动 enter/exit scope
+
+    def enter_scope(self, app_id: str) -> None:
+        """进入应用 scope，活跃范围 = 全局 screen + 该 app_id 的局部 screen
+
+        仅当 YAML 中存在 app_id 匹配的 screen 时才真正启用 scope，否则保持全量匹配。
+
+        Args:
+            app_id: 当前应用的唯一标识符（与 ScreenInfo.app_id 对应）
+        """
+        self.exit_scope()
+
+        if not self._global_screen_names:
+            return  # 所有 screen 都没有 app_id，不启用 scope
+
+        local_names = {s.screen_name for s in self.screen_info_list if s.app_id == app_id}
+        if not local_names:
+            return  # 该应用没有专属 screen，不启用 scope
+
+        self._local_screen_names = local_names
+        self._scoped = True
+
+    def exit_scope(self) -> None:
+        """退出应用 scope，恢复全量 screen 匹配"""
+        self._local_screen_names.clear()
+        self._scoped = False
+
+    @property
+    def active_screen_names(self) -> set[str] | None:
+        """当前活跃的 screen 名称集合。None 表示全部活跃（未启用 scope）。"""
+        if not self._scoped:
+            return None
+        return self._global_screen_names | self._local_screen_names
+
+    @property
+    def active_screen_info_list(self) -> list[ScreenInfo]:
+        """当前活跃的 ScreenInfo 列表"""
+        names = self.active_screen_names
+        if names is None:
+            return self.screen_info_list
+        return [s for s in self.screen_info_list if s.screen_name in names]
+
+    def is_screen_active(self, screen_name: str) -> bool:
+        """判断某个 screen 是否在当前活跃范围内"""
+        names = self.active_screen_names
+        if names is None:
+            return True
+        return screen_name in names

--- a/src/one_dragon/base/screen/screen_utils.py
+++ b/src/one_dragon/base/screen/screen_utils.py
@@ -363,7 +363,7 @@ def get_match_screen_name(
     elif ctx.screen_loader.current_screen_name is not None or ctx.screen_loader.last_screen_name is not None:
         return get_match_screen_name_from_last(ctx, screen, crop_first=crop_first)
     else:
-        for screen_info in ctx.screen_loader.screen_info_list:
+        for screen_info in ctx.screen_loader.active_screen_info_list:
             if is_target_screen(ctx, screen, screen_info=screen_info, crop_first=crop_first):
                 return screen_info.screen_name
 
@@ -385,6 +385,8 @@ def get_match_screen_name_from_last(
     Returns:
         str | None: 画面名称
     """
+    active_names = ctx.screen_loader.active_screen_names  # set or None
+
     bfs_list = []
 
     if ctx.screen_loader.current_screen_name is not None:  # 如果有记录上次所在画面 则从这个画面开始搜索
@@ -400,6 +402,18 @@ def get_match_screen_name_from_last(
         current_screen_name = bfs_list[bfs_idx]
         bfs_idx += 1
 
+        # 在 scope 模式下 跳过非活跃 screen 的匹配（但仍展开其邻居以保持图连通性）
+        if active_names is not None and current_screen_name not in active_names:
+            screen_info = ctx.screen_loader.screen_info_map.get(current_screen_name)
+            if screen_info is not None:
+                for area in screen_info.area_list:
+                    if area.goto_list is None or len(area.goto_list) == 0:
+                        continue
+                    for goto_screen in area.goto_list:
+                        if goto_screen not in bfs_list:
+                            bfs_list.append(goto_screen)
+            continue
+
         if is_target_screen(ctx, screen, screen_name=current_screen_name, crop_first=crop_first):
             return current_screen_name
 
@@ -414,7 +428,7 @@ def get_match_screen_name_from_last(
                     bfs_list.append(goto_screen)
 
     # 最后 尝试搜索中没有出现的画面
-    for screen_info in ctx.screen_loader.screen_info_list:
+    for screen_info in ctx.screen_loader.active_screen_info_list:
         if screen_info.screen_name in bfs_list:
             continue
         if is_target_screen(ctx, screen, screen_info=screen_info, crop_first=crop_first):

--- a/src/one_dragon/base/screen/screen_utils.py
+++ b/src/one_dragon/base/screen/screen_utils.py
@@ -359,7 +359,7 @@ def get_match_screen_name(
     elif ctx.screen_loader.current_screen_name is not None or ctx.screen_loader.last_screen_name is not None:
         return get_match_screen_name_from_last(ctx, screen, crop_first=crop_first)
     else:
-        for screen_info in ctx.screen_loader.screen_info_list:
+        for screen_info in ctx.screen_loader.active_screen_info_list:
             if is_target_screen(ctx, screen, screen_info=screen_info, crop_first=crop_first):
                 return screen_info.screen_name
 
@@ -381,6 +381,8 @@ def get_match_screen_name_from_last(
     Returns:
         str | None: 画面名称
     """
+    active_names = ctx.screen_loader.active_screen_names  # set or None
+
     bfs_list = []
 
     if ctx.screen_loader.current_screen_name is not None:  # 如果有记录上次所在画面 则从这个画面开始搜索
@@ -396,6 +398,18 @@ def get_match_screen_name_from_last(
         current_screen_name = bfs_list[bfs_idx]
         bfs_idx += 1
 
+        # 在 scope 模式下 跳过非活跃 screen 的匹配（但仍展开其邻居以保持图连通性）
+        if active_names is not None and current_screen_name not in active_names:
+            screen_info = ctx.screen_loader.screen_info_map.get(current_screen_name)
+            if screen_info is not None:
+                for area in screen_info.area_list:
+                    if area.goto_list is None or len(area.goto_list) == 0:
+                        continue
+                    for goto_screen in area.goto_list:
+                        if goto_screen not in bfs_list:
+                            bfs_list.append(goto_screen)
+            continue
+
         if is_target_screen(ctx, screen, screen_name=current_screen_name, crop_first=crop_first):
             return current_screen_name
 
@@ -410,7 +424,7 @@ def get_match_screen_name_from_last(
                     bfs_list.append(goto_screen)
 
     # 最后 尝试搜索中没有出现的画面
-    for screen_info in ctx.screen_loader.screen_info_list:
+    for screen_info in ctx.screen_loader.active_screen_info_list:
         if screen_info.screen_name in bfs_list:
             continue
         if is_target_screen(ctx, screen, screen_info=screen_info, crop_first=crop_first):


### PR DESCRIPTION
- ScreenInfo 新增 app_id 字段，YAML 中声明所属应用（空=全局，非空=局部）
- ScreenContext 新增 enter_scope/exit_scope API，自动从 app_id 推导活跃范围
- screen_utils BFS 匹配适配活跃范围，跳过非活跃 screen 的 OCR/模板匹配
- Application 生命周期自动进入/退出 scope

向后兼容：未设 app_id 时行为不变，渐进迁移无风险

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增屏幕作用域设计与落地迁移文档，含作用域规则、加载/生命周期与回归要点。

* **新功能**
  * 支持全局与应用级局部屏幕的作用域划分与动态切换（应用启动/停止自动生效）。
  * 支持插件屏幕自动加载并归类到对应应用命名空间，冲突会记录并跳过。

* **改进**
  * 批量为大量屏幕配置补充应用标识；匹配逻辑在非活跃屏幕上跳过识别开销并限制回退搜索，路由计算与复用更稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->