### PR TITLE
喝咖啡加速

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -272,9 +272,9 @@ class CoffeeApp(ZApplication):
         if result.is_success:
             self.had_coffee_list.add(self.chosen_coffee.coffee_name)
             if self.chosen_coffee.extra:
-                return self.round_success(status=CoffeeApp.STATUS_EXTRA_COFFEE, wait=1)
+                return self.round_success(status=CoffeeApp.STATUS_EXTRA_COFFEE, wait=0.5)
             elif self.chosen_coffee.without_benefit:
-                return self.round_success(status=CoffeeApp.STATUS_WITHOUT_BENEFIT, wait=1)
+                return self.round_success(status=CoffeeApp.STATUS_WITHOUT_BENEFIT, wait=0.5)
             else:
                 return self.round_success(wait=3)
         return self.round_retry(wait=1)
@@ -305,7 +305,7 @@ class CoffeeApp(ZApplication):
         result = self.round_by_find_area(self.last_screenshot, '咖啡店', '点单后跳过')
         if result.is_success:
             area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
-            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
+            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.2)
             self.ctx.controller.click()
             return self.round_success(result.status, wait=1)
 

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -307,7 +307,7 @@ class CoffeeApp(ZApplication):
             area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
             self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
             self.ctx.controller.click()
-            return self.round_success(result.status)
+            return self.round_success(result.status, wait=1)
 
         result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '不可贪杯确认')
         if result.is_success:

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -301,9 +301,13 @@ class CoffeeApp(ZApplication):
             return self.round_success(result.status)
 
         # 这个点击很怪 需要多点几次
-        result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '点单后跳过')
+        # 原因是绝区零逆天按钮, 需要先拖鼠标, 让鼠标显形才能点击
+        result = self.round_by_find_area(self.last_screenshot, '咖啡店', '点单后跳过')
         if result.is_success:
-            return self.round_wait(result.status, wait=1)
+            area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
+            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
+            self.ctx.controller.click()
+            return self.round_success(result.status)
 
         result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '不可贪杯确认')
         if result.is_success:

--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_boo_box.py
@@ -252,10 +252,10 @@ class SuibianTempleBooBox(ZOperation):
         if any('聘用' in text for text in ocr_result_map):
             return self.round_success(status='已返回邦巢界面')
 
-        self.ctx.controller.click(
-            pos=self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过').center,
-            press_time=0.5,  # 长按一点
-        )
+        # 绝区零逆天按钮, 需要先拖鼠标, 让鼠标显形才能点击
+        area = self.ctx.screen_loader.get_area('随便观-邦巢', '按钮-跳过')
+        self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.2)
+        self.ctx.controller.click()
         return self.round_wait(status='点击跳过', wait=0.5)
 
     @node_from(from_name='处理购买动画', status='点击跳过')

--- a/src/zzz_od/operation/eat_noodle.py
+++ b/src/zzz_od/operation/eat_noodle.py
@@ -89,9 +89,13 @@ class EatNoodle(ZOperation):
             return self.round_success(result.status, wait=1)
 
         # 这个点击很怪 需要多点几次 直到出现效果确认
-        result = self.round_by_find_and_click_area(self.last_screenshot, '咖啡店', '点单后跳过')
+        # 原因是绝区零逆天按钮, 需要先拖鼠标, 让鼠标显形才能点击
+        result = self.round_by_find_area(self.last_screenshot, '咖啡店', '点单后跳过')
         if result.is_success:
-            return self.round_wait(result.status, wait=1)
+            area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
+            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
+            self.ctx.controller.click()
+            return self.round_success(result.status)
 
         return self.round_retry(result.status, wait=1)
 

--- a/src/zzz_od/operation/eat_noodle.py
+++ b/src/zzz_od/operation/eat_noodle.py
@@ -95,7 +95,7 @@ class EatNoodle(ZOperation):
             area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
             self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
             self.ctx.controller.click()
-            return self.round_success(result.status)
+            return self.round_success(result.status, wait=1)
 
         return self.round_retry(result.status, wait=1)
 

--- a/src/zzz_od/operation/eat_noodle.py
+++ b/src/zzz_od/operation/eat_noodle.py
@@ -79,7 +79,7 @@ class EatNoodle(ZOperation):
     @operation_node(name='点单后确认')
     def confirm_after_order(self) -> OperationRoundResult:
         return self.round_by_find_and_click_area(self.last_screenshot, '拉面店', '点单确认',
-                                                 success_wait=1, retry_wait=1)
+                                                 success_wait=0.5, retry_wait=1)
 
     @node_from(from_name='点单后确认')
     @operation_node(name='点单后跳过')
@@ -93,7 +93,7 @@ class EatNoodle(ZOperation):
         result = self.round_by_find_area(self.last_screenshot, '咖啡店', '点单后跳过')
         if result.is_success:
             area = self.ctx.screen_loader.get_area('咖啡店', '点单后跳过')
-            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.5)
+            self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.2)
             self.ctx.controller.click()
             return self.round_success(result.status, wait=1)
 


### PR DESCRIPTION
修复六分街拉面店 (未测试) 和咖啡店 (已测试一个号) 的点单后跳过按钮点不上的bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化“点单后跳过/点单后确认”的交互时序：在成功识别后先进行短时拖拽使光标显形，再立即点击，提升操作稳定性与成功率。
  * 调整部分成功分支的等待时长（例如由 1 缩短为 0.5），减少误判与无效重试。
  * 优化部分跳过按钮的触发方式：从定点长按改为拖拽到按钮区域后执行普通点击，进一步提升一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->