### PR TITLE
fix: 特训目标已达成时使其可提前跳过

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -491,6 +491,20 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 战斗结果-已达成
+    id_mark: false
+    pc_rect:
+    - 610
+    - 1000
+    - 690
+    - 1055
+    text: 已达成
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
   - area_name: 距离显示区域
     id_mark: false
     pc_rect:

--- a/assets/game_data/screen_info/battle.yml
+++ b/assets/game_data/screen_info/battle.yml
@@ -128,6 +128,20 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 战斗结果-已达成
+  id_mark: false
+  pc_rect:
+  - 610
+  - 1000
+  - 690
+  - 1055
+  text: 已达成
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
 - area_name: 距离显示区域
   id_mark: false
   pc_rect:

--- a/src/zzz_od/application/charge_plan/charge_plan_app.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_app.py
@@ -15,6 +15,9 @@ from zzz_od.application.charge_plan.charge_plan_run_record import ChargePlanRunR
 from zzz_od.application.zzz_application import ZApplication
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.back_to_normal_world import BackToNormalWorld
+from zzz_od.operation.challenge_mission.check_next_after_battle import (
+    ChooseNextOrFinishAfterBattle,
+)
 from zzz_od.operation.compendium.area_patrol import AreaPatrol
 from zzz_od.operation.compendium.combat_simulation import CombatSimulation
 from zzz_od.operation.compendium.expert_challenge import ExpertChallenge
@@ -196,6 +199,10 @@ class ChargePlanApp(ZApplication):
     @node_from(from_name='专业挑战室', status=ExpertChallenge.STATUS_CHARGE_NOT_ENOUGH)
     @node_from(from_name='恶名狩猎', status=NotoriousHunt.STATUS_CHARGE_NOT_ENOUGH)
     @node_from(from_name='恶名狩猎', status=NotoriousHunt.STATUS_BLOCKED_BY_LEFT_TIMES)
+    @node_from(from_name='实战模拟室', status=ChooseNextOrFinishAfterBattle.STATUS_AGENT_PLAN_FINISHED)
+    @node_from(from_name='区域巡防', status=ChooseNextOrFinishAfterBattle.STATUS_AGENT_PLAN_FINISHED)
+    @node_from(from_name='专业挑战室', status=ChooseNextOrFinishAfterBattle.STATUS_AGENT_PLAN_FINISHED)
+    @node_from(from_name='恶名狩猎', status=ChooseNextOrFinishAfterBattle.STATUS_AGENT_PLAN_FINISHED)
     @node_from(from_name='恢复电量', status=RestoreCharge.STATUS_CHARGE_NOT_ENOUGH)
     @node_from(from_name='传送', success=False, status='找不到 代理人方案培养')
     @operation_node(name='跳过或结束计划')

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -200,7 +200,6 @@ class AutoBattleContext:
         self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
-        self.last_check_in_battle: bool = False  # 是否在战斗画面 重置避免上一场遗留导致首帧被误判为刚离开战斗
         self.last_check_end_result: str | None = None  # 识别战斗结束的结果
         self.without_distance_times: int = 0  # 没有显示距离的次数
         self.with_distance_times: int = 0  # 有显示距离的次数

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -62,12 +62,19 @@ class AutoBattleContext:
         self._check_end_interval: float | list[float] = 5
         self._check_distance_interval: float | list[float] = 5
 
+        # 离开战斗画面后加快结算识别：结算的"再来一次/完成"按钮固定在离开约4秒后才出现
+        # 故离开后先维持常规间隔，超过延迟时长再切到更短间隔密集识别，识别到即停手，避免攻击键误触再来一次
+        # 连携、终结技等短过场（时长 < 延迟）不会进入密集识别，避免无谓的 OCR 开销
+        self._left_battle_check_delay: float = 3.5  # 离开战斗后开始密集识别的延迟
+        self._left_battle_check_interval: float = 0.1  # 延迟之后的结束识别间隔
+
         # 上一次识别的时间
         self._last_check_chain_time: float = 0
         self._last_check_quick_time: float = 0
         self._last_check_end_time: float = 0
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
+        self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
         self.last_check_in_battle: bool = False  # 是否在战斗画面
@@ -190,6 +197,7 @@ class AutoBattleContext:
         self._last_check_end_time: float = 0
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
+        self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
         self.last_check_end_result: str | None = None  # 识别战斗结束的结果
@@ -525,9 +533,15 @@ class AutoBattleContext:
     ) -> bool:
         """
         识别战斗状态的总入口
+        根据当前是否在战斗画面，分发各类识别任务（闪避/角色/连携/战斗结束等）
         :return: 当前是否在战斗画面
         """
         in_battle = self.is_normal_attack_btn_available(screen)
