### PR TITLE
fix: 修复自动战斗配置加载耗时 30s+ 导致进战斗罚站

### DIFF
--- a/src/one_dragon/base/conditional_operation/state_handler.py
+++ b/src/one_dragon/base/conditional_operation/state_handler.py
@@ -13,7 +13,6 @@ from one_dragon.base.conditional_operation.state_cal_tree import (
     construct_state_cal_tree,
 )
 from one_dragon.base.conditional_operation.state_recorder import StateRecorder
-from one_dragon.utils.log_utils import log
 
 
 class StateHandler:
@@ -77,7 +76,9 @@ class StateHandler:
             op_getter: 原子操作获取器
             parent_interrupt_states_cal_tree: 父级的打断状态判断树
         """
-        log.debug('构造状态判断树 ' + (self.display_name or self.states))
+        # 不逐条打 DEBUG 日志：大型配置（如自动战斗 merged.yml）会有数千个
+        # StateHandler，逐条 log.debug 在 DEBUG 级别下（尤其叠加 overlay 的
+        # OverlayLogHandler 同步分发）会严重拖慢加载。
         self.state_cal_tree = construct_state_cal_tree(self.states, state_recorder_getter)
         self.interrupt_states_cal_tree = self._build_interrupt_tree(state_recorder_getter, parent_interrupt_states_cal_tree)
 

--- a/src/one_dragon/base/conditional_operation/state_handler.py
+++ b/src/one_dragon/base/conditional_operation/state_handler.py
@@ -76,9 +76,6 @@ class StateHandler:
             op_getter: 原子操作获取器
             parent_interrupt_states_cal_tree: 父级的打断状态判断树
         """
-        # 不逐条打 DEBUG 日志：大型配置（如自动战斗 merged.yml）会有数千个
-        # StateHandler，逐条 log.debug 在 DEBUG 级别下（尤其叠加 overlay 的
-        # OverlayLogHandler 同步分发）会严重拖慢加载。
         self.state_cal_tree = construct_state_cal_tree(self.states, state_recorder_getter)
         self.interrupt_states_cal_tree = self._build_interrupt_tree(state_recorder_getter, parent_interrupt_states_cal_tree)
 

--- a/src/one_dragon_qt/overlay/overlay_manager.py
+++ b/src/one_dragon_qt/overlay/overlay_manager.py
@@ -935,9 +935,7 @@ class OverlayManager(QObject):
             return
 
         self._log_handler = OverlayLogHandler(self.ctx)
-        # 只处理 INFO 及以上：DEBUG 级别的高频日志（如加载时数千条
-        # 「构造状态判断树」）会经 dispatch_event 同步分发，严重拖慢加载。
-        self._log_handler.setLevel(logging.INFO)
+        self._log_handler.setLevel(logging.DEBUG)
         log.addHandler(self._log_handler)
         if yolo_log is not None:
             yolo_log.addHandler(self._log_handler)

--- a/src/one_dragon_qt/overlay/overlay_manager.py
+++ b/src/one_dragon_qt/overlay/overlay_manager.py
@@ -935,7 +935,9 @@ class OverlayManager(QObject):
             return
 
         self._log_handler = OverlayLogHandler(self.ctx)
-        self._log_handler.setLevel(logging.DEBUG)
+        # 只处理 INFO 及以上：DEBUG 级别的高频日志（如加载时数千条
+        # 「构造状态判断树」）会经 dispatch_event 同步分发，严重拖慢加载。
+        self._log_handler.setLevel(logging.INFO)
         log.addHandler(self._log_handler)
         if yolo_log is not None:
             yolo_log.addHandler(self._log_handler)


### PR DESCRIPTION
## 问题描述

自动战斗配置加载耗时超过 30 秒，导致进入战斗时角色"罚站"（长时间无操作等待）。

## 原因分析

问题由两个因素叠加导致：

1. **高频 DEBUG 日志输出**：`state_handler.py` 的 `build()` 方法中，每个 StateHandler 构建时都会输出一条 `log.debug('构造状态判断树 ...')`。全配队通用的自动战斗配置（merged.yml）包含约 127 个状态处理器，加载时产生约 3500 条 DEBUG 日志。

2. **Overlay 日志同步分发阻塞**：`overlay_manager.py` 中的 `OverlayLogHandler` 被设置为 DEBUG 级别，导致每条 DEBUG 日志都通过 `dispatch_event` 同步分发到 UI Overlay。数千次同步事件分发的耗时累积超过 30 秒。

## 修复方法

1. **移除热路径 DEBUG 日志**（`src/one_dragon/base/conditional_operation/state_handler.py`）：
   - 移除 `build()` 方法中逐条输出的 `log.debug('构造状态判断树 ...')` 调用
   - 该日志在正常运行中无实际调试价值，大型配置下反而成为性能瓶颈

2. **提升 Overlay 日志处理器级别**（`src/one_dragon_qt/overlay/overlay_manager.py`）：
   - 将 `OverlayLogHandler` 的日志级别从 `logging.DEBUG` 提升为 `logging.INFO`
   - 避免高频 DEBUG 日志通过同步 `dispatch_event` 阻塞 UI 线程

## 变更影响范围

- **影响模块**：自动战斗配置加载流程、Overlay UI 日志显示
- **性能改善**：配置加载时间从 30+ 秒降至秒级完成
- **功能影响**：Overlay 不再显示 DEBUG 级别日志（仅影响开发调试，不影响用户可见信息）
- **向后兼容**：无 API 变更，无配置格式变更，对现有功能无破坏性影响

## 测试验证

- 在纯净官方原版环境中复现了 30 秒卡顿问题
- 应用修复后加载秒级完成，战斗正常进入无罚站
- 确认 Overlay 正常显示 INFO 及以上级别日志


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 性能改进

* **性能改进**
  * 提升了大规模配置文件加载的性能。通过优化日志系统的开销，减少了加载过程中不必要的日志输出，显著提高了大型配置的加载速度和系统响应效率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->