### PR TITLE
fix(gui): 避免首页自动触发 Git 远程访问

### DIFF
--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -109,6 +109,7 @@ uv run pyinstaller --noconfirm --clean "OneDragon-Launcher.spec"
 - **最小打包**：仅打包 `one_dragon.launcher`、`one_dragon.version` 模块和二进制依赖（pygit2 等）
 - **源码加载**：借助 `hook_path_inject.py` 运行时钩子，将 `<exe_dir>/src` 注入 `sys.path`，其余模块从 `src/` 目录加载
 - **自动更新**：首次运行时自动克隆代码仓库；后续运行时根据 `auto_update_code` 配置自动拉取最新代码
+- **GUI 边界**：主界面启动后不自动访问 Git 远程；代码远程检查与同步仅在“代码同步”页等明确入口触发
 - **Manifest 兼容性检查**：`module_manifest.py` 记录打包时的外部依赖清单，更新代码后如新增依赖不在清单中，提示用户更新启动器
 
 #### 打包命令

--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -805,8 +805,7 @@ class GitService:
         """
         获取当前代码版本
         """
-        logs = self.fetch_page_commit(0, 1)
-        return logs[0].commit_id if logs else None
+        return self.get_head_commit_id(short=True)
 
     def get_latest_tag(self) -> tuple[str, str]:
         """获取最新tag，未找到时返回空字符串

--- a/src/zzz_od/gui/view/home/home_interface.py
+++ b/src/zzz_od/gui/view/home/home_interface.py
@@ -24,7 +24,7 @@ from qfluentwidgets import (
 )
 
 from one_dragon.base.config.custom_config import BackgroundTypeEnum
-from one_dragon.utils import app_utils, os_utils
+from one_dragon.utils import os_utils
 from one_dragon.utils.log_utils import log
 from one_dragon_qt.services.theme_manager import ThemeManager
 from one_dragon_qt.utils.color_utils import get_foreground_color
@@ -357,7 +357,7 @@ class HomeInterface(BaseInterface):
         self._last_reload_banner_signal = False
         self._last_applied_theme_color: tuple[int, int, int] | None = None
 
-        # 记录上次自动检查更新的时间
+        # 记录上次自动检查资源更新的时间；代码同步由启动器或代码同步页负责。
         self._last_auto_check_time = 0
         self._auto_check_interval = 300  # 5分钟冷却时间
 
@@ -431,17 +431,7 @@ class HomeInterface(BaseInterface):
             apply_shadow(button)
 
     def _init_check_runners(self):
-        """初始化检查更新的线程"""
-        self._check_code_runner = CheckRunner(
-            self.ctx,
-            lambda ctx: not ctx.git_service.is_current_branch_latest()[0],
-            self
-        )
-        self._check_code_runner.need_update.connect(
-            self._need_to_update_code,
-            Qt.ConnectionType.QueuedConnection
-        )
-
+        """初始化资源检查线程。"""
         self._check_model_runner = CheckRunner(
             self.ctx,
             lambda ctx: ctx.model_config.using_old_model(),
@@ -449,30 +439,6 @@ class HomeInterface(BaseInterface):
         )
         self._check_model_runner.need_update.connect(
             self._need_to_update_model,
-            Qt.ConnectionType.QueuedConnection
-        )
-
-        def check_launcher_update(ctx: ZContext) -> bool:
-            current_version = app_utils.get_launcher_version()
-            latest_stable, latest_beta = ctx.git_service.get_latest_tag()
-
-            # 根据当前版本是否包含 -beta 来确定比较通道
-            if current_version and '-beta' in current_version:
-                # 测试通道：与最新测试版比较；若不存在测试版，则和稳定版比较
-                target_latest = latest_beta or latest_stable
-            else:
-                # 稳定通道：与最新稳定版比较；若不存在稳定版，则视为已最新
-                target_latest = latest_stable or current_version
-
-            return current_version != target_latest
-
-        self._check_launcher_runner = CheckRunner(
-            self.ctx,
-            check_launcher_update,
-            self
-        )
-        self._check_launcher_runner.need_update.connect(
-            self._need_to_update_launcher,
             Qt.ConnectionType.QueuedConnection
         )
 
@@ -526,7 +492,7 @@ class HomeInterface(BaseInterface):
             self._banner_widget.release_media()
 
     def on_interface_shown(self) -> None:
-        """界面显示时启动检查更新的线程"""
+        """界面显示时启动资源检查线程。"""
         super().on_interface_shown()
 
         if self._banner_widget:
@@ -544,12 +510,8 @@ class HomeInterface(BaseInterface):
         should_check = (current_time - self._last_auto_check_time) > self._auto_check_interval
 
         if should_check:
-            if not self._check_code_runner.isRunning():
-                self._check_code_runner.start()
             if not self._check_model_runner.isRunning():
                 self._check_model_runner.start()
-            if not self._check_launcher_runner.isRunning():
-                self._check_launcher_runner.start()
             self._last_auto_check_time = current_time
 
         # Banner 刷新检查不需要冷却，因为它依赖信号
@@ -597,20 +559,9 @@ class HomeInterface(BaseInterface):
         if self._dynamic_background_downloader.isRunning():
             self._dynamic_background_downloader.stop()
 
-    def _need_to_update_code(self, with_new: bool):
-        if not with_new:
-            self._show_info_bar("代码已是最新版本", "Enjoy it & have fun!")
-            return
-        else:
-            self._show_info_bar("有新版本啦", "稍安勿躁~")
-
     def _need_to_update_model(self, with_new: bool):
         if with_new:
             self._show_info_bar("有新模型啦", "到[设置-资源下载]更新吧~", 5000)
-
-    def _need_to_update_launcher(self, with_new: bool):
-        if with_new:
-            self._show_info_bar("有新启动器啦", "到[设置-资源下载]更新吧~", 5000)
 
     def _show_info_bar(self, title: str, content: str, duration: int = 20000):
         """显示信息条（手动定位，避免标题栏遮挡）"""


### PR DESCRIPTION
## 变更说明

本 PR 调整 GUI 首页和代码同步状态的 Git 查询行为，避免应用启动后首页自动访问远程仓库。

- 首页不再主动触发 Git 远程拉取/检查
- 获取当前版本信息时避免分页读取 commit 列表
- 保留代码同步页自身的同步能力，减少启动阶段网络超时对 GUI 的影响

## 测试验证

- `uv run ruff check src\zzz_od\gui\view\home\home_interface.py src\one_dragon\envs\git_service.py`
- `uv run python -m py_compile src\zzz_od\gui\view\home\home_interface.py src\one_dragon\envs\git_service.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 主页启动后不再自动访问远程仓库；代码同步与检查仅会在明确入口触发。
  * 主页的自动检查更聚焦于模型更新、横幅刷新和背景资源下载。

* **Bug Fixes**
  * 当前版本信息改为直接读取本地当前提交的短哈希，结果更稳定。

* **Documentation**
  * 更新了架构说明，明确启动器不会在主界面自动进行远程同步。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->