### PR TITLE
feat(ocr): 懒加载并空闲释放 OCR 模型

### DIFF
--- a/docs/develop/zzz/ocr_lifecycle.md
+++ b/docs/develop/zzz/ocr_lifecycle.md
@@ -1,0 +1,11 @@
+# OCR 生命周期
+
+绝区零侧不直接修改 `one_dragon` 基础 OCR 框架，而是在 `ZContext` 中替换为业务侧封装：
+
+- `ManagedOnnxOcrMatcher` 位于 `src/zzz_od/context/managed_ocr_matcher.py`
+- GUI 初始化阶段只配置 OCR 的 GPU 与代理参数，不创建 ONNX Runtime 会话
+- 首次实际 OCR 调用时懒加载模型
+- OCR 模型超过 30 分钟未使用时由后台线程自动释放
+- 模型加载、OCR 推理、空闲释放共用生命周期锁，避免加载和释放并发冲突
+
+调用侧继续使用 `ctx.ocr` 与 `ctx.ocr_service`，不需要感知生命周期管理细节。

--- a/src/zzz_od/context/managed_ocr_matcher.py
+++ b/src/zzz_od/context/managed_ocr_matcher.py
@@ -29,6 +29,7 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
         self._last_used_at: float | None = None
         self._proxy_url: str | None = None
         self._ghproxy_url: str | None = None
+        self._shutdown: bool = False
         self._shutdown_event: threading.Event = threading.Event()
         self._release_thread: threading.Thread | None = None
 
@@ -68,6 +69,10 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
     ) -> bool:
         """懒加载 OCR 模型，并启动空闲释放监控。"""
         with self._lifecycle_lock:
+            if self._shutdown:
+                log.warning('OCR 已关闭，跳过模型初始化')
+                return False
+
             actual_proxy_url = proxy_url if proxy_url is not None else self._proxy_url
             actual_ghproxy_url = ghproxy_url if ghproxy_url is not None else self._ghproxy_url
             success = super().init_model(
@@ -92,6 +97,10 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
     ) -> str:
         """单行 OCR，期间禁止释放模型。"""
         with self._lifecycle_lock:
+            if self._shutdown:
+                log.warning('OCR 已关闭，跳过单行识别')
+                return ''
+
             try:
                 return super().run_ocr_single_line(image, threshold, strict_one_line)
             finally:
@@ -105,6 +114,10 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
     ) -> dict[str, MatchResultList]:
         """整图 OCR，期间禁止释放模型。"""
         with self._lifecycle_lock:
+            if self._shutdown:
+                log.warning('OCR 已关闭，跳过整图识别')
+                return {}
+
             try:
                 return super().run_ocr(image, threshold, merge_line_distance)
             finally:
@@ -122,6 +135,10 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
             return []
 
         with self._lifecycle_lock:
+            if self._shutdown:
+                log.warning('OCR 已关闭，跳过识别')
+                return []
+
             try:
                 if self._model is None and not self.init_model():
                     return []
@@ -147,8 +164,11 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
 
     def shutdown(self) -> None:
         """停止空闲释放线程并释放模型。"""
-        self._shutdown_event.set()
-        release_thread = self._release_thread
+        with self._lifecycle_lock:
+            self._shutdown = True
+            self._shutdown_event.set()
+            release_thread = self._release_thread
+
         if release_thread is not None and release_thread.is_alive():
             if threading.current_thread() is not release_thread:
                 release_thread.join(timeout=2)
@@ -173,6 +193,9 @@ class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
 
     def _ensure_release_monitor_started_locked(self) -> None:
         """确保空闲释放线程已启动。"""
+        if self._shutdown:
+            return
+
         if self._release_thread is not None and self._release_thread.is_alive():
             return
 

