### PR TITLE
fix: 适配3.0快捷手册Tab与分类列表区域下移

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1586,9 +1586,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1602,7 +1602,7 @@
     - 164
     - 287
     - 429
-    - 870
+    - 1055
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1800,9 +1800,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 训练
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1815,9 +1815,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 目标
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1830,9 +1830,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 日常
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1845,9 +1845,9 @@
     id_mark: true
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 作战
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1866,9 +1866,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 战术
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1901,9 +1901,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 训练
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1916,9 +1916,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 目标
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1931,9 +1931,9 @@
     id_mark: true
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 日常
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1952,9 +1952,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 作战
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1967,9 +1967,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 战术
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2002,9 +2002,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 训练
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2017,9 +2017,9 @@
     id_mark: true
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 目标
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2038,9 +2038,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 日常
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2053,9 +2053,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 作战
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2068,9 +2068,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 战术
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2103,9 +2103,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 训练
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2118,9 +2118,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 目标
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2133,9 +2133,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 日常
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2148,9 +2148,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 作战
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2163,9 +2163,9 @@
     id_mark: true
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 战术
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2204,9 +2204,9 @@
     id_mark: true
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 训练
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2225,9 +2225,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 目标
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2240,9 +2240,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 日常
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2255,9 +2255,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 作战
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2270,9 +2270,9 @@
     id_mark: false
     pc_rect:
     - 708
-    - 140
+    - 160
     - 1636
-    - 220
+    - 270
     text: 战术
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium.yml
+++ b/assets/game_data/screen_info/compendium.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -22,7 +22,7 @@ area_list:
   - 164
   - 287
   - 429
-  - 870
+  - 1055
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_combat.yml
+++ b/assets/game_data/screen_info/compendium_combat.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 训练
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -21,9 +21,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 目标
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -36,9 +36,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 日常
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -51,9 +51,9 @@ area_list:
   id_mark: true
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 作战
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -72,9 +72,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 战术
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_errands.yml
+++ b/assets/game_data/screen_info/compendium_errands.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 训练
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -21,9 +21,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 目标
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -36,9 +36,9 @@ area_list:
   id_mark: true
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 日常
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -57,9 +57,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 作战
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -72,9 +72,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 战术
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_primer.yml
+++ b/assets/game_data/screen_info/compendium_primer.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 训练
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -21,9 +21,9 @@ area_list:
   id_mark: true
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 目标
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -42,9 +42,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 日常
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -57,9 +57,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 作战
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -72,9 +72,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 战术
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_tactics.yml
+++ b/assets/game_data/screen_info/compendium_tactics.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 训练
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -21,9 +21,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 目标
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -36,9 +36,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 日常
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -51,9 +51,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 作战
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -66,9 +66,9 @@ area_list:
   id_mark: true
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 战术
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_training.yml
+++ b/assets/game_data/screen_info/compendium_training.yml
@@ -6,9 +6,9 @@ area_list:
   id_mark: true
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 训练
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -27,9 +27,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 目标
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -42,9 +42,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 日常
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -57,9 +57,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 作战
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -72,9 +72,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 708
-  - 140
+  - 160
   - 1636
-  - 220
+  - 270
   text: 战术
   lcs_percent: 0.5
   template_sub_dir: ''


### PR DESCRIPTION
## 问题
3.0 更新后，体力刷本（以及其它经快捷手册传送的流程）在「传送 快捷手册」步骤报 `未能识别当前画面` 失败，无法进入恶名狩猎等副本。

## 根因
3.0 将快捷手册顶部 Tab 栏与左侧分类列表整体下移。#2342 已调过 Tab 区域，但实测仍偏高：

- Tab 识别区当前为 `[708,140,1636,220]`，而 1080p 下「训练」等 Tab 实际位于 y≈173-258，该区域内 OCR 不到任何 Tab 文字（金色滤镜后为空）→ `快捷手册-训练` 等画面无法识别。
- 左侧「分类列表」区域 y 底为 `870`，而「恶名狩猎」等靠下分类实际位于 y≈1021，超出区域 → 分类选择报 `找不到 XXX`。

## 修复
- 快捷手册各 Tab 识别区（目标/日常/训练/作战/战术）：y `140-220` → `160-270`
- 快捷手册「分类列表」区域：y 底 `870` → `1055`
- 同步更新 `_od_merged.yml`

## 验证
1080p（2048×1152 缩放至 1920×1080）实测：训练 Tab 实际 y173-258、恶名狩猎分类 y1021，均落在修复后区域内。实跑「体力刷本 → 恶名狩猎 → 基塔布鲁」整条链路通过（识别 Tab → 选分类 → 选副本 → 传送 → 进入战斗）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **调整优化**
  * 更新快捷手册各界面的显示区域配置，包括选项卡及分类列表的布局坐标调整，优化界面显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->