### PR TITLE
AI编程工具文档规范

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,12 @@ deploy/dist/
 recording.jsonl
 QWEN.md
 GEMINI.md
-CLAUDE.md
+CLAUDE.local.md
 .lingma/
 .qwen/
-.claude/
+.claude/*
+!.claude/CLAUDE.md
+nul
 
 # 用户独有的配置文件
 env.bat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 本文件是项目级 AI 编码协作入口，只保留会直接影响实现落点与提交流程的约束。
 详细规范与背景资料不要堆在这里，按需继续阅读：
-- 开发环境与 Vibe Coding 配置：[docs/develop/README.md](docs/develop/README.md)
+- 开发环境与打包：[docs/develop/README.md](docs/develop/README.md)
 - 详细编码规范：[docs/develop/spec/agent_guidelines.md](docs/develop/spec/agent_guidelines.md)
 - 一条龙整体架构：[docs/develop/one_dragon/one_dragon_architecture.md](docs/develop/one_dragon/one_dragon_architecture.md)
 - 应用插件开发指引：[docs/develop/guides/application_plugin_guide.md](docs/develop/guides/application_plugin_guide.md)
@@ -84,7 +84,3 @@ uv run --env-file .env ruff check --fix src/你修改的文件.py
 - 框架与模块架构：`docs/develop/one_dragon/`、`docs/develop/one_dragon/modules/`
 - 游戏业务与专项设计：`docs/develop/zzz/`
 - 打包与 RuntimeLauncher：`docs/develop/README.md`、`docs/develop/one_dragon/runtime_launcher.md`
-
-## AI 工具接入
-
-本仓库以根目录 `AGENTS.md` 作为统一入口；其他工具按 [docs/develop/README.md](docs/develop/README.md) 中的硬链接说明接入即可。

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -1,16 +1,22 @@
 # 开发指南
 
+> `docs/develop/` 的入口与索引。开发环境与流程见 §1–§3；各类专题文档按下索引查阅。
+
+## 文档索引
+
+- **开发环境与工具**：[开发环境](setup/environment.md) · [AI 编码助手接入](setup/ai_coding.md)
+- **编码规范**：[agent_guidelines.md](spec/agent_guidelines.md)
+- **架构设计**：[一条龙整体架构](one_dragon/one_dragon_architecture.md) · [集成启动器 RuntimeLauncher](one_dragon/runtime_launcher.md) · [模块文档](one_dragon/modules/)
+- **开发指引**：[应用插件开发](guides/application_plugin_guide.md) · [应用设置界面](guides/application_setting_guide.md)
+- **游戏业务**：[自动战斗](zzz/auto_battle.md) · [进游戏](zzz/enter_game.md) · [转向与灵敏度](zzz/turn_sensitivity.md) · [功能模块](zzz/application/) · [Web 架构](zzz/web/web-architecture.md)
+- **AI Harness 工程**：[总览与路线图](harness/README.md)
+- **设计文档**：[屏幕区域识别设计](screen_scope_design.md) · [屏幕区域推进](screen_scope_rollout.md)
+
 ## 1.开发
 
 ### 1.1.开发环境
 
-项目使用 [uv](https://github.com/astral-sh/uv/releases/latest) 进行依赖管理，使用以下命令可安装对应环境。
-
-```shell
-uv sync --group dev
-```
-
-项目整体布局使用`src-layout`结构，源代码位于`src/`目录下。请自行在IDE中设置为`Sources Root`，或增加环境变量`PYTHONPATH=src`。
+见 [setup/environment.md](setup/environment.md)。
 
 ### 1.2.代码规范
 
@@ -53,23 +59,8 @@ uv run --env-file .env pytest zzz-od-test/
 
 ## 2.Vibe Coding
 
-### Agent指南
-
-推荐使用 [agent_guidelines.md](spec/agent_guidelines.md) 指导Agent进行编程
-
-可以通过创建硬链接到各个编程工具所需位置
-
-> 以下命令请在仓库根目录执行。
-
-- Qwen Coder - `New-Item -ItemType HardLink -Path "QWEN.md" -Target "AGENTS.md"`
-- Lingma Rules - `New-Item -ItemType HardLink -Path ".lingma/rules/project_rule.md" -Target "AGENTS.md"`
-- Gemini CLI - `New-Item -ItemType HardLink -Path "GEMINI.md" -Target "AGENTS.md"`
-- Claude Code - `New-Item -ItemType HardLink -Path "CLAUDE.md" -Target "AGENTS.md"`
-
-
-### 推荐MCP
-
-- [context7](https://github.com/upstash/context7) - 查询各个库的文档。
+- AI 编码工具（Claude Code / GitHub Copilot / Qwen / Gemini 等）的接入方式、MCP 与扩展配置见 [setup/ai_coding.md](setup/ai_coding.md)。
+- AI Coding Harness 工程的设计决策、skill 清单与 MCP 路线图见 [harness/](harness/README.md)。
 
 ## 3.打包
 

--- a/docs/develop/harness/README.md
+++ b/docs/develop/harness/README.md
@@ -1,0 +1,43 @@
+# AI Coding Harness 工程
+
+本目录是「绝区零一条龙」**AI 编码 harness 工程**的专题文档区。它记录"如何让 AI 编码工具（Claude Code 等）在本项目高效、可靠地工作"这件事本身的工程化沉淀。
+
+## 什么是 harness 工程
+
+Harness 指把 LLM 变成能干活的编码 Agent 的那一层"外壳"——上下文（CLAUDE.md / AGENTS.md）、工具（MCP / skills / commands）、记忆、权限，以及把本项目特有的能力（游戏操作、CV 调试）暴露给 Agent 的接入层。模型本身只会 next-token，harness 决定它能不能在这个 repo 里**做对事**。
+
+## 两条方向
+
+- **方向 A｜武装 harness（当前重心）**：把项目知识、规范、工具固化进 harness，让 AI（和贡献者）开箱即用、少踩坑。已落地：`AGENTS.md` 单源、`.claude/CLAUDE.md`、`skills/`、`setup/ai_coding.md`。
+- **方向 B｜MCP 驱动的游戏自动化（远期）**：把游戏操作（截图 / OCR / 进游戏 / 跑流程）通过常驻 MCP 暴露给 Agent，用于辅助开发调试，乃至让 Agent 直接驱动游戏。
+
+## 当前状态（方向 A）
+
+| 组件 | 位置 | 作用 |
+|---|---|---|
+| `AGENTS.md` | 仓库根 | 统一 AI 编码入口（架构 / 硬约束 / 流程），所有工具的信息源 |
+| `.claude/CLAUDE.md` | 仓库根 | Claude Code 入口，`@../AGENTS.md` 引入 |
+| `.github/copilot-instructions.md` | 仓库根 | Copilot 入口 |
+| [`skills/`](../../../skills/) | 仓库根 | 4 个 Claude Code skill（`agent-auto-battle-config` / `agent-definition` / `new-config` / `zzz-one-dragon-player`） |
+| [../setup/ai_coding.md](../setup/ai_coding.md) | docs/develop/setup | 各 AI 工具的接入指引（用户向："怎么用"） |
+
+> "怎么用"见 `setup/ai_coding.md`；本目录（harness/）记录"怎么建、为什么这么建"。
+
+## 架构原则
+
+1. **单一信息源**：项目知识集中在 `AGENTS.md` + `docs/`，工具入口用 `@import` 引入而非复制。
+2. **贵重 infra 常驻**：MCP 的价值是让 `ZContext`（OCR / YOLO / 控制器）常驻内存，规避每次冷启动数秒成本。
+3. **共享 Layer 0、单服务器生长**：A→B1 工具在同一 MCP 服务器内按命名空间增长；B2（模型实时当玩家）另起独立 loop，复用 Layer 0，MCP 退为控制面。
+
+## 路线图
+
+| 阶段 | 内容 | 状态 |
+|---|---|---|
+| A-1 | AGENTS.md 单源 + CLAUDE.md/@import + ai-tooling 文档 | ✅ |
+| A-2 | skills/ 整理与约定 | ⏳ 待实施 |
+| A-3 | devtools 调试指南、术语表、游戏领域文档 | ⏳ 规划 |
+| B-1 | MCP：dev/inspection 工具（截图 / OCR / 跑流程） | ⏳ 规划 |
+| B-2 | MCP：原子操作工具 + 跑现成 Application/Operation | ⏳ 规划 |
+| B-3 | 模型实时当玩家（独立 loop，MCP 作控制面） | 🔭 远期 |
+
+> 各方向的详细设计（决策记录 / skill 清单 / MCP 实现）在真正实施后再补对应子文档。

--- a/docs/develop/setup/ai_coding.md
+++ b/docs/develop/setup/ai_coding.md
@@ -1,0 +1,76 @@
+# AI 编码助手接入
+
+本仓库支持多种 AI 编码助手（如 Claude Code、GitHub Copilot 等）协作开发。本文档说明如何把它们接入本项目，以及**新增的 AI 协作约定应该放到哪一级**。
+
+## 核心原则：三级晋升
+
+新增任何"给 AI 看的约定"时，按下面的阶梯**从低到高**放——能放低就不放高：
+
+| 级别 | 位置 | 是否提交 | 适用 |
+|---|---|:---:|---|
+| **① 个人级** | `CLAUDE.local.md`（及各工具的本地文件） | ❌ gitignore | 只对自己有用的偏好、实验性约定。**先在这里试。** |
+| **② 项目级** | 工具的项目文件（如 `.claude/CLAUDE.md`、`.github/copilot-instructions.md`）或 `docs/develop/` 文档 | ✅ 提交 | 团队共享、但**某个工具特有**的内容。 |
+| **③ 统一源** | 根目录 `AGENTS.md` | ✅ 提交 | **跨工具通用**的项目知识（架构、硬约束、流程）。 |
+
+**晋升路径**：① 个人级 →（证明对团队有用）→ ② 项目级 →（证明跨工具通用）→ ③ `AGENTS.md`。
+
+- **工具特有**的内容（如 Claude 专属的 uv / context7 规则）**不进 `AGENTS.md`**，留在该工具的项目级文件里。
+- 只有"所有工具都该知道"的内容，才晋升到 `AGENTS.md`。
+
+## AGENTS.md：统一源
+
+根目录 [AGENTS.md](../../../AGENTS.md) 是跨工具的单一信息源（项目架构、开发硬约束、提交流程）；详细编码规范见 [spec/agent_guidelines.md](../spec/agent_guidelines.md)。
+
+> 修改这两份即等同于更新所有已接入工具的行为——前提是内容确实**跨工具通用**。否则按上面的阶梯放低一级。
+
+## 各工具接入
+
+> **原则**：入口文件优先放该工具自己的**配置目录**（如 `.claude/`、`.github/`），而不是项目根目录，避免根目录堆积。最理想的是工具能直接读 `AGENTS.md`——这样根本不需要入口文件。
+
+### Claude Code（用 `@` 引用，不用硬链接）
+
+- 仓库已提交 `.claude/CLAUDE.md`，内部用 `@../AGENTS.md` **引入** `AGENTS.md`。Claude Code 启动时自动加载，无需配置。
+- **Claude 特有**的项目级规则写在 `.claude/CLAUDE.md` 里 `@` 引入的**下方**（提交、团队共享）。例如强制 `uv`、用 context7、Bash 后台等。
+- **个人**偏好写在仓库根 `CLAUDE.local.md`（gitignore），加载顺序在 `CLAUDE.md` 之后。
+
+### GitHub Copilot
+
+- 仓库已提交 `.github/copilot-instructions.md`（frontmatter `applyTo: '**'`，对所有文件生效）；每次会话自动注入，并 defer 到 `AGENTS.md` 取完整上下文。
+
+### 其他工具（无原生引入机制时）
+
+若某工具既读不了 `AGENTS.md`、又没有 `@` 之类的引入语法，只能读它自己固定的入口文件，就用**硬链接**让该文件镜像 `AGENTS.md`。入口文件位置同样遵循上面的原则——优先配置目录，其次根目录。
+
+示例（文件名依工具而定，此处以 `CLAUDE.md` 作占位演示命令形式）：
+
+```powershell
+New-Item -ItemType HardLink -Path "CLAUDE.md" -Target "AGENTS.md"
+```
+
+- 该入口文件应被 `.gitignore` 忽略，仅本地生效（个人级）。
+- 工具特有的项目级内容，另起一个**提交**的文件维护，不要塞进 `AGENTS.md`。
+- 将来某工具支持引入语法时，优先用引入、弃用硬链接。（Unix：`ln AGENTS.md CLAUDE.md`。）
+
+## 内容该放哪（速查）
+
+| 内容 | 放哪 |
+|---|---|
+| 只对自己有用的偏好 / 实验 | ① 个人级：`CLAUDE.local.md` |
+| 团队共享、但某工具特有 | ② 项目级：该工具文件（如 `.claude/CLAUDE.md`） |
+| 跨所有工具通用 | ③ `AGENTS.md` |
+
+## MCP
+
+- **推荐**：[context7](https://github.com/upstash/context7) — 查询库文档；已在本项目 `.claude/settings.json` 启用（Claude Code 场景）。
+- **项目自有 MCP（规划中）**：后续将把游戏操作（截图 / OCR / 进游戏等）暴露给 agent，用于辅助开发与调试。整体设计见 [harness/README.md](../harness/README.md)。
+
+## Skills
+
+现有 Claude Code skill 在仓库根 `skills/`（如 `agent-auto-battle-config`、`agent-definition`、`new-config`）。后续约定与清单见 [harness/README.md](../harness/README.md)（待实施）。
+
+## 相关文档
+
+- [AGENTS.md](../../../AGENTS.md) — 统一 AI 编码协作入口
+- [spec/agent_guidelines.md](../spec/agent_guidelines.md) — 详细编码规范
+- [开发指南](../README.md)
+- [AI Coding Harness 工程](../harness/README.md)

--- a/docs/develop/setup/environment.md
+++ b/docs/develop/setup/environment.md
@@ -1,0 +1,13 @@
+# 开发环境
+
+## 依赖管理
+
+本项目使用 [uv](https://github.com/astal-sh/uv/releases/latest) 进行依赖管理。安装开发环境：
+
+```shell
+uv sync --group dev
+```
+
+## 源码布局（src-layout）
+
+项目使用 `src-layout` 结构，源代码位于 `src/` 目录下。请自行在 IDE 中设置为 `Sources Root`，或增加环境变量 `PYTHONPATH=src`。


### PR DESCRIPTION
要开始我们项目的Harness之路了

这半年发展很快，我在公司内部推进好几个系统的Harness工程化，效果都还不错，已经基本不需要古法编程了。

业界趋势也是这样，文档 -> 设计 -> 开发 -> 测试 -> 部署 -> 运维，全方位都有AI介入。我目前感觉最重要的还是端到端的集成测试，毕竟这个直接决定了最终质量。

我们的开始，肯定是要服侍好我们的AI工具，本次界定的是工具文档的维护规范：个人级 -> 项目级(工具 例如 CLAUDE.md) -> 项目级(全局AGENTS.md)

项目级(工具)由用这个工具的开发来共同决定， AGENTS.md 由 @ShadowLemoon 把关决定

后续像这种不会影响实际功能的，我会直接合入，加快点推进的节奏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增多份开发文档入口与说明，涵盖 AI 编码助手接入、开发环境、文档索引与相关架构指引。
  * 新增 `.claude/CLAUDE.md`，作为 Claude 相关配置入口。

* **文档**
  * 统一调整项目级开发资料的引用结构，补充 AI Coding Harness、工具接入方式和环境配置说明。
  * 更新忽略规则，保留必要的项目级 Claude 文档，同时新增个人配置忽略项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->