### PR TITLE
fix: 修复未定义运行记录的应用会抛出异常导致后面的应用不加载的问题

### DIFF
--- a/src/one_dragon/base/operation/application/application_factory.py
+++ b/src/one_dragon/base/operation/application/application_factory.py
@@ -99,7 +99,7 @@ class ApplicationFactory(ABC):
         Returns:
             AppRunRecord: 创建的运行记录对象
         """
-        raise Exception(f"未提供应用运行记录创建方法 {self.app_id}")
+        raise NotImplementedError(f"未提供应用运行记录创建方法 {self.app_id}")
 
     def get_config(
         self, instance_idx: int, group_id: str

--- a/src/one_dragon/base/operation/application/application_run_context.py
+++ b/src/one_dragon/base/operation/application/application_run_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import StrEnum
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from one_dragon.base.operation.context_event_bus import ContextEventBus
 from one_dragon.base.operation.notify_pool import NotifyPool
@@ -79,10 +79,10 @@ class ApplicationRunContext:
         self.default_group_apps: list = []  # 默认应用组的应用ID列表
 
         # 当前运行的应用
-        self.current_app_id: Optional[str] = None
-        self.current_instance_idx: Optional[int] = None
-        self.current_group_id: Optional[str] = None
-        self.current_application: Optional[Application] = None
+        self.current_app_id: str | None = None
+        self.current_instance_idx: int | None = None
+        self.current_group_id: str | None = None
+        self.current_application: Application | None = None
 
         # 通知池，应用开始时清空重用
         self.notify_pool: NotifyPool = NotifyPool()
@@ -201,9 +201,9 @@ class ApplicationRunContext:
 
     def get_config(
         self,
-        app_id: Optional[str] = None,
-        instance_idx: Optional[int] = None,
-        group_id: Optional[str] = None,
+        app_id: str | None = None,
+        instance_idx: int | None = None,
+        group_id: str | None = None,
     ) -> CONFIG:
         """
         获取配置实例。
@@ -239,9 +239,9 @@ class ApplicationRunContext:
 
     def get_run_record(
         self,
-        app_id: Optional[str] = None,
-        instance_idx: Optional[int] = None,
-    ) -> RECORD:
+        app_id: str | None = None,
+        instance_idx: int | None = None,
+    ) -> RECORD | None:
         """
         获取运行记录实例。
 
@@ -269,7 +269,11 @@ class ApplicationRunContext:
             raise Exception(f"应用未注册 {app_id}")
 
         factory = self._application_factory_map[app_id]
-        return factory.get_run_record(instance_idx)
+        try:
+            return factory.get_run_record(instance_idx)
+        except NotImplementedError:
+            log.warning(f"应用 {app_id} 获取运行记录失败，未实现运行记录创建方法")
+            return None
 
     @property
     def is_context_stop(self) -> bool:

--- a/src/one_dragon/base/operation/application/group_application.py
+++ b/src/one_dragon/base/operation/application/group_application.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from one_dragon.base.operation.application.application_group_config import (
     ApplicationGroupConfig,
@@ -21,7 +21,7 @@ class GroupApplication(Application):
         self,
         ctx: OneDragonContext,
         group_id: str,
-        op_to_enter_game: Optional[Operation] = None,
+        op_to_enter_game: Operation | None = None,
     ):
         Application.__init__(
             self,
@@ -32,7 +32,7 @@ class GroupApplication(Application):
         )
         self._group_id: str = group_id
 
-        self._group_config: Optional[ApplicationGroupConfig] = None
+        self._group_config: ApplicationGroupConfig | None = None
         self._current_app_idx: int = 0  # 当前运行的app 下标
         self._fail_app_idx_list: list[int] = []  # 失败的app下标 未实现重试功能
 


### PR DESCRIPTION
```
Exception: 未提供应用运行记录创建方法 xxx
C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\view\one_dragon\one_dragon_run_interface.py:152: RuntimeWarning: Failed to disconnect (<bound method OneDragonRunInterface._on_instance_changed of <zzz_od.gui.view.one_dragon.zzz_one_dragon_run_interface.ZOneDragonRunInterface(0x5daa9ca0, name="one_dragon_run_interface") at 0x000000006EE61D00>>) from signal "instance_changed()".
  self._context_event_signal.instance_changed.disconnect(self._on_instance_changed)
C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\view\one_dragon\one_dragon_run_interface.py:156: RuntimeWarning: Failed to disconnect (<bound method OneDragonRunInterface._on_app_setting_manager_ready of <zzz_od.gui.view.one_dragon.zzz_one_dragon_run_interface.ZOneDragonRunInterface(0x5daa9ca0, name="one_dragon_run_interface") at 0x000000006EE61D00>>) from signal "ready()".
  window.app_setting_manager.ready.disconnect(self._on_app_setting_manager_ready)
Traceback (most recent call last):
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\windows\main_app_window_base.py", line 64, in init_interface_on_shown
    super().init_interface_on_shown(index)
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\windows\app_window_base.py", line 96, in init_interface_on_shown
    base_interface.on_interface_shown()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\zzz_od\gui\view\one_dragon\zzz_one_dragon_interface.py", line 46, in on_interface_shown
    super().on_interface_shown()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\widgets\pivot_navi_interface.py", line 91, in on_interface_shown
    current_widget.on_interface_shown()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\widgets\page_stack_wrapper.py", line 54, in on_interface_shown
    self._sub_interface.on_interface_shown()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\view\one_dragon\one_dragon_run_interface.py", line 120, in on_interface_shown
    self._refresh_app_config()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\view\one_dragon\one_dragon_run_interface.py", line 116, in _refresh_app_config
    self._init_app_list()
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\view\one_dragon\one_dragon_run_interface.py", line 107, in _init_app_list
    self.app_run_list.set_app_list(
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\widgets\app_run_list.py", line 88, in set_app_list
    self._create_new_cards(app_list, instance_idx)
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon_qt\widgets\app_run_list.py", line 130, in _create_new_cards
    run_record = self.ctx.run_context.get_run_record(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon\base\operation\application\application_run_context.py", line 272, in get_run_record
    return factory.get_run_record(instance_idx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon\base\operation\application\application_factory.py", line 151, in get_run_record
    record = self.create_run_record(instance_idx)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Anonymous\IdeaProjects\ZenlessZoneZero-OneDragon\src\one_dragon\base\operation\application\application_factory.py", line 102, in create_run_record
    raise Exception(f"未提供应用运行记录创建方法 {self.app_id}")
Exception: 未提供应用运行记录创建方法 xxx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 获取运行记录更稳健：当底层不支持时会记录告警并返回空结果，避免异常外抛影响使用。
  * 增强配置获取参数兼容性：对可选参数的类型标注更匹配，减少空值处理问题。

* **Refactor**
  * 统一更新类型标注写法：将 `Optional` 迁移为 `T | None`，并同步相关方法签名与实例属性类型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->