### PR TITLE
fix: 修复生成模块文件时使用CRLF导致集成启动器无法更新

### DIFF
--- a/deploy/generate_module_manifest.py
+++ b/deploy/generate_module_manifest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 生成 PyInstaller 模块清单的脚本
 扫描源码目录中的所有导入，生成 module_manifest.py 用于 PyInstaller 依赖分析
@@ -156,7 +155,7 @@ def write_seed_script(seed_file: Path, mods: list[str], repo_root: Path) -> None
     """
     if not mods:
         print("[warn] No external dependencies found")
-        seed_file.write_text("# AUTO-GENERATED — DO NOT EDIT\npass\n", encoding="utf-8")
+        seed_file.write_text("# AUTO-GENERATED — DO NOT EDIT\npass\n", encoding="utf-8", newline="\n")
         return
 
     # 生成导入语句
@@ -166,7 +165,7 @@ def write_seed_script(seed_file: Path, mods: list[str], repo_root: Path) -> None
     for mod in mods:
         content += f"    {mod}\n"
 
-    seed_file.write_text(content, encoding="utf-8")
+    seed_file.write_text(content, encoding="utf-8", newline="\n")
     print(f"Writing -> {seed_file.relative_to(repo_root)} ({len(mods)} imports)")
 
 

--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -413,6 +413,13 @@ class GitService:
         if local_manifest == remote_manifest:
             return True, ''
 
+        # 兼容旧打包产物的 CRLF；先走 raw bytes 快路径，仅不一致时再归一化。
+        if b'\r' in local_manifest or b'\r' in remote_manifest:
+            normalized_local_manifest = local_manifest.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
+            normalized_remote_manifest = remote_manifest.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
+            if normalized_local_manifest == normalized_remote_manifest:
+                return True, ''
+
         msg = gt('目标版本的运行环境与当前不兼容')
         log.warning(f'模块清单已变更，阻止代码更新。目标: {str(target_oid)[:7]}')
         return False, msg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了模块清单比对逻辑，减少不同系统换行符（如 Windows 与 Unix）导致的误判，避免不必要的更新阻止。
  * 生成的 seed 文件统一使用 `\n` 换行，提升跨平台一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->