### PR TITLE
fix: 迷失之地 - 点击对话后可能出现需要点击的黑屏 (如战斗区域被npc提前清理了)

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -4872,6 +4872,13 @@
     - 245
     - 1365
     - 770
+    text: ''
+    lcs_percent: null
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: null
+    color_range: null
+    goto_list: []
 - screen_id: lost_void_entry
   screen_name: 迷失之地-入口
   pc_alt: false

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -4865,6 +4865,13 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 中间区域-识别黑屏
+    id_mark: false
+    pc_rect:
+    - 520
+    - 245
+    - 1365
+    - 770
 - screen_id: lost_void_entry
   screen_name: 迷失之地-入口
   pc_alt: false

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -142,3 +142,10 @@ area_list:
   - 245
   - 1365
   - 770
+  text: ''
+  lcs_percent: null
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: null
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -135,3 +135,10 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 中间区域-识别黑屏
+  id_mark: false
+  pc_rect:
+  - 520
+  - 245
+  - 1365
+  - 770

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -473,6 +473,7 @@ class LostVoidRunLevel(ZOperation):
             else:
                 return self.round_fail(op_result.status)
 
+        # 尝试对话
         talk_result = self.try_talk(self.last_screenshot)
         if talk_result is not None:
             # 对话的情况 说明交互到的不是下层入口 中途交互到其他内容了
@@ -480,6 +481,13 @@ class LostVoidRunLevel(ZOperation):
                 self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
 
             return talk_result
+
+        # 对话后可能出现需要点击的黑屏 (如战斗区域被npc提前清理了)
+        center_area = self.ctx.screen_loader.get_area('委托助手', '中间选项区域')
+        center_image, _ = cv2_utils.crop_image(self.last_screenshot, center_area.rect)
+        if not cv2_utils.is_colorful(center_image, saturation_threshold=1, color_ratio_threshold=0.01):
+            self.ctx.controller.click(press_time=0.001)
+            return self.round_wait(status='黑屏点击', wait=0.5)
 
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):
             return self.round_success('迷失之地-大世界')

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -483,7 +483,7 @@ class LostVoidRunLevel(ZOperation):
             return talk_result
 
         # 对话后可能出现需要点击的黑屏 (如战斗区域被npc提前清理了)
-        center_area = self.ctx.screen_loader.get_area('委托助手', '中间选项区域')
+        center_area = self.ctx.screen_loader.get_area('迷失之地-通用选择', '中间区域-识别黑屏')
         center_image, _ = cv2_utils.crop_image(self.last_screenshot, center_area.rect)
         if not cv2_utils.is_colorful(center_image, saturation_threshold=1, color_ratio_threshold=0.01):
             self.ctx.controller.click()

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -486,7 +486,7 @@ class LostVoidRunLevel(ZOperation):
         center_area = self.ctx.screen_loader.get_area('委托助手', '中间选项区域')
         center_image, _ = cv2_utils.crop_image(self.last_screenshot, center_area.rect)
         if not cv2_utils.is_colorful(center_image, saturation_threshold=1, color_ratio_threshold=0.01):
-            self.ctx.controller.click(press_time=0.001)
+            self.ctx.controller.click()
             return self.round_wait(status='黑屏点击', wait=0.5)
 
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):


### PR DESCRIPTION
<img width="883" height="715" alt="image" src="https://github.com/user-attachments/assets/4ce51f12-76f3-4ba9-a383-06de16ce357d" />
<img width="1217" height="514" alt="image" src="https://github.com/user-attachments/assets/f2e6f114-a384-4f02-992a-55f3ea35364e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改善交互流程稳定性：新增对“中间区域”黑屏的识别与兜底检测，使用饱和度与色彩比例阈值判断无响应画面后会执行一次短促点击并等待约0.5秒，以推进后续界面状态，减少卡顿和中断。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->