### PR TITLE
fix: 预备编队识别、UI刷新、下拉框溢出、战斗结算卡死

### DIFF
--- a/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
+++ b/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
@@ -85,6 +85,7 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
                 self.combo_box.addItem(opt_item.ui_text, userData=opt_item.value)
 
     def showEvent(self, event: QEvent) -> None:
+        """首次显示后收窄说明文字。"""
         super().showEvent(event)
         if self._content_shrink:
             self._shrink_content()

--- a/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
+++ b/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
@@ -31,6 +31,7 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
                  options_enum: Optional[Iterable[Enum]] = None,
                  options_list: Optional[List[ConfigItem]] = None,
                  tooltip: Optional[str] = None,
+                 content_shrink: bool = False,
                  parent=None
                  ):
 
@@ -50,6 +51,7 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
         self.combo_box = ComboBox(self)
         self.hBoxLayout.addWidget(self.combo_box, 0, Qt.AlignmentFlag.AlignRight)
         self.hBoxLayout.addSpacing(16)
+        self._content_shrink = content_shrink
 
         # 处理工具提示
         self.tooltip_text: str = tooltip
@@ -81,6 +83,22 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
             for opt_item in options_list:
                 self._opts_list.append(opt_item)
                 self.combo_box.addItem(opt_item.ui_text, userData=opt_item.value)
+
+    def showEvent(self, event: QEvent) -> None:
+        super().showEvent(event)
+        if self._content_shrink:
+            self._shrink_content()
+
+    def _shrink_content(self) -> None:
+        """下拉框变宽时收窄说明文字，右边界不动、下拉框文字完整显示"""
+        card_w = self.width()
+        if card_w <= 0:
+            return
+        combo_w = self.combo_box.sizeHint().width()
+        max_content = card_w - 80 - combo_w
+        if max_content < 40:
+            max_content = 40
+        self.contentLabel.setMaximumWidth(max_content)
 
     def eventFilter(self, obj, event: QEvent) -> bool:
         """处理标题标签的鼠标事件。"""
@@ -140,6 +158,8 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
             return
 
         self.last_index = index
+        if self._content_shrink:
+            self._shrink_content()
         self._update_desc()
         val = self.combo_box.itemData(index)
 
@@ -174,6 +194,8 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
         if not emit_signal:
             self.combo_box.blockSignals(False)
         self._update_desc()
+        if self._content_shrink:
+            self._shrink_content()
 
     def getValue(self) -> object:
         """获取当前选中的值。"""

--- a/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
+++ b/src/one_dragon_qt/widgets/setting_card/combo_box_setting_card.py
@@ -1,4 +1,5 @@
 from PySide6.QtCore import QEvent
+from PySide6.QtGui import QResizeEvent
 from PySide6.QtCore import Qt
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QColor
@@ -87,6 +88,12 @@ class ComboBoxSettingCard(SettingCardBase, AdapterInitMixin):
     def showEvent(self, event: QEvent) -> None:
         """首次显示后收窄说明文字。"""
         super().showEvent(event)
+        if self._content_shrink:
+            self._shrink_content()
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        """窗口尺寸变化时重新收窄说明文字。"""
+        super().resizeEvent(event)
         if self._content_shrink:
             self._shrink_content()
 

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -561,18 +561,18 @@ class AutoBattleContext:
             # 连携
             future_list.append(_battle_state_check_executor.submit(self.check_chain_attack, screen, screenshot_time))
 
