### PR TITLE
fix: 修复启动器版本输出编码异常

### DIFF
--- a/src/one_dragon/launcher/exe_launcher.py
+++ b/src/one_dragon/launcher/exe_launcher.py
@@ -1,8 +1,6 @@
 import argparse
 import sys
 
-import pyuac
-
 from one_dragon.launcher.launcher_base import LauncherBase
 
 
@@ -19,8 +17,8 @@ class ExeLauncher(LauncherBase):
         parser.add_argument("-o", "--onedragon", action="store_true", help="一条龙运行")
 
     def show_version(self) -> None:
-        """显示版本信息"""
-        print(f"{self.description} {self.version}")
+        """仅输出版本号"""
+        print(self.version)
         sys.exit(0)
 
     def build_launch_args(self, args) -> list[str]:
@@ -51,6 +49,8 @@ class ExeLauncher(LauncherBase):
         if not args.onedragon and (args.close_game or args.shutdown or args.instance):
             print("错误：参数 --close-game, --shutdown, --instance 只能在指定 --onedragon 时使用")
             sys.exit(1)
+
+        import pyuac
 
         if not pyuac.isUserAdmin():
             pyuac.runAsAdmin(sys.argv, wait=False)

--- a/tests/one_dragon/launcher/test_exe_launcher.py
+++ b/tests/one_dragon/launcher/test_exe_launcher.py
@@ -1,0 +1,25 @@
+import io
+import sys
+
+import pytest
+
+from one_dragon.launcher.exe_launcher import ExeLauncher
+
+
+def test_show_version_writes_ascii_version_under_legacy_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    buffer = io.BytesIO()
+    stdout = io.TextIOWrapper(buffer, encoding='cp1252', errors='strict')
+
+    try:
+        monkeypatch.setattr(sys, 'stdout', stdout)
+        with pytest.raises(SystemExit) as exc_info:
+            ExeLauncher('绝区零 一条龙 启动器', 'v2.3.3').show_version()
+        stdout.flush()
+        output = buffer.getvalue().decode('cp1252').strip()
+    finally:
+        stdout.close()
+
+    assert exc_info.value.code == 0
+    assert output == 'v2.3.3'


### PR DESCRIPTION
## 问题

官方打包的 `OneDragon-Launcher.exe --version` 会输出中文启动器名称和版本号。在部分 Windows 环境中，stdout 编码无法表示中文字符，会触发 `UnicodeEncodeError`，导致版本读取失败。

版本读取失败后，界面会把当前启动器版本识别为空字符串，从而误判为“启动器未安装”。

## 修改

- 将启动器 `--version` 输出调整为仅输出版本号，例如 `v2.3.3`。
- 新增回归测试，模拟 `cp1252` 编码的 stdout，确保中文启动器名称存在时也不会影响版本输出。

## 验证

```powershell
$env:PYTHONPATH='C:\Users\pengx\Documents\GitHub\ZenlessZoneZero-OneDragon\src'
C:\ZZZ-OD\.venv\Scripts\python.exe -m pytest tests\one_dragon\launcher\test_exe_launcher.py
```

结果：`1 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复版本显示在非 UTF-8/历史编码环境下的兼容性问题，并调整版本输出内容为仅显示版本号。

* **Tests**
  * 新增在遗留 stdout 编码（如 cp1252）下的版本显示测试用例，验证输出版本字符串与退出状态是否正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->