### PR TITLE
ci: 模块文件变化时自动发布beta版

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+      create_release: ${{ steps.release_requested.outputs.value }}
 
     steps:
     - name: Checkout code
@@ -42,6 +43,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
+    - name: Check release requested
+      id: release_requested
+      shell: pwsh
+      run: |
+        "value=$env:CREATE_RELEASE" >> $env:GITHUB_OUTPUT
 
     - name: Get version
       id: get_version
@@ -180,9 +187,7 @@ jobs:
     needs:
       - version
       - build
-    if: ${{ github.repository_owner == 'OneDragon-Anything' &&
-            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
-        }}
+    if: ${{ github.repository_owner == 'OneDragon-Anything' && needs.version.outputs.create_release == 'true' }}
     env:
       SIGNED_DIR: 'signed'
       SIGNPATH_SIGNING_POLICY_SLUG: 'release-signing'
@@ -215,8 +220,8 @@ jobs:
       - sign
     if: ${{ always() &&
             needs.build.result == 'success' &&
-            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) &&
-            (needs.sign.result == 'success')
+            needs.version.outputs.create_release == 'true' &&
+            needs.sign.result == 'success'
         }}
     steps:
     - name: Checkout code

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,6 +2,10 @@ name: Build and Release
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - 'deploy/module_manifest.py'
     tags:
       - 'v*'
   pull_request:
@@ -19,7 +23,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  CREATE_RELEASE: ${{ (github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') }}
+  CREATE_RELEASE: ${{ (github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   version:
@@ -177,7 +181,7 @@ jobs:
       - version
       - build
     if: ${{ github.repository_owner == 'OneDragon-Anything' &&
-            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/'))
+            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         }}
     env:
       SIGNED_DIR: 'signed'
@@ -211,7 +215,7 @@ jobs:
       - sign
     if: ${{ always() &&
             needs.build.result == 'success' &&
-            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/')) &&
+            ((github.event_name == 'workflow_dispatch' && inputs.create_release == true) || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) &&
             (needs.sign.result == 'success')
         }}
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
- 优化发布工作流触发条件：推送到主分支时，仅在特定清单文件变更时才触发对应构建与发布流程；同时保留按需手动与标签触发的判定。  
- 调整发布判定逻辑：新增发布请求检查步骤，统一计算创建发布开关并通过作业输出驱动作业执行；签名与发布在前置构建与签名成功后继续进行。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->