### PR TITLE
fix: 修复自动战斗启动失败导致罚站

### DIFF
--- a/src/one_dragon/base/conditional_operation/operator.py
+++ b/src/one_dragon/base/conditional_operation/operator.py
@@ -52,7 +52,8 @@ class ConditionalOperator(ConditionalOperatorLoader):
         self.current_execution_info: ExecutionInfo | None = None  # 当前的执行信息
         self.running_executor: OperationExecutor | None = None  # 正在运行的任务
         self.running_executor_cnt: AtomicInt = AtomicInt()  # 统计有
-        
+        self._pending_stop_decs: int = 0  # 记录 _stop_running_task 提前递减的次数
+
         self._inited: bool = False
         self._task_lock: Lock = Lock()
 
@@ -262,6 +263,7 @@ class ConditionalOperator(ConditionalOperatorLoader):
                 # 如果 finish=True 则计数器已经在 _on_task_done 减少了 这里就不减了
                 # 如果 finish=False 则代表还有操作在继续。在这里要减少计数器而不是等_on_task_done 让无触发器场景尽早运行
                 self.running_executor_cnt.dec()
+                self._pending_stop_decs += 1  # 记录这次提前递减 防止 _on_task_done 双重递减
             self.running_executor = None
 
     def _on_task_done(self, future: Future) -> None:
@@ -273,8 +275,19 @@ class ConditionalOperator(ConditionalOperatorLoader):
                 result = future.result()
                 if result:  # 顺利执行完毕
                     self.running_executor_cnt.dec()
+                else:
+                    # 被 _stop_running_task 提前停止时 已经递减过了 消耗掉标记即可
+                    if self._pending_stop_decs > 0:
+                        self._pending_stop_decs -= 1
+                    else:
+                        # op_list 为空等情况返回 False 需要递减计数器 否则主循环永远阻塞
+                        self.running_executor_cnt.dec()
             except Exception:  # run_async里有callback打印日志
-                pass
+                if self._pending_stop_decs > 0:
+                    self._pending_stop_decs -= 1
+                else:
+                    # 异常路径同样需要递减计数器 防止 running_executor_cnt 永远 > 0 导致死锁
+                    self.running_executor_cnt.dec()
 
     @cached_property
     def usage_states(self) -> set[str]:

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -99,6 +99,9 @@ class AutoBattleContext:
         read_from_merged = self.ctx.battle_assistant_config.use_merged_file
         if read_from_merged and key in self._op_cache:
             self.auto_op = self._op_cache[key]
+            # 从缓存取出时，确保 is_running 已清理，防止上次异常退出残留标志
+            if self.auto_op.is_running:
+                self.auto_op.stop_running()
         else:
             self.auto_op = AutoBattleOperator(
                 ctx=self,
@@ -143,7 +146,6 @@ class AutoBattleContext:
         """
         if self.auto_op is not None:
             # 清空之前检测到的状态
-
             self.auto_op.start_running_async()
             self.start_context_async()
             self.clear_all_states()


### PR DESCRIPTION
Closes #2324, #2325

### 原因
缓存复用的 AutoBattleOperator 可能残留 is_running=True 状态，导致 start_running_async() 静默失败，主循环不启动。同时 _on_task_done 在异常路径未递减 running_executor_cnt，计数器泄漏进一步阻塞后续启动。

### 修复
- auto_battle_context.py: 从缓存取出 operator 时检查并清理 is_running
- operator.py: _on_task_done 在 result=False 和异常路径补充 running_executor_cnt 递减

### 影响范围
自动战斗启动流程（战斗助手、体力刷本等所有调用 start_auto_battle 的场景）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* 修复自动任务/执行过程中计数与停止流程不同步导致的等待卡住问题，提升运行稳定性与异常恢复能力。  
* 改进自动战斗恢复：当检测到缓存的运行状态仍未结束时，会先清理残留运行信息再继续，减少对后续执行的干扰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->