### PR TITLE
fix: tolerate locked log rollover on Windows

### DIFF
--- a/src/one_dragon/utils/log_utils.py
+++ b/src/one_dragon/utils/log_utils.py
@@ -1,8 +1,24 @@
 import logging
 import os
+import time
 from logging.handlers import TimedRotatingFileHandler
 
 from one_dragon.utils import os_utils
+
+
+class SafeTimedRotatingFileHandler(TimedRotatingFileHandler):
+    def doRollover(self):
+        try:
+            super().doRollover()
+        except PermissionError:
+            if self.stream is None:
+                self.stream = self._open()
+
+            current_time = int(time.time())
+            rollover_at = self.computeRollover(current_time)
+            while rollover_at <= current_time:
+                rollover_at += self.interval
+            self.rolloverAt = rollover_at
 
 
 def get_logger():
@@ -13,7 +29,7 @@ def get_logger():
     formatter = logging.Formatter('[%(asctime)s.%(msecs)03d] [%(filename)s %(lineno)d] [%(levelname)s]: %(message)s', '%H:%M:%S')
 
     log_file_path = os.path.join(os_utils.get_path_under_work_dir('.log'), 'log.txt')
-    archive_handler = TimedRotatingFileHandler(log_file_path, when='midnight', interval=1, backupCount=3, encoding='utf-8')
+    archive_handler = SafeTimedRotatingFileHandler(log_file_path, when='midnight', interval=1, backupCount=3, encoding='utf-8')
     archive_handler.setLevel(logging.INFO)
     archive_handler.setFormatter(formatter)
     logger.addHandler(archive_handler)

--- a/src/one_dragon/utils/log_utils.py
+++ b/src/one_dragon/utils/log_utils.py
@@ -7,7 +7,7 @@ from one_dragon.utils import os_utils
 
 
 class SafeTimedRotatingFileHandler(TimedRotatingFileHandler):
-    def doRollover(self):
+    def doRollover(self) -> None:
         try:
             super().doRollover()
         except PermissionError:


### PR DESCRIPTION
## Summary

- add a safe timed rotating log handler that tolerates Windows `PermissionError` during log rollover
- keep logging usable when another OneDragon process temporarily holds `.log/log.txt`
- avoid repeated `--- Logging error ---` tracebacks that can flood unattended runners and obscure the real automation state

## Problem solved

On Windows, `TimedRotatingFileHandler` rotates the log by renaming the active file, for example:

```text
.log/log.txt -> .log/log.txt.2026-05-06
```

If a previous OneDragon process is still alive, or two OneDragon processes write the same log file around midnight, Windows can reject that rename because the source file is still open by another process:

```text
PermissionError: [WinError 32] another process is using this file
```

After that failure, the handler still considers the file due for rollover. That means every later log write can try the same failing rename again, producing repeated `Logging error` stack traces instead of normal progress logs.

In unattended launchers such as ScriptChainer, this can make the task look stuck or fail early because the child process keeps emitting logging exceptions, the useful state transitions are buried, and normal startup/enter-game diagnostics become unreliable. In the observed failure, the automation started the game but then failed around the enter-world step with `未识别到大世界`, while the runner log was dominated by repeated rollover `PermissionError` traces.

## Root cause

The default `TimedRotatingFileHandler` is not safe for this Windows multi-process/log-file-lock scenario. A stale process holding yesterday's `log.txt` can make a new run repeatedly fail rollover before normal logging can continue cleanly.

## Fix

This PR wraps `TimedRotatingFileHandler.doRollover()` and handles `PermissionError` by:

- keeping/reopening the current log stream so logging can continue
- recomputing the next rollover time so each log record does not retry the same failed rename immediately
- using the safe handler only for the existing `.log/log.txt` setup, without changing log format or call sites

This does not try to kill stale processes or solve unrelated game-window/OCR failures. It prevents a locked log file from turning into a repeated logging failure loop that destabilizes or hides the actual automation state.

## Verification

- Ran `py_compile` for `src/one_dragon/utils/log_utils.py`
- Ran `git diff --check`
- Verified locally that, after clearing stale processes, the one-dragon run can enter the game, reach the world screen, and complete the one-dragon workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 日志系统可靠性改进 — 当日志轮转因文件权限或访问失败时，系统能自动处理并调整下一次轮转时间以继续写入，避免因轮转失败导致日志中断或丢失。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
