### PR TITLE
fix: 处理点击特定跳过按钮不生效的问题

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -32,6 +32,7 @@ from zzz_od.operation.back_to_normal_world import BackToNormalWorld
 from zzz_od.operation.compendium.area_patrol import AreaPatrol
 from zzz_od.operation.compendium.combat_simulation import CombatSimulation
 from zzz_od.operation.compendium.expert_challenge import ExpertChallenge
+from zzz_od.operation.input_utils import wake_mouse_at
 from zzz_od.operation.transport import Transport
 from zzz_od.operation.wait_normal_world import WaitNormalWorld
 
@@ -277,6 +278,9 @@ class CoffeeApp(ZApplication):
             return self.round_success(result.status)
 
         # 这个点击很怪 需要多点几次
+        # 点击前甩动一下激活鼠标
+        skip_area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
+        wake_mouse_at(self.ctx.controller, skip_area.center)
         result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '点单后跳过')
         if result.is_success:
             return self.round_wait(result.status, wait=1)

--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
@@ -15,6 +15,7 @@ from zzz_od.application.suibian_temple.suibian_temple_config import (
     SuibianTempleConfig,
 )
 from zzz_od.context.zzz_context import ZContext
+from zzz_od.operation.input_utils import wake_mouse_at
 from zzz_od.operation.zzz_operation import ZOperation
 
 
@@ -252,8 +253,11 @@ class SuibianTempleBooBox(ZOperation):
         if any('聘用' in text for text in ocr_result_map):
             return self.round_success(status='已返回邦巢界面')
 
+        skip_area = self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过')
+        # 点击前甩动一下激活鼠标
+        wake_mouse_at(self.ctx.controller, skip_area.center)
         self.ctx.controller.click(
-            pos=self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过').center,
+            pos=skip_area.center,
             press_time=0.5,  # 长按一点
         )
         return self.round_wait(status='点击跳过', wait=0.5)

--- a/src/zzz_od/operation/input_utils.py
+++ b/src/zzz_od/operation/input_utils.py
@@ -1,0 +1,11 @@
+import time
+
+from one_dragon.base.controller.pc_controller_base import PcControllerBase
+from one_dragon.base.geometry.point import Point
+
+
+def wake_mouse_at(controller: PcControllerBase, pos: Point, distance: int = 8, interval: float = 0.03) -> None:
+    """让游戏先收到鼠标移动，再执行后续点击。"""
+    for offset in (Point(-distance, 0), Point(distance, 0), Point(0, 0)):
+        controller.mouse_move(pos + offset)
+        time.sleep(interval)


### PR DESCRIPTION
引入甩动鼠标方法，在点击前激活可能被隐藏的鼠标

cc @Usagi-wusaqi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新说明

* **New Features**
  * 增加了对跳过按钮前置鼠标激活的处理，提升点击命中率和响应稳定性

* **Bug Fixes**
  * 优化了咖啡订单“跳过”交互，减少误点和失败重试
  * 优化了随便庙蛋盒购买界面跳过按钮的响应，提升交互可靠性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->