-            # 战斗结束
-            check_battle_end = check_battle_end_normal_result or check_battle_end_hollow_result or check_battle_end_defense_result
-            if check_battle_end:
-                if self.ctx.model_config.ocr_use_gpu:
-                    executor = gpu_executor
-                else:
-                    executor = _battle_state_check_executor
-                future_list.append(executor.submit(
-                    self._check_battle_end,
-                    screen, screenshot_time,
-                    check_battle_end_normal_result, check_battle_end_hollow_result, check_battle_end_defense_result
-                ))
+        # 战斗结束 — 不受 in_battle 限制，防止攻击按钮误匹配结算画面导致永不检测结束
+        check_battle_end = check_battle_end_normal_result or check_battle_end_hollow_result or check_battle_end_defense_result
+        if check_battle_end:
+            if self.ctx.model_config.ocr_use_gpu:
+                executor = gpu_executor
+            else:
+                executor = _battle_state_check_executor
+            future_list.append(executor.submit(
+                self._check_battle_end,
+                screen, screenshot_time,
+                check_battle_end_normal_result, check_battle_end_hollow_result, check_battle_end_defense_result
+            ))
 
         # 统一处理结果
         for future in future_list:

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -437,7 +437,7 @@ class ChargePlanInterface(VerticalScrollInterface, GroupIdMixin):
         self.content_widget.add_widget(HorizontalSettingCardGroup([self.loop_opt, self.skip_plan_opt], spacing=6))
 
         self.daily_reset_plan_times_opt = SwitchSettingCard(icon=FluentIcon.HISTORY, title='每日重置', content='开启后，每天首次运行体力计划前，会将所有体力计划已运行次数清零')
-        self.restore_charge_opt = ComboBoxSettingCard(icon=FluentIcon.ADD_TO, title='恢复电量', content='体力不足时按所选方式恢复。若提取后仍不足以触发挑战则会跳过提取', options_enum=RestoreChargeEnum)
+        self.restore_charge_opt = ComboBoxSettingCard(icon=FluentIcon.ADD_TO, title='恢复电量', content='体力不足时按所选方式恢复。若提取后仍不足以触发挑战则会跳过提取', options_enum=RestoreChargeEnum, content_shrink=True)
         self.content_widget.add_widget(HorizontalSettingCardGroup([self.daily_reset_plan_times_opt, self.restore_charge_opt], spacing=6))
 
         self.double_reward_group = ExpandSettingCardGroup(

--- a/src/zzz_od/gui/view/one_dragon/predefined_team_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/predefined_team_interface.py
@@ -231,3 +231,14 @@ class PredefinedTeamInterface(SplitAppRunInterface):
 
     def _on_team_info_changed(self, team: PredefinedTeamInfo) -> None:
         self.ctx.team_config.update_team(team)
+
+    def on_context_state_changed(self) -> None:
+        super().on_context_state_changed()
+        if self.ctx.run_context.is_context_stop:
+            self._refresh_team_cards()
+
+    def _refresh_team_cards(self) -> None:
+        auto_battle_list = get_auto_battle_op_config_list('auto_battle')
+        team_list = self.ctx.team_config.team_list
+        for i in range(min(len(team_list), len(self.team_opt_list))):
+            self.team_opt_list[i].init_setting_card(auto_battle_list, team_list[i])

--- a/src/zzz_od/gui/view/one_dragon/predefined_team_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/predefined_team_interface.py
@@ -233,11 +233,13 @@ class PredefinedTeamInterface(SplitAppRunInterface):
         self.ctx.team_config.update_team(team)
 
     def on_context_state_changed(self) -> None:
+        """运行状态变化时刷新编队卡片。"""
         super().on_context_state_changed()
         if self.ctx.run_context.is_context_stop:
             self._refresh_team_cards()
 
     def _refresh_team_cards(self) -> None:
+        """根据当前配置刷新编队卡片的代理人选项。"""
         auto_battle_list = get_auto_battle_op_config_list('auto_battle')
         team_list = self.ctx.team_config.team_list
         for i in range(min(len(team_list), len(self.team_opt_list))):


### PR DESCRIPTION
- 预备编队识别完成后 UI 自动刷新填充代理人
- ComboBoxSettingCard 新增 content_shrink 参数，下拉框变宽时动态 收窄说明文字，右边界不溢出
- 自动战斗结束检测不再依赖攻击按钮模板先消失，防止打怪太快 时结算画面误匹配导致卡死

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 设置卡片新增“说明文字收缩”显示：根据界面尺寸自动优化文字宽度与排版。

* **Bug修复**
  * 改进战斗结束识别逻辑：在结算画面等场景下减少误判，确保能正确触发结束识别。
  * 停止运行时自动刷新编队卡片，确保界面内容保持同步。

* **优化**
  * “恢复电量”设置项已启用收缩显示，使内容展示更清晰、更适配当前布局。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->