### PR TITLE
feat: 3.0的快捷手册关闭按钮(减少不同分辨率点歪的可能性)

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1697,10 +1697,10 @@
   - area_name: 按钮-退出
     id_mark: false
     pc_rect:
-    - 1730
-    - 206
-    - 1794
-    - 266
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1880,10 +1880,10 @@
   - area_name: 按钮-关闭
     id_mark: false
     pc_rect:
-    - 1728
-    - 206
-    - 1796
-    - 268
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1981,10 +1981,10 @@
   - area_name: 按钮-关闭
     id_mark: false
     pc_rect:
-    - 1728
-    - 206
-    - 1796
-    - 268
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2082,10 +2082,10 @@
   - area_name: 按钮-关闭
     id_mark: false
     pc_rect:
-    - 1728
-    - 206
-    - 1796
-    - 268
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2183,10 +2183,10 @@
   - area_name: 按钮-关闭
     id_mark: false
     pc_rect:
-    - 1728
-    - 206
-    - 1796
-    - 268
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -2284,10 +2284,10 @@
   - area_name: 按钮-关闭
     id_mark: false
     pc_rect:
-    - 1728
-    - 206
-    - 1796
-    - 268
+    - 1721
+    - 229
+    - 1799
+    - 307
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium.yml
+++ b/assets/game_data/screen_info/compendium.yml
@@ -117,10 +117,10 @@ area_list:
 - area_name: 按钮-退出
   id_mark: false
   pc_rect:
-  - 1730
-  - 206
-  - 1794
-  - 266
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_combat.yml
+++ b/assets/game_data/screen_info/compendium_combat.yml
@@ -86,10 +86,10 @@ area_list:
 - area_name: 按钮-关闭
   id_mark: false
   pc_rect:
-  - 1728
-  - 206
-  - 1796
-  - 268
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_errands.yml
+++ b/assets/game_data/screen_info/compendium_errands.yml
@@ -86,10 +86,10 @@ area_list:
 - area_name: 按钮-关闭
   id_mark: false
   pc_rect:
-  - 1728
-  - 206
-  - 1796
-  - 268
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_primer.yml
+++ b/assets/game_data/screen_info/compendium_primer.yml
@@ -86,10 +86,10 @@ area_list:
 - area_name: 按钮-关闭
   id_mark: false
   pc_rect:
-  - 1728
-  - 206
-  - 1796
-  - 268
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_tactics.yml
+++ b/assets/game_data/screen_info/compendium_tactics.yml
@@ -86,10 +86,10 @@ area_list:
 - area_name: 按钮-关闭
   id_mark: false
   pc_rect:
-  - 1728
-  - 206
-  - 1796
-  - 268
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_training.yml
+++ b/assets/game_data/screen_info/compendium_training.yml
@@ -86,10 +86,10 @@ area_list:
 - area_name: 按钮-关闭
   id_mark: false
   pc_rect:
-  - 1728
-  - 206
-  - 1796
-  - 268
+  - 1721
+  - 229
+  - 1799
+  - 307
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **数据更新**
  * 更新了快捷手册多个页面的退出/关闭按钮识别区域，包括：主手册、战斗手册、委托手册、入门手册、战术手册和训练手册。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->