### PR TITLE
fix: 修复选择编队节点死循环

### DIFF
--- a/src/zzz_od/operation/choose_predefined_team.py
+++ b/src/zzz_od/operation/choose_predefined_team.py
@@ -52,7 +52,7 @@ class ChoosePredefinedTeam(ZOperation):
 
     @node_from(from_name='点击预备编队')
     @node_from(from_name='尝试查找编队')
-    @operation_node(name='选择编队')
+    @operation_node(name='选择编队', timeout_seconds=30)
     def choose_team(self) -> OperationRoundResult:
         area = self.ctx.screen_loader.get_area('实战模拟室', '预备出战')
         result = self.round_by_ocr(self.last_screenshot, '预备出战', area=area,


### PR DESCRIPTION
Closes #2327

### 原因
choose_team 节点在未找到预备出战按钮时持续 round_wait，而 round_wait 不计入 node_max_retry_times，导致无限等待。

### 修复
为 choose_team 节点添加 timeout_seconds=30 超时保护

### 影响范围
所有使用预备编队选择的场景（体力刷本、式舆防卫战等）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 为编队选择操作设置 30 秒超时限制，防止操作无限期等待。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->