### PR TITLE
fix: 执行情报板前传送回录像店

### DIFF
--- a/src/zzz_od/application/intel_board/intel_board_app.py
+++ b/src/zzz_od/application/intel_board/intel_board_app.py
@@ -14,9 +14,9 @@ from zzz_od.application.intel_board.intel_board_config import IntelBoardConfig
 from zzz_od.application.intel_board.intel_board_run_record import IntelBoardRunRecord
 from zzz_od.application.zzz_application import ZApplication
 from zzz_od.context.zzz_context import ZContext
-from zzz_od.operation.back_to_normal_world import BackToNormalWorld
 from zzz_od.operation.choose_predefined_team import ChoosePredefinedTeam
 from zzz_od.operation.compendium.notorious_hunt_move import NotoriousHuntMove
+from zzz_od.operation.transport import Transport
 
 
 class CommissionType(StrEnum):
@@ -43,12 +43,12 @@ class IntelBoardApp(ZApplication):
         self.current_commission_type: CommissionType | None = None
         self.has_filtered: bool = False
 
-    @operation_node(name='返回大世界', is_start_node=True)
+    @operation_node(name='返回录像店', is_start_node=True)
     def back_to_world(self) -> OperationRoundResult:
-        op = BackToNormalWorld(self.ctx, ensure_normal_world=True)
+        op = Transport(self.ctx, '录像店', '房间')
         return self.round_by_op_result(op.execute())
 
-    @node_from(from_name='返回大世界')
+    @node_from(from_name='返回录像店')
     @operation_node(name='打开情报板')
     def open_board(self) -> OperationRoundResult:
         if self.config.exp_grind_mode:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能调整**
  * 情报板返回流程已更新，用户现在将返回至录像店而非主世界，确保游戏进度的连贯性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->