### PR TITLE
fix: 修复咖啡店点单后节点路由错误

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -294,6 +294,7 @@ class CoffeeApp(ZApplication):
 
     @node_from(from_name='点单')
     @node_from(from_name='不占用点单确认')
+    @node_from(from_name='对话选咖啡', status='已点单')
     @operation_node(name='点单后跳过')
     def skip_after_order(self) -> OperationRoundResult:
         result = self.round_by_find_area(self.last_screenshot, '咖啡店', '电量确认')
@@ -338,7 +339,6 @@ class CoffeeApp(ZApplication):
         return self.round_retry(status='等待对话框', wait=1)
 
     @node_from(from_name='点单后跳过')
-    @node_from(from_name='对话选咖啡', status='已点单')
     @node_notify(when=NotifyTiming.CURRENT_SUCCESS)
     @operation_node(name='电量确认')
     def charge_confirm(self) -> OperationRoundResult:


### PR DESCRIPTION
Closes #2328

### 原因
@node_from(from_name='对话选咖啡', status='已点单') 指向 charge_confirm 而非 skip_after_order，导致点单后跳过了动画处理节点。

### 修复
将该 @node_from 从 charge_confirm 移到 skip_after_order

### 影响范围
咖啡店自动化（coffee_app）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了咖啡点单完成后的流程处理逻辑，确保跳过确认步骤的流程能正确执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->