+        # 维护离开战斗的时间：进入战斗清空，刚离开则记录，供结算识别提速判断
+        if in_battle:
+            self._left_battle_time = None
+        elif self.last_check_in_battle:
+            self._left_battle_time = screenshot_time
         self.last_check_in_battle = in_battle
 
         future_list: list[Future] = []
@@ -793,7 +807,12 @@ class AutoBattleContext:
             return
 
         try:
-            if screenshot_time - self._last_check_end_time < cal_utils.random_in_range(self._check_end_interval):
+            # 离开战斗画面超过延迟时长后（结算按钮约此时出现），改用更短间隔密集识别，尽快停手避免后台模式攻击键误触再来一次
+            check_interval = self._check_end_interval
+            if (self._left_battle_time is not None
+                    and screenshot_time - self._left_battle_time >= self._left_battle_check_delay):
+                check_interval = self._left_battle_check_interval
+            if screenshot_time - self._last_check_end_time < cal_utils.random_in_range(check_interval):
                 # 还没有达到识别间隔
                 return
             self._last_check_end_time = screenshot_time

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -62,19 +62,12 @@ class AutoBattleContext:
         self._check_end_interval: float | list[float] = 5
         self._check_distance_interval: float | list[float] = 5
 
-        # 离开战斗画面后加快结算识别：结算的"再来一次/完成"按钮固定在离开约4秒后才出现
-        # 故离开后先维持常规间隔，超过延迟时长再切到更短间隔密集识别，识别到即停手，避免攻击键误触再来一次
-        # 连携、终结技等短过场（时长 < 延迟）不会进入密集识别，避免无谓的 OCR 开销
-        self._left_battle_check_delay: float = 3.5  # 离开战斗后开始密集识别的延迟
-        self._left_battle_check_interval: float = 0.1  # 延迟之后的结束识别间隔
-
         # 上一次识别的时间
         self._last_check_chain_time: float = 0
         self._last_check_quick_time: float = 0
         self._last_check_end_time: float = 0
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
-        self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
         self.last_check_in_battle: bool = False  # 是否在战斗画面
@@ -197,7 +190,6 @@ class AutoBattleContext:
         self._last_check_end_time: float = 0
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
-        self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
         self.last_check_end_result: str | None = None  # 识别战斗结束的结果
@@ -533,15 +525,9 @@ class AutoBattleContext:
     ) -> bool:
         """
         识别战斗状态的总入口
-        根据当前是否在战斗画面，分发各类识别任务（闪避/角色/连携/战斗结束等）
         :return: 当前是否在战斗画面
         """
         in_battle = self.is_normal_attack_btn_available(screen)
-        # 维护离开战斗的时间：进入战斗清空，刚离开则记录，供结算识别提速判断
-        if in_battle:
-            self._left_battle_time = None
-        elif self.last_check_in_battle:
-            self._left_battle_time = screenshot_time
         self.last_check_in_battle = in_battle
 
         future_list: list[Future] = []
@@ -807,12 +793,7 @@ class AutoBattleContext:
             return
 
         try:
-            # 离开战斗画面超过延迟时长后（结算按钮约此时出现），改用更短间隔密集识别，尽快停手避免后台模式攻击键误触再来一次
-            check_interval = self._check_end_interval
-            if (self._left_battle_time is not None
-                    and screenshot_time - self._left_battle_time >= self._left_battle_check_delay):
-                check_interval = self._left_battle_check_interval
-            if screenshot_time - self._last_check_end_time < cal_utils.random_in_range(check_interval):
+            if screenshot_time - self._last_check_end_time < cal_utils.random_in_range(self._check_end_interval):
                 # 还没有达到识别间隔
                 return
             self._last_check_end_time = screenshot_time

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -200,6 +200,7 @@ class AutoBattleContext:
         self._left_battle_time: float | None = None  # 最近一次离开战斗画面的时间 None表示尚未离开
 
         # 识别结果
+        self.last_check_in_battle: bool = False  # 是否在战斗画面 重置避免上一场遗留导致首帧被误判为刚离开战斗
         self.last_check_end_result: str | None = None  # 识别战斗结束的结果
         self.without_distance_times: int = 0  # 没有显示距离的次数
         self.with_distance_times: int = 0  # 有显示距离的次数

--- a/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
+++ b/src/zzz_od/operation/challenge_mission/check_next_after_battle.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
@@ -12,18 +14,32 @@ from zzz_od.operation.zzz_operation import ZOperation
 
 class ChooseNextOrFinishAfterBattle(ZOperation):
 
