### PR TITLE
feat: 维琳娜战斗优化

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -11354,36 +11354,17 @@
           - "op_name": "等待秒数"
             "seconds": 4.0
           "states": "[维琳娜-终结技可用]"
-        - "debug_name": "强化特殊技，持续6秒"
-          "interrupt_states": "[按键可用-快速支援]"
+        - "debug_name": "强化特殊技"
           "operations":
           - "op_name": "设置状态"
-            "seconds": 5
+            "seconds": 1
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
             "repeat": 10
-          - "op_name": "按键-特殊攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
           - "op_name": "清除状态"
             "state": "自定义-动作不打断"
-          "states": "[维琳娜-特殊技可用]"
+          "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
         - "debug_name": "龙卷风"
           "interrupt_states": "[按键可用-快速支援]"
           "operations":
@@ -11401,7 +11382,7 @@
             "seconds": 1
           - "op_name": "清除状态"
             "state": "自定义-动作不打断"
-          "states": "[维琳娜-风华]{100,135}"
+          "states": "[维琳娜-风华]{85,135}"
         - "debug_name": "普通攻击"
           "operations":
           - "op_name": "按键-普通攻击"
@@ -21642,36 +21623,17 @@
         - "op_name": "等待秒数"
           "seconds": 4.0
         "states": "[维琳娜-终结技可用]"
-      - "debug_name": "强化特殊技，持续6秒"
-        "interrupt_states": "[按键可用-快速支援]"
+      - "debug_name": "强化特殊技"
         "operations":
         - "op_name": "设置状态"
-          "seconds": 5
+          "seconds": 1
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
           "repeat": 10
-        - "op_name": "按键-特殊攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
         - "op_name": "清除状态"
           "state": "自定义-动作不打断"
-        "states": "[维琳娜-特殊技可用]"
+        "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
       - "debug_name": "龙卷风"
         "interrupt_states": "[按键可用-快速支援]"
         "operations":
@@ -21689,7 +21651,7 @@
           "seconds": 1
         - "op_name": "清除状态"
           "state": "自定义-动作不打断"
-        "states": "[维琳娜-风华]{100,135}"
+        "states": "[维琳娜-风华]{85,135}"
       - "debug_name": "普通攻击"
         "operations":
         - "op_name": "按键-普通攻击"

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -10406,36 +10406,17 @@
           - "op_name": "等待秒数"
             "seconds": 4.0
           "states": "[维琳娜-终结技可用]"
-        - "debug_name": "强化特殊技，持续6秒"
-          "interrupt_states": "[按键可用-快速支援]"
+        - "debug_name": "强化特殊技"
           "operations":
           - "op_name": "设置状态"
-            "seconds": 5
+            "seconds": 1
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
             "repeat": 10
-          - "op_name": "按键-特殊攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
           - "op_name": "清除状态"
             "state": "自定义-动作不打断"
-          "states": "[维琳娜-特殊技可用]"
+          "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
         - "debug_name": "龙卷风"
           "interrupt_states": "[按键可用-快速支援]"
           "operations":
@@ -10453,7 +10434,7 @@
             "seconds": 1
           - "op_name": "清除状态"
             "state": "自定义-动作不打断"
-          "states": "[维琳娜-风华]{100,135}"
+          "states": "[维琳娜-风华]{85,135}"
         - "debug_name": "普通攻击"
           "operations":
           - "op_name": "按键-普通攻击"

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -9475,36 +9475,17 @@
       - "op_name": "等待秒数"
         "seconds": 4.0
       "states": "[维琳娜-终结技可用]"
-    - "debug_name": "强化特殊技，持续6秒"
-      "interrupt_states": "[按键可用-快速支援]"
+    - "debug_name": "强化特殊技"
       "operations":
       - "op_name": "设置状态"
-        "seconds": 5
+        "seconds": 1
         "state": "自定义-动作不打断"
       - "op_name": "按键-特殊攻击"
         "post_delay": 0.1
         "repeat": 10
-      - "op_name": "按键-特殊攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
       - "op_name": "清除状态"
         "state": "自定义-动作不打断"
-      "states": "[维琳娜-特殊技可用]"
+      "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
     - "debug_name": "龙卷风"
       "interrupt_states": "[按键可用-快速支援]"
       "operations":
@@ -9522,7 +9503,7 @@
         "seconds": 1
       - "op_name": "清除状态"
         "state": "自定义-动作不打断"
-      "states": "[维琳娜-风华]{100,135}"
+      "states": "[维琳娜-风华]{85,135}"
     - "debug_name": "普通攻击"
       "operations":
       - "op_name": "按键-普通攻击"
@@ -18960,36 +18941,17 @@
       - "op_name": "等待秒数"
         "seconds": 4.0
       "states": "[维琳娜-终结技可用]"
