### PR TITLE
fix: 处理点击特定跳过按钮不生效的问题

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, ClassVar, List, Optional, cast
 import cv2
 import numpy as np
 
+from one_dragon.base.controller.pc_button.ds4_button_controller import Ds4ButtonEnum
+from one_dragon.base.controller.pc_button.xbox_button_controller import XboxButtonEnum
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.matcher.match_result import MatchResultList
 from one_dragon.base.operation.application import application_const
@@ -26,6 +28,7 @@ from zzz_od.application.coffee.coffee_config import (
     CoffeeConfig,
 )
 from zzz_od.application.zzz_application import ZApplication
+from zzz_od.config.game_config import GamepadTypeEnum
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.game_data.compendium import Coffee
 from zzz_od.operation.back_to_normal_world import BackToNormalWorld
@@ -283,11 +286,18 @@ class CoffeeApp(ZApplication):
         result = self.round_by_ocr(self.last_screenshot, '跳过', area=skip_area)
         if result.is_success:
             controller = cast('ZPcController', self.ctx.controller)
-            controller.btn_tap('esc')
+            skip_key = 'esc'
+            if controller.background_mode:
+                skip_key = (
+                    Ds4ButtonEnum.CIRCLE.value.value
+                    if self.ctx.game_config.background_gamepad_type == GamepadTypeEnum.DS4.value.value
+                    else XboxButtonEnum.B.value.value
+                )
+            controller.btn_tap(skip_key)
             result = self.round_by_ocr(self.screenshot(), '跳过', area=skip_area)
             if result.is_success:
-                controller.btn_tap('esc')
-            return self.round_wait('按ESC跳过', wait=0.5)
+                controller.btn_tap(skip_key)
+            return self.round_wait('按键跳过', wait=0.5)
 
         result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '不可贪杯确认')
         if result.is_success:

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -1,6 +1,6 @@
 import difflib
 import time
-from typing import ClassVar, List, Optional
+from typing import TYPE_CHECKING, ClassVar, List, Optional, cast
 
 import cv2
 import numpy as np
@@ -34,6 +34,9 @@ from zzz_od.operation.compendium.combat_simulation import CombatSimulation
 from zzz_od.operation.compendium.expert_challenge import ExpertChallenge
 from zzz_od.operation.transport import Transport
 from zzz_od.operation.wait_normal_world import WaitNormalWorld
+
+if TYPE_CHECKING:
+    from zzz_od.controller.zzz_pc_controller import ZPcController
 
 
 class CoffeeApp(ZApplication):
@@ -276,10 +279,15 @@ class CoffeeApp(ZApplication):
         if result.is_success:
             return self.round_success(result.status)
 
-        # 这个点击很怪 需要多点几次
-        result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '点单后跳过')
+        skip_area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
+        result = self.round_by_ocr(self.last_screenshot, '跳过', area=skip_area)
         if result.is_success:
-            return self.round_wait(result.status, wait=1)
+            controller = cast('ZPcController', self.ctx.controller)
+            controller.btn_tap('esc')
+            result = self.round_by_ocr(self.screenshot(), '跳过', area=skip_area)
+            if result.is_success:
+                controller.btn_tap('esc')
+            return self.round_wait('按ESC跳过', wait=0.5)
 
         result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '不可贪杯确认')
         if result.is_success:

--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
@@ -1,4 +1,5 @@
 import time
+from typing import TYPE_CHECKING, cast
 
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.geometry.rectangle import Rect
@@ -16,6 +17,9 @@ from zzz_od.application.suibian_temple.suibian_temple_config import (
 )
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
+
+if TYPE_CHECKING:
+    from zzz_od.controller.zzz_pc_controller import ZPcController
 
 
 class SuibianTempleBooBox(ZOperation):
@@ -252,11 +256,17 @@ class SuibianTempleBooBox(ZOperation):
         if any('聘用' in text for text in ocr_result_map):
             return self.round_success(status='已返回邦巢界面')
 
-        self.ctx.controller.click(
-            pos=self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过').center,
-            press_time=0.5,  # 长按一点
-        )
-        return self.round_wait(status='点击跳过', wait=0.5)
+        skip_area = self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过')
+        result = self.round_by_ocr(self.last_screenshot, '跳过', area=skip_area)
+        if result.is_success:
+            controller = cast('ZPcController', self.ctx.controller)
+            controller.btn_tap('esc')
+            result = self.round_by_ocr(self.screenshot(), '跳过', area=skip_area)
+            if result.is_success:
+                controller.btn_tap('esc')
+            return self.round_wait(status='点击跳过', wait=0.5)
+
+        return self.round_retry(status='未找到或未跳过', wait=0.5)
 
     @node_from(from_name='处理购买动画', status='点击跳过')
     @operation_node(name='返回界面')

--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
@@ -1,6 +1,8 @@
 import time
 from typing import TYPE_CHECKING, cast
 
+from one_dragon.base.controller.pc_button.ds4_button_controller import Ds4ButtonEnum
+from one_dragon.base.controller.pc_button.xbox_button_controller import XboxButtonEnum
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.geometry.rectangle import Rect
 from one_dragon.base.matcher.ocr import ocr_utils
@@ -15,6 +17,7 @@ from zzz_od.application.suibian_temple.suibian_temple_config import (
     BangbooPrice,
     SuibianTempleConfig,
 )
+from zzz_od.config.game_config import GamepadTypeEnum
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
 
@@ -260,10 +263,17 @@ class SuibianTempleBooBox(ZOperation):
         result = self.round_by_ocr(self.last_screenshot, '跳过', area=skip_area)
         if result.is_success:
             controller = cast('ZPcController', self.ctx.controller)
-            controller.btn_tap('esc')
+            skip_key = 'esc'
+            if controller.background_mode:
+                skip_key = (
+                    Ds4ButtonEnum.CIRCLE.value.value
+                    if self.ctx.game_config.background_gamepad_type == GamepadTypeEnum.DS4.value.value
+                    else XboxButtonEnum.B.value.value
+                )
+            controller.btn_tap(skip_key)
             result = self.round_by_ocr(self.screenshot(), '跳过', area=skip_area)
             if result.is_success:
-                controller.btn_tap('esc')
+                controller.btn_tap(skip_key)
             return self.round_wait(status='点击跳过', wait=0.5)
 
         return self.round_retry(status='未找到或未跳过', wait=0.5)


### PR DESCRIPTION
直接按下esc来跳过

cc @Usagi-wusaqi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了咖啡应用中的“点单后跳过”交互，改为基于屏幕文字检测后按键触发，提升准确性与稳定性。
  * 改进了购买动画中的跳过流程，加入文字识别校验并根据手柄类型选择相应按键触发跳过。
  * 在检测为跳过后会进行二次确认并重复触发以确保跳过成功，减少误操作。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneDragon-Anything/ZenlessZoneZero-OneDragon/pull/2280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->