### PR TITLE
feat: 自动战斗期间自动截图闪光图

### DIFF
--- a/src/one_dragon/envs/env_config.py
+++ b/src/one_dragon/envs/env_config.py
@@ -362,6 +362,22 @@ class EnvConfig(YamlConfig):
         self.update('is_debug', new_value)
 
     @property
+    def dodge_detect(self) -> bool:
+        """
+        闪避检测截图：开启后自动战斗检测到闪光时自动保存 debug 截图
+        :return:
+        """
+        return self.get('dodge_detect', True)
+
+    @dodge_detect.setter
+    def dodge_detect(self, new_value: bool) -> None:
+        """
+        更新闪避检测截图开关
+        :return:
+        """
+        self.update('dodge_detect', new_value)
+
+    @property
     def copy_screenshot(self) -> bool:
         """
         截图后是否复制到剪贴板

--- a/src/zzz_od/application/devtools/screenshot_helper/screenshot_helper_app.py
+++ b/src/zzz_od/application/devtools/screenshot_helper/screenshot_helper_app.py
@@ -91,9 +91,18 @@ class ScreenshotHelperApp(ZApplication):
 
         if self.config.dodge_detect:
             if self.ctx.auto_battle_context.dodge_context.check_dodge_flash(self.last_screenshot, self.last_screenshot_time):
-                debug_utils.save_debug_image(self.last_screenshot, prefix='dodge')
+                # 查 state record 判断具体闪光类型
+                sr = self.ctx.auto_battle_context.state_record_service
+                t = self.last_screenshot_time
+                prefix = 'dodge'
+                for state_name in ['闪避识别-红光', '闪避识别-黄光']:
+                    state = sr.get_state_recorder(state_name)
+                    if state is not None and state.last_record_time == t:
+                        prefix = 'dodge_red' if '红光' in state_name else 'dodge_yellow'
+                        break
+                debug_utils.save_debug_image(self.last_screenshot, prefix=prefix)
             elif self.ctx.auto_battle_context.dodge_context.check_dodge_audio(self.last_screenshot_time):
-                debug_utils.save_debug_image(self.last_screenshot, prefix='dodge')
+                debug_utils.save_debug_image(self.last_screenshot, prefix='dodge_audio')
 
         if self.to_save_screenshot:
             if not self.config.screenshot_before_key and self.is_saving_after_key:

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -14,7 +14,7 @@ from one_dragon.base.matcher.match_result import MatchResult
 from one_dragon.base.screen import screen_utils
 from one_dragon.base.screen.screen_area import ScreenArea
 from one_dragon.base.screen.screen_utils import FindAreaResultEnum
-from one_dragon.utils import cal_utils, cv2_utils, gpu_executor, str_utils, thread_utils
+from one_dragon.utils import cal_utils, cv2_utils, debug_utils, gpu_executor, str_utils, thread_utils
 from one_dragon.utils.log_utils import log
 from zzz_od.auto_battle.atomic_op.atomic_op_factory import AtomicOpFactory
 from zzz_od.auto_battle.auto_battle_agent_context import AutoBattleAgentContext
@@ -554,6 +554,8 @@ class AutoBattleContext:
         self.last_check_in_battle = in_battle
 
         future_list: list[Future] = []
+        flash_future: Future | None = None
+        audio_future: Future | None = None
 
         # 统一提交检测任务
         if in_battle:
@@ -561,9 +563,10 @@ class AutoBattleContext:
             audio_future = _battle_state_check_executor.submit(self.dodge_context.check_dodge_audio, screenshot_time)
             future_list.append(audio_future)
             if self.ctx.model_config.flash_classifier_gpu:
-                future_list.append(gpu_executor.submit(self.dodge_context.check_dodge_flash, screen, screenshot_time, audio_future))
+                flash_future = gpu_executor.submit(self.dodge_context.check_dodge_flash, screen, screenshot_time, audio_future)
             else:
-                future_list.append(_battle_state_check_executor.submit(self.dodge_context.check_dodge_flash, screen, screenshot_time, audio_future))
+                flash_future = _battle_state_check_executor.submit(self.dodge_context.check_dodge_flash, screen, screenshot_time, audio_future)
+            future_list.append(flash_future)
 
             # 角色状态
             future_list.append(_battle_state_check_executor.submit(self.agent_context.check_agent_related, screen, screenshot_time))
@@ -605,6 +608,16 @@ class AutoBattleContext:
         if sync:
             for future in future_list:
                 future.result()
+
+        # debug 闪避检测截图
+        if self.ctx.env_config.dodge_detect and flash_future is not None and audio_future is not None:
+            try:
+                flash_detected = flash_future.result()
+                audio_detected = audio_future.result()
+                if flash_detected or audio_detected:
+                    debug_utils.save_debug_image(screen, prefix='dodge')
+            except Exception:
+                log.error('保存闪避 debug 截图失败', exc_info=True)
 
         return in_battle
 

--- a/src/zzz_od/gui/view/devtools/devtools_screenshot_helper_interface.py
+++ b/src/zzz_od/gui/view/devtools/devtools_screenshot_helper_interface.py
@@ -50,7 +50,7 @@ class DevtoolsScreenshotHelperInterface(AppRunInterface):
         top_widget.add_widget(self.key_save_opt)
 
         self.dodge_detect_opt = SwitchSettingCard(icon=FluentIcon.GAME, title='闪避检测',
-                                                  content='脚本识别黄光红光时，自动截图，用于捕捉误判')
+                                                  content='脚本识别黄光红光时，自动截图，用于捕捉误判；开启后自动战斗也会同步保存闪光截图')
         top_widget.add_widget(self.dodge_detect_opt)
 
         self.screenshot_before_key_opt = SwitchSettingCard(icon=FluentIcon.GAME, title='按键前截图',


### PR DESCRIPTION
在自动战斗期间检测到闪避闪光（红光/黄光/音频）时，自动保存 debug 截图，并按类型区分文件名前缀。

- 新增 `dodge_detect` 配置项（默认开启），可控制是否截图
- 根据闪光类型分别保存为 `dodge_red` / `dodge_yellow` / `dodge_audio`
- 截图助手中的闪光检测也同步改为按类型保存