### PR TITLE
fix:迷失之地(特遣调查) - 鸣徽狂热策略下挚交会谈开局不往右走从而卡住的bug

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -41,7 +41,9 @@ class LostVoidApp(ZApplication):
     STATUS_AGAIN: ClassVar[str] = '继续挑战'
     STATUS_AGAIN_MATRIX: ClassVar[str] = '继续挑战-矩阵行动'
 
-    def __init__(self, ctx: ZContext):
+    def __init__(self, ctx: ZContext,
+                 lost_void_debug: bool = False,
+                 next_region_type: LostVoidRegionType = LostVoidRegionType.ENTRY):
         ZApplication.__init__(
             self,
             ctx=ctx,
@@ -58,12 +60,15 @@ class LostVoidApp(ZApplication):
             app_id=lost_void_const.APP_ID,
         )
 
-        self.next_region_type: LostVoidRegionType = LostVoidRegionType.ENTRY  # 下一个区域的类型
+        self.next_region_type = next_region_type  # 下一个区域的类型
         self.priority_agent_list: list[Agent] = []  # 优先选择的代理人列表
 
         self.use_priority_agent: bool = False  # 本次挑战是否使用了UP代理人
         self._entry_nav_click_cooldown_sec: float = 1.0
         self._entry_nav_last_click_at: float = 0.0
+
+        # debug
+        self.lost_void_debug = lost_void_debug
 
     @operation_node(name='初始化加载', is_start_node=True)
     def init_for_lost_void(self) -> OperationRoundResult:
@@ -82,6 +87,8 @@ class LostVoidApp(ZApplication):
     @node_from(from_name='初始化加载', status=STATUS_AGAIN)
     @operation_node(name='识别初始画面')
     def check_initial_screen(self) -> OperationRoundResult:
+        if self.lost_void_debug:
+            return self.round_success('迷失之地-大世界')
         result = self.round_by_find_and_click_area(self.last_screenshot, '迷失之地-大世界', '按钮-挑战-确认')
         # 特殊兼容：在挑战区域开始，接力运行
         if result.is_success:
@@ -921,7 +928,7 @@ def __debug():
     ctx = ZContext()
     ctx.init()
     ctx.run_context.start_running()
-    op = LostVoidApp(ctx)
+    op = LostVoidApp(ctx, lost_void_debug=True, next_region_type = LostVoidRegionType.FRIENDLY_TALK)
     op.execute()
 
 

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -11,7 +11,7 @@ from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_notify import NotifyTiming, node_notify
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.base.screen import screen_utils
-from one_dragon.utils import cv2_utils, gpu_executor, str_utils
+from one_dragon.utils import cv2_utils, gpu_executor, str_utils, log_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 from one_dragon.yolo.detect_utils import DetectFrameResult
@@ -108,6 +108,7 @@ class LostVoidRunLevel(ZOperation):
         self.click_challenge_confirm: bool = False  # 点击了挑战确认
         self.boss_pre_battle: bool = self.region_type == LostVoidRegionType.BOSS  # 终结之役正式开战前的交互阶段
 
+        self.room_inited_times: int = 0  # 挚交会谈需要初始化两次
         self.had_been_list: list[str] = []  # 已经访问过的类型 1.5更新后 交互后交互类型的图标不会消失 需要自己过滤
 
     @node_from(from_name='非战斗画面识别', status='未在大世界')  # 有小概率交互入口后 没处理好结束本次RunLevel 重新从等待加载 开始
@@ -116,12 +117,8 @@ class LostVoidRunLevel(ZOperation):
     @operation_node(name='等待加载', node_max_retry_times=60, is_start_node=True)
     def wait_loading(self) -> OperationRoundResult:
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):
-            # 有一个战略会在挚交会谈时奖励一个鸣徽 这个画面会在进入大世界一秒内触发
-            if self.region_type == LostVoidRegionType.FRIENDLY_TALK:
-                wait = 1
-            else:
-                wait = 0
-            return self.round_success('大世界', wait=wait)
+            self.room_inited_times = 0
+            return self.round_success('大世界')
 
         # 1. 在精英怪后 点击完挑战结果后 加载挚交会谈前 可能会弹出奖励
         # 2. 有战略可以导致进入新一层时获取战利品
@@ -184,11 +181,6 @@ class LostVoidRunLevel(ZOperation):
         if self.region_type == LostVoidRegionType.BANGBOO_STORE:
             return self.round_success('非战斗区域')
         if self.region_type == LostVoidRegionType.FRIENDLY_TALK:
-            # 挚交会谈 刚开始时 先往右走一段距离 避开桌子
-            # 如果桌子旁有感叹号交互会走过去 交互之后往右后移动
-            # 如果桌子旁没有感叹号交互 可以直接走到后方的感叹号
-            self.ctx.controller.move_w(press=True, press_time=0.7, release=True)
-            self.ctx.controller.move_d(press=True, press_time=2, release=True)
             return self.round_success('非战斗区域')
         if self.region_type == LostVoidRegionType.ELITE:
             return self.round_success('战斗区域')
@@ -247,6 +239,7 @@ class LostVoidRunLevel(ZOperation):
         if self.last_screenshot_time - self.operation_start_time >= 600:  # 10分钟超时
             return self.round_fail(Operation.STATUS_TIMEOUT)
 
+        # 黄金魔神邦布开战前对话
         if self.boss_pre_battle:
             if self.is_boss_battle_started():
                 return self.enter_battle(end_boss_pre_battle=True)
@@ -256,6 +249,21 @@ class LostVoidRunLevel(ZOperation):
                 self.nothing_times = 0
                 self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
                 return self.round_success(LostVoidDetector.CLASS_INTERACT, wait=0.5)
+
+        # 挚交会谈初始化
+        if self.region_type == LostVoidRegionType.FRIENDLY_TALK:
+            # 有一个战略会在挚交会谈时奖励一个鸣徽 这个画面会在进入大世界一秒内触发(?)
+            if self.room_inited_times == 0:
+                self.room_inited_times = 1
+                return self.round_wait(wait=2)
+            elif self.room_inited_times == 1:
+                self.room_inited_times = 2
+                # 挚交会谈 刚开始时 先往右走一段距离 避开桌子
+                # 如果桌子旁有感叹号交互会走过去 交互之后往右后移动
+                # 如果桌子旁没有感叹号交互 可以直接走到后方的感叹号
+                self.ctx.controller.move_w(press=True, press_time=0.7, release=True)
+                self.ctx.controller.move_d(press=True, press_time=1.4, release=True)
+                log_utils.log('挚交会谈开局向右移动')
 
         # 在大世界 开始检测
         frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复/优化**
  * 改进了特定玩法的初始化与加载流程，重置与分阶段执行加载/定位逻辑以提升稳定性。
  * 调整了角色移动与开局定位的执行时序，减少异常情况与卡顿。

* **开发工具**
  * 增强了调试模式支持，可在启动时使用调试短路以加速测试与问题排查。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->