### PR TITLE
fix: 修复澄辉坪-汀曼咖啡偶发卡在对话点单

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1040,6 +1040,20 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 对话框标题-汀曼大师
+    id_mark: false
+    pc_rect:
+    - 880
+    - 800
+    - 1040
+    - 840
+    text: 汀曼大师
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
 - screen_id: combat_simulation
   screen_name: 实战模拟室
   pc_alt: false

--- a/assets/game_data/screen_info/coffee_shop.yml
+++ b/assets/game_data/screen_info/coffee_shop.yml
@@ -128,3 +128,17 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 对话框标题-汀曼大师
+  id_mark: false
+  pc_rect:
+  - 880
+  - 800
+  - 1040
+  - 840
+  text: 汀曼大师
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -315,6 +315,10 @@ class CoffeeApp(ZApplication):
     @operation_node(name='对话选咖啡', node_max_retry_times=20)
     def dialog_choose_coffee(self) -> OperationRoundResult:
         """处理澄辉坪-汀曼咖啡交互后的专属点单对话框，对话框包含"明天再来"（无选项）即视作已喝过"""
+        result = self.round_by_find_area(self.last_screenshot, '咖啡店', '对话框标题-汀曼大师')
+        if not result.is_success:
+            return self.round_retry(status='等待对话框加载', wait=0.5)  # issue #2301
+
         if self.round_by_find_area(self.last_screenshot, '咖啡店', '对话框-明天再来').is_success:
             return self.round_success(status='已喝过', wait=1)
 


### PR DESCRIPTION
close #2301 

测试通过

# 问题分析
如图所示，若配置的是“澄辉坪-汀曼咖啡”，传送落地并交互后，角色会自动往前走一段距离靠近摊子，随后才弹出“对话点单”。问题在于交互后没有任何wait行为，”对话选咖啡“的节点立即运作，且摊子旁边的牌匾上的“汀曼大师特调”这几个字刚好在“右侧选项区域”，“特调”被巧妙地识别并点击，导致后续流程完全卡住

指令[ 等待大世界画面 ] 节点 检测游戏窗口 返回状态 成功
指令[ 等待大世界画面 ] 节点 检测游戏窗口 -> 画面识别 返回状态 大世界-普通
指令[ 等待大世界画面 ] 执行成功 返回状态 大世界-普通
指令[ 咖啡店 ] 节点 传送 -> 等待大世界加载 返回状态 大世界-普通
指令[ 咖啡店 ] 节点 等待大世界加载 -> 移动交互 返回状态 对话点单
OCR结果 [] 耗时 0.03
OCR结果 ['20', '特调'] 耗时 0.09
指令[ 咖啡店 ] 节点 移动交互 -> 对话选咖啡 返回状态 已点单
OCR结果 [] 耗时 0.03
指令[ 咖啡店 ] 节点 对话选咖啡 -> 电量确认 返回状态 重试
OCR结果 [] 耗时 0.03
指令[ 咖啡店 ] 节点 对话选咖啡 -> 电量确认 返回状态 重试
OCR结果 [] 耗时 0.03
指令[ 咖啡店 ] 节点 对话选咖啡 -> 电量确认 返回状态 重试
OCR结果 [] 耗时 0.03
指令[ 咖啡店 ] 节点 对话选咖啡 -> 电量确认 返回状态 重试
指令[ 咖啡店 ] 执行失败 返回状态 失败

<img width="2560" height="1528" alt="8c563e0910d162587156d40083b4c26f" src="https://github.com/user-attachments/assets/9cf3aad2-afe8-413b-97eb-435042999ad2" />
<img width="2560" height="1528" alt="3b1b9b39ef1a656725d1f55df04b2af9" src="https://github.com/user-attachments/assets/142ecc1b-0231-454b-ab37-d11cda0e1963" />

# 修复结果
指令[ 等待大世界画面 ] 节点 检测游戏窗口 返回状态 成功
指令[ 等待大世界画面 ] 节点 检测游戏窗口 -> 画面识别 返回状态 大世界-普通
指令[ 等待大世界画面 ] 执行成功 返回状态 大世界-普通
指令[ 咖啡店 ] 节点 传送 -> 等待大世界加载 返回状态 大世界-普通
指令[ 咖啡店 ] 节点 等待大世界加载 -> 移动交互 返回状态 对话点单
OCR结果 [] 耗时 0.02
指令[ 咖啡店 ] 节点 移动交互 -> 对话选咖啡 返回状态 等待对话框加载
OCR结果 [] 耗时 0.03
指令[ 咖啡店 ] 节点 移动交互 -> 对话选咖啡 返回状态 等待对话框加载
OCR结果 ['汀曼大师'] 耗时 0.08
OCR结果 [] 耗时 0.03
OCR结果 [] 耗时 0.04
指令[ 咖啡店 ] 节点 移动交互 -> 对话选咖啡 返回状态 等待对话框
OCR结果 ['汀曼大师'] 耗时 0.08

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/552d5f39-ed27-405e-bc55-9481af1e7534" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 咖啡店对话框新增"汀曼大师"标题识别功能，系统现可准确识别该对话框并正确处理相关交互流程。

* **改进**
  * 优化咖啡点单流程，在执行后续操作前新增对话框标题加载验证机制，确保识别成功后再进行点单逻辑处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->