--- a/src/zzz_od/context/managed_ocr_matcher.py
+++ b/src/zzz_od/context/managed_ocr_matcher.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+
+from cv2.typing import MatLike
+
+from one_dragon.base.matcher.match_result import MatchResultList
+from one_dragon.base.matcher.ocr.ocr_match_result import OcrMatchResult
+from one_dragon.base.matcher.ocr.onnx_ocr_matcher import OnnxOcrMatcher, OnnxOcrParam
+from one_dragon.utils.log_utils import log
+
+
+class ManagedOnnxOcrMatcher(OnnxOcrMatcher):
+    """绝区零侧的 OCR 生命周期管理器。"""
+
+    def __init__(
+        self,
+        ocr_param: OnnxOcrParam,
+        idle_release_seconds: float = 30 * 60,
+        release_check_interval: float = 60,
+    ) -> None:
+        super().__init__(ocr_param)
+        self._lifecycle_lock: threading.RLock = threading.RLock()
+        self._init_lock = self._lifecycle_lock
+        self._idle_release_seconds: float = idle_release_seconds
+        self._release_check_interval: float = release_check_interval
+        self._last_used_at: float | None = None
+        self._proxy_url: str | None = None
+        self._ghproxy_url: str | None = None
+        self._shutdown_event: threading.Event = threading.Event()
+        self._release_thread: threading.Thread | None = None
+
+    def configure_runtime(
+        self,
+        use_gpu: bool,
+        proxy_url: str | None,
+        ghproxy_url: str | None,
+    ) -> None:
+        """更新 OCR 运行配置，不主动加载 ONNX 会话。"""
+        with self._lifecycle_lock:
+            self._proxy_url = proxy_url
+            self._ghproxy_url = ghproxy_url
+            if self._ocr_param.use_gpu == use_gpu:
+                return
+
+            self._ocr_param.use_gpu = use_gpu
+            self._release_model_locked('OCR GPU 配置变更')
+
+    def update_use_gpu(self, use_gpu: bool) -> None:
+        """更新 GPU 开关，并释放已加载的旧会话。"""
+        with self._lifecycle_lock:
+            if self._ocr_param.use_gpu == use_gpu:
+                return
+            self._ocr_param.use_gpu = use_gpu
+            self._release_model_locked('OCR GPU 配置变更')
+
+    def init_model(
+        self,
+        download_by_github: bool = True,
+        download_by_gitee: bool = False,
+        download_by_mirror_chan: bool = False,
+        proxy_url: str | None = None,
+        ghproxy_url: str | None = None,
+        skip_if_existed: bool = True,
+        progress_callback: Callable[[float, str], None] | None = None,
+    ) -> bool:
+        """懒加载 OCR 模型，并启动空闲释放监控。"""
+        with self._lifecycle_lock:
+            actual_proxy_url = proxy_url if proxy_url is not None else self._proxy_url
+            actual_ghproxy_url = ghproxy_url if ghproxy_url is not None else self._ghproxy_url
+            success = super().init_model(
+                download_by_github=download_by_github,
+                download_by_gitee=download_by_gitee,
+                download_by_mirror_chan=download_by_mirror_chan,
+                proxy_url=actual_proxy_url,
+                ghproxy_url=actual_ghproxy_url,
+                skip_if_existed=skip_if_existed,
+                progress_callback=progress_callback,
+            )
+            if success:
+                self._touch_locked()
+                self._ensure_release_monitor_started_locked()
+            return success
+
+    def run_ocr_single_line(
+        self,
+        image: MatLike,
+        threshold: float = 0,
+        strict_one_line: bool = True,
+    ) -> str:
+        """单行 OCR，期间禁止释放模型。"""
+        with self._lifecycle_lock:
+            try:
+                return super().run_ocr_single_line(image, threshold, strict_one_line)
+            finally:
+                self._touch_locked()
+
+    def run_ocr(
+        self,
+        image: MatLike,
+        threshold: float | None = 0,
+        merge_line_distance: float = -1,
+    ) -> dict[str, MatchResultList]:
+        """整图 OCR，期间禁止释放模型。"""
+        with self._lifecycle_lock:
+            try:
+                return super().run_ocr(image, threshold, merge_line_distance)
+            finally:
+                self._touch_locked()
+
+    def ocr(
+        self,
+        image: MatLike,
+        threshold: float = 0,
+        merge_line_distance: float = -1,
+    ) -> list[OcrMatchResult]:
+        """OCR 列表接口，补齐业务侧懒加载保护。"""
+        if image is None:
+            log.warning('OCR输入的图片为None')
+            return []
+
+        with self._lifecycle_lock:
+            try:
+                if self._model is None and not self.init_model():
+                    return []
+                return super().ocr(image, threshold, merge_line_distance)
+            finally:
+                self._touch_locked()
+
+    def release_idle_model(self, force: bool = False) -> bool:
+        """释放超过空闲时间的 OCR 模型。"""
+        with self._lifecycle_lock:
+            if self._model is None:
+                return False
+
+            if not force:
+                if self._last_used_at is None:
+                    return False
+                idle_seconds = time.monotonic() - self._last_used_at
+                if idle_seconds < self._idle_release_seconds:
+                    return False
+
+            self._release_model_locked('OCR 空闲释放' if not force else 'OCR 强制释放')
+            return True
+
+    def shutdown(self) -> None:
+        """停止空闲释放线程并释放模型。"""
+        self._shutdown_event.set()
+        release_thread = self._release_thread
+        if release_thread is not None and release_thread.is_alive():
+            if threading.current_thread() is not release_thread:
+                release_thread.join(timeout=2)
+
+        self.release_idle_model(force=True)
+
+    def _touch_locked(self) -> None:
+        """记录最近一次实际使用 OCR 模型的时间。"""
+        if self._model is not None:
+            self._last_used_at = time.monotonic()
+
+    def _release_model_locked(self, reason: str) -> None:
+        """在生命周期锁内释放 OCR 模型。"""
+        if self._model is None:
+            return
+
+        model = self._model
+        self._model = None
+        self._last_used_at = None
+        del model
+        log.info(reason)
+
+    def _ensure_release_monitor_started_locked(self) -> None:
+        """确保空闲释放线程已启动。"""
+        if self._release_thread is not None and self._release_thread.is_alive():
+            return
+
+        self._shutdown_event.clear()
+        self._release_thread = threading.Thread(
+            target=self._release_monitor_loop,
+            name='zzz_ocr_release_monitor',
+            daemon=True,
+        )
+        self._release_thread.start()
+
+    def _release_monitor_loop(self) -> None:
+        """定期检查 OCR 模型是否需要空闲释放。"""
+        while not self._shutdown_event.wait(self._release_check_interval):
+            try:
+                self.release_idle_model()
+            except Exception:
+                log.error('OCR 空闲释放检查失败', exc_info=True)