-    - "debug_name": "强化特殊技，持续6秒"
-      "interrupt_states": "[按键可用-快速支援]"
+    - "debug_name": "强化特殊技"
       "operations":
       - "op_name": "设置状态"
-        "seconds": 5
+        "seconds": 1
         "state": "自定义-动作不打断"
       - "op_name": "按键-特殊攻击"
         "post_delay": 0.1
         "repeat": 10
-      - "op_name": "按键-特殊攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
       - "op_name": "清除状态"
         "state": "自定义-动作不打断"
-      "states": "[维琳娜-特殊技可用]"
+      "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
     - "debug_name": "龙卷风"
       "interrupt_states": "[按键可用-快速支援]"
       "operations":
@@ -19007,7 +18969,7 @@
         "seconds": 1
       - "op_name": "清除状态"
         "state": "自定义-动作不打断"
-      "states": "[维琳娜-风华]{100,135}"
+      "states": "[维琳娜-风华]{85,135}"
     - "debug_name": "普通攻击"
       "operations":
       - "op_name": "按键-普通攻击"

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -9435,36 +9435,17 @@
         - "op_name": "等待秒数"
           "seconds": 4.0
         "states": "[维琳娜-终结技可用]"
-      - "debug_name": "强化特殊技，持续6秒"
-        "interrupt_states": "[按键可用-快速支援]"
+      - "debug_name": "强化特殊技"
         "operations":
         - "op_name": "设置状态"
-          "seconds": 5
+          "seconds": 1
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
           "repeat": 10
-        - "op_name": "按键-特殊攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
         - "op_name": "清除状态"
           "state": "自定义-动作不打断"
-        "states": "[维琳娜-特殊技可用]"
+        "states": "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
       - "debug_name": "龙卷风"
         "interrupt_states": "[按键可用-快速支援]"
         "operations":
@@ -9482,7 +9463,7 @@
           "seconds": 1
         - "op_name": "清除状态"
           "state": "自定义-动作不打断"
-        "states": "[维琳娜-风华]{100,135}"
+        "states": "[维琳娜-风华]{85,135}"
       - "debug_name": "普通攻击"
         "operations":
         - "op_name": "按键-普通攻击"

--- a/config/auto_battle_operation/维琳娜-强化特殊技.sample.yml
+++ b/config/auto_battle_operation/维琳娜-强化特殊技.sample.yml
@@ -1,28 +1,10 @@
-# 占位模板，强化特殊技持续约6秒
+# 占位模板，强化特殊技持续约1秒
 operations:
   - op_name: "设置状态"
     state: "自定义-动作不打断"
-    seconds: 5
+    seconds: 1
   - op_name: "按键-特殊攻击"
     post_delay: 0.1
     repeat: 10
-  - op_name: "按键-特殊攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
   - op_name: "清除状态"
     state: "自定义-动作不打断"

--- a/config/auto_battle_state_handler/速切模板-维琳娜.sample.yml
+++ b/config/auto_battle_state_handler/速切模板-维琳娜.sample.yml
@@ -45,13 +45,12 @@ handlers:
         operations:
           - operation_template: "维琳娜-终结技"
 
-      - states: "[维琳娜-特殊技可用]"
-        interrupt_states: "[按键可用-快速支援]"  # 不可用时打断
-        debug_name: "强化特殊技，持续6秒"
+      - states: "[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}"
+        debug_name: "强化特殊技"
         operations:
           - operation_template: "维琳娜-强化特殊技"
 
-      - states: "[维琳娜-风华]{100,135}"
+      - states: "[维琳娜-风华]{85,135}"
         interrupt_states: "[按键可用-快速支援]"  # 不可用时打断
         debug_name: "龙卷风"
         operations:


### PR DESCRIPTION
**标题:** feat: 维琳娜战斗优化

**变更内容:**
- 简化维琳娜强化特殊技逻辑，去掉无意义的持续长按普攻循环（从6秒 → 1秒）
- 维琳娜强化特殊技 `[维琳娜-特殊技可用]` 改为 `[维琳娜-特殊技可用] & [维琳娜-风华]{0,85}`，只有风华≤85时才放强化特殊技
- 龙卷风条件从 `[维琳娜-风华]{100,135}` 改为 `[维琳娜-风华]{85,135}`，阈值降低到 85
- 操作模板 `维琳娜-强化特殊技.sample.yml` 同步简化，删除多余按键

**涉及文件:**
- `config/auto_battle_operation/维琳娜-强化特殊技.sample.yml`
- `config/auto_battle_state_handler/速切模板-维琳娜.sample.yml`
- 4 个 merged.yml 同步更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了维琳娜相关的自动战斗/速切配置，强化特殊技的触发更简洁，整体切换更顺畅。
* **Bug 修复**
  * 调整了“风华”状态的判定范围，减少部分场景下强化特殊技与后续“龙卷风”衔接不稳定的问题。
  * 缩短了强化特殊技的执行时长，使流程更快完成。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->