-    def __init__(self, ctx: ZContext, try_next: bool) -> None:
+    STATUS_AGENT_PLAN_FINISHED: ClassVar[str] = '特训目标已达成'
+
+    def __init__(self, ctx: ZContext, try_next: bool, is_agent_plan: bool = False) -> None:
         """
         在战斗结束画面 尝试点击 【再来一次】 或者 【结束】
         :param ctx: 上下文
         :param try_next: 是否尝试点击下一次
+        :param is_agent_plan: 当前是否特训目标(代理人方案培养) 用于判断是否已达成
         """
         ZOperation.__init__(self, ctx, op_name=gt('战斗后选择'))
         self.try_next: bool = try_next
+        self.is_agent_plan: bool = is_agent_plan
 
     @node_from(from_name='恢复电量', status='战斗结果-完成')
     @operation_node(name='判断再来一次', is_start_node=True)
     def check_next(self) -> OperationRoundResult:
+        # 特训目标(代理人方案培养)结算画面左下角显示“已达成”时 说明本条计划无需再打 直接点完成结束
+        if self.try_next and self.is_agent_plan:
+            result = self.round_by_find_area(self.last_screenshot, '战斗画面', '战斗结果-已达成')
+            if result.is_success:
+                result = self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-完成',
+                                                           success_wait=5, retry_wait=1)
+                if result.is_success:
+                    return self.round_success(status=ChooseNextOrFinishAfterBattle.STATUS_AGENT_PLAN_FINISHED)
+                return result
+
         if self.try_next:
             result = self.round_by_find_and_click_area(self.last_screenshot, '战斗画面', '战斗结果-再来一次',
                                                        success_wait=1, retry_wait=1)

--- a/src/zzz_od/operation/compendium/area_patrol.py
+++ b/src/zzz_od/operation/compendium/area_patrol.py
@@ -191,6 +191,7 @@ class AreaPatrol(ZOperation):
         op = ChooseNextOrFinishAfterBattle(
             self.ctx,
             self.plan.plan_times > self.plan.run_times,
+            is_agent_plan=self.plan.is_agent_plan,
         )
         return self.round_by_op_result(op.execute())
 

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -309,6 +309,7 @@ class CombatSimulation(ZOperation):
         op = ChooseNextOrFinishAfterBattle(
             self.ctx,
             self.plan.plan_times > self.plan.run_times,
+            is_agent_plan=self.plan.is_agent_plan,
         )
         return self.round_by_op_result(op.execute())
 

--- a/src/zzz_od/operation/compendium/expert_challenge.py
+++ b/src/zzz_od/operation/compendium/expert_challenge.py
@@ -169,6 +169,7 @@ class ExpertChallenge(ZOperation):
         op = ChooseNextOrFinishAfterBattle(
             self.ctx,
             self.plan.plan_times > self.plan.run_times,
+            is_agent_plan=self.plan.is_agent_plan,
         )
         return self.round_by_op_result(op.execute())
 

--- a/src/zzz_od/operation/compendium/notorious_hunt.py
+++ b/src/zzz_od/operation/compendium/notorious_hunt.py
@@ -423,7 +423,7 @@ class NotoriousHunt(ZOperation):
             try_next = self.plan.plan_times > self.plan.run_times
         else:
             try_next = self.can_run_times > 0
-        op = ChooseNextOrFinishAfterBattle(self.ctx, try_next)
+        op = ChooseNextOrFinishAfterBattle(self.ctx, try_next, is_agent_plan=self.plan.is_agent_plan)
         result = op.execute()
         if result.status == '战斗结果-完成' and self.can_run_times > 0:
             # 可能是其他设备挑战了 没有剩余次数了


### PR DESCRIPTION
# 自测通过

* [x]  功能测试通过
* [x]  回归测试通过

close #2247 
close #986 

<img width="1920" height="1080" alt="80b4eb9976d831af84ae9d4ca1a653ec" src="https://github.com/user-attachments/assets/b856e1f4-1840-4d46-b384-17e320f20c0b" />
<img width="1920" height="1080" alt="c27ca1ba8a2010de8dc69595642c06e0" src="https://github.com/user-attachments/assets/a9f6b577-fba6-48ce-840c-9347c931e999" />
<img width="1920" height="1080" alt="72078c3c541c72f5c96aa3d4f5706c7a" src="https://github.com/user-attachments/assets/446dd5cf-5968-4546-9c17-52d342c3b25b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加对战斗结算中“特训目标已达成/已达成”状态的识别与自动处理
  * 在实战模拟室、区域巡防、专业挑战室与恶名狩猎中支持该特殊结算流程

* **性能优化**
  * 优化离开战斗后的结算识别节奏，提高结算画面识别速度与响应稳定性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->