--- a/src/zzz_od/context/zzz_context.py
+++ b/src/zzz_od/context/zzz_context.py
@@ -10,10 +10,29 @@ class ZContext(OneDragonContext):
     def __init__(self,):
 
         OneDragonContext.__init__(self)
+        self._init_managed_ocr()
 
         # 后续所有用到自动战斗的 都统一设置到这个里面
         from zzz_od.auto_battle.auto_battle_context import AutoBattleContext
         self.auto_battle_context: AutoBattleContext = AutoBattleContext(self)
+
+    def _init_managed_ocr(self) -> None:
+        """替换基础 OCR 为绝区零侧的懒加载管理实现。"""
+        from one_dragon.base.matcher.ocr.ocr_service import OcrService
+        from one_dragon.base.matcher.ocr.onnx_ocr_matcher import OnnxOcrParam
+        from zzz_od.context.managed_ocr_matcher import ManagedOnnxOcrMatcher
+
+        self.ocr = ManagedOnnxOcrMatcher(
+            OnnxOcrParam(
+                use_gpu=self.model_config.ocr_use_gpu,
+                det_limit_side_len=max(
+                    self.project_config.screen_standard_width,
+                    self.project_config.screen_standard_height,
+                ),
+            )
+        )
+        self.ocr.overlay_debug_bus = self.overlay_debug_bus
+        self.ocr_service = OcrService(ocr_matcher=self.ocr)
 
     #------------------- 需要懒加载的都使用 @cached_property -------------------#
 
@@ -130,6 +149,20 @@ class ZContext(OneDragonContext):
         self.compendium_service.reload()  # 快捷手册
         self.auto_battle_context.init_screen_area()  # 自动战斗相关的区域 依赖 ScreenLoader
 
+    def init_ocr(self) -> None:
+        """配置 OCR 运行参数，不在 GUI 启动阶段加载 ONNX 会话。"""
+        from zzz_od.context.managed_ocr_matcher import ManagedOnnxOcrMatcher
+
+        if isinstance(self.ocr, ManagedOnnxOcrMatcher):
+            self.ocr.configure_runtime(
+                use_gpu=self.model_config.ocr_use_gpu,
+                proxy_url=self.env_config.personal_proxy if self.env_config.is_personal_proxy else None,
+                ghproxy_url=self.env_config.gh_proxy_url if self.env_config.is_gh_proxy else None,
+            )
+            return
+
+        OneDragonContext.init_ocr(self)
+
     def init_others(self) -> None:
         self.telemetry.initialize()  # 遥测
 
@@ -146,5 +179,8 @@ class ZContext(OneDragonContext):
 
         from zzz_od.auto_battle.auto_battle_operator import AutoBattleOperator
         AutoBattleOperator.after_app_shutdown()
+
+        if hasattr(self.ocr, 'shutdown'):
+            self.ocr.shutdown()
 
         OneDragonContext.after_app_shutdown(self)


### PR DESCRIPTION
## 变更说明

本 PR 为 OCR 模型增加懒加载和空闲释放机制，减少 GUI 启动时立即初始化 OCR/ONNX Runtime 会话带来的启动压力。

- 新增 `ManagedOcrMatcher`，统一管理 OCR matcher 的加载、使用和释放
- OCR 首次使用时才创建 matcher，避免应用启动阶段立即加载模型
- 超过空闲时间后自动释放 OCR matcher，降低长期占用
- 加锁保护加载/释放流程，避免并发使用时互相冲突
- 补充 OCR 生命周期开发文档

## 测试验证

- `uv run ruff check src\zzz_od\context\managed_ocr_matcher.py src\zzz_od\context\zzz_context.py`
- `uv run python -m py_compile src\zzz_od\context\managed_ocr_matcher.py src\zzz_od\context\zzz_context.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * OCR 现改为按需加载，并在后台空闲后自动释放模型，启动更轻量、资源占用更可控。
  * 支持运行时更新 GPU 与代理配置；变更后会自动重建相关运行环境。
  * 应用关闭时将自动释放 OCR 资源，提升稳定性。
* **Bug 修复**
  * OCR 调用在未初始化或空输入场景下更稳健（必要时自动初始化，并避免异常结果）。
* **文档**
  * 新增 OCR 生命周期管理说明文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->