### PR TITLE
[codex] add application init hook

### DIFF
--- a/src/one_dragon/base/operation/application_base.py
+++ b/src/one_dragon/base/operation/application_base.py
@@ -64,6 +64,8 @@ class Application(Operation):
         运行前初始化
         """
         Operation.handle_init(self)
+        self.handle_application_init()
+
         if self.run_record is not None:
             self.run_record.check_and_update_status()  # 先判断是否重置记录
             self.run_record.update_status(AppRunRecord.STATUS_RUNNING)
@@ -77,6 +79,14 @@ class Application(Operation):
             pool.max_images = 10 if notify_level >= NotifyLevel.ALL else 1
 
         self.ctx.dispatch_event(ApplicationEventId.APPLICATION_START.value, self.app_id)
+
+    def handle_application_init(self) -> None:
+        """
+        应用自定义初始化。
+
+        应用子类应重写这个方法，不要重写 handle_init，避免跳过应用运行记录、通知和事件。
+        """
+        pass
 
     def after_operation_done(self, result: OperationResult):
         """

--- a/src/one_dragon/base/operation/one_dragon_app.py
+++ b/src/one_dragon/base/operation/one_dragon_app.py
@@ -43,7 +43,7 @@ class OneDragonApp(Application):
         self._last_account_config: GameAccountConfig | None = None
         self._last_controller: ControllerBase | None = None
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/battle_assistant/auto_battle/auto_battle_app.py
+++ b/src/zzz_od/application/battle_assistant/auto_battle/auto_battle_app.py
@@ -29,7 +29,7 @@ class AutoBattleApp(ZApplication):
             op_name=auto_battle_const.APP_NAME,
         )
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/battle_assistant/dodge_assitant/dodge_assistant_app.py
+++ b/src/zzz_od/application/battle_assistant/dodge_assitant/dodge_assistant_app.py
@@ -25,7 +25,7 @@ class DodgeAssistantApp(ZApplication):
             op_name=dodge_assistant_const.APP_NAME,
         )
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -70,7 +70,7 @@ class CoffeeApp(ZApplication):
         self.had_coffee_list: set[str] = set()  # 已经喝过的咖啡
         self.turn_compensator: AngleTurnCompensator = AngleTurnCompensator(self.ctx.controller)
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/commission_assistant/commission_assistant_app.py
+++ b/src/zzz_od/application/commission_assistant/commission_assistant_app.py
@@ -52,7 +52,7 @@ class CommissionAssistantApp(ZApplication):
         self.fishing_btn_pressed: str | None = None  # 钓鱼在按下的按键
         self.fishing_done: bool = False  # 钓鱼是否结束 通常是比赛类 最后会有挑战结果显示
 
-    def handle_init(self):
+    def handle_application_init(self) -> None:
         self._listen_btn()
 
     def _unlisten_btn(self) -> None:

--- a/src/zzz_od/application/devtools/screenshot_helper/screenshot_helper_app.py
+++ b/src/zzz_od/application/devtools/screenshot_helper/screenshot_helper_app.py
@@ -44,12 +44,11 @@ class ScreenshotHelperApp(ZApplication):
         self.cache_max_count: int = 0  # 最大缓存数量
         self.is_saving_after_key: bool = False  # 是否正在保存按键后的截图
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用
         """
-        ZApplication.handle_init(self)
         length_second = self.config.length_second
         freq_second = self.config.frequency_second
         self.ctx.controller.screenshot_alive_seconds = length_second + 1

--- a/src/zzz_od/application/email_app/email_app.py
+++ b/src/zzz_od/application/email_app/email_app.py
@@ -21,7 +21,7 @@ class EmailApp(ZApplication):
             op_name=email_app_const.APP_NAME,
         )
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/hollow_zero/withered_domain/withered_domain_app.py
+++ b/src/zzz_od/application/hollow_zero/withered_domain/withered_domain_app.py
@@ -50,7 +50,7 @@ class WitheredDomainApp(ZApplication):
         self.level: int = 1
         self.phase: int = 1
 
-    def handle_init(self):
+    def handle_application_init(self) -> None:
         self.ctx.withered_domain.init_before_run()
         mission_name = self.config.mission_name
         idx = mission_name.find('-')

--- a/src/zzz_od/application/notorious_hunt/notorious_hunt_app.py
+++ b/src/zzz_od/application/notorious_hunt/notorious_hunt_app.py
@@ -41,7 +41,7 @@ class NotoriousHuntApp(ZApplication):
             instance_idx=self.ctx.current_instance_idx,
         )
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -46,7 +46,7 @@ class RandomPlayApp(ZApplication):
             group_id=application_const.DEFAULT_GROUP_ID,
         )
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用

--- a/src/zzz_od/application/redemption_code/redemption_code_app.py
+++ b/src/zzz_od/application/redemption_code/redemption_code_app.py
@@ -35,7 +35,7 @@ class RedemptionCodeApp(ZApplication):
         self.unused_code_list: List[str] = []
         self.code_idx: int = 0  # 当前输入兑换码的下标
 
-    def handle_init(self) -> None:
+    def handle_application_init(self) -> None:
         """
         执行前的初始化 由子类实现
         注意初始化要全面 方便一个指令重复使用


### PR DESCRIPTION
## Summary

- add `Application.handle_application_init()` as the subclass extension point for application-specific startup work
- keep `Application.handle_init()` responsible for run record, notify pool, start notification, and application start event dispatch
- migrate existing Application subclasses from `handle_init()` to `handle_application_init()` so framework lifecycle logic cannot be skipped by missing parent calls

## Why

Some Application subclasses override `handle_init()` without calling the parent implementation. That skips application-level lifecycle behavior such as setting the run record to running, clearing the notify pool, sending start notifications, and dispatching `APPLICATION_START` for UI refresh. The new hook preserves the historical placement of application startup logic in `handle_init()` while giving subclasses a safer place for custom initialization.

## Validation

- `uv run python -m compileall ...` on the modified files passed
- `git diff --check` passed
- `uv run ruff check ...` on the modified files was attempted, but existing lint in touched application files fails unrelated rules such as deprecated `typing.List`/`Optional`, unused imports, and SIM simplifications
