### PR TITLE
fix: 更新所有日常app的交互时机，防止交互无效

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -121,7 +121,7 @@ class CoffeeApp(ZApplication):
                 return result
             self.ctx.controller.move_w(press=True, press_time=1, release=True)
 
-        time.sleep(1)
+        time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
 
         if self.config.transport_point == CoffeeTransportPoint.POINT_2.value.value:

--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -126,6 +126,7 @@ class CoffeeApp(ZApplication):
 
         if self.config.transport_point == CoffeeTransportPoint.POINT_2.value.value:
             return self.round_success(status='对话点单')
+
         return self.round_success()
 
     @node_from(from_name='移动交互')

--- a/src/zzz_od/application/hou_hou_bakery/hou_hou_bakery_app.py
+++ b/src/zzz_od/application/hou_hou_bakery/hou_hou_bakery_app.py
@@ -44,8 +44,8 @@ class HouHouBakeryApp(ZApplication):
     def move_and_interact(self) -> OperationRoundResult:
         """传送之后与吼吼先生交互, 打开领奖界面。传送点已足够近, 无需前移。"""
         # self.ctx.controller.move_w(press=True, press_time=1, release=True)
-        # time.sleep(1)
 
+        time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
         time.sleep(3)
 

--- a/src/zzz_od/application/hou_hou_bakery/hou_hou_bakery_app.py
+++ b/src/zzz_od/application/hou_hou_bakery/hou_hou_bakery_app.py
@@ -47,9 +47,8 @@ class HouHouBakeryApp(ZApplication):
 
         time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
-        time.sleep(3)
 
-        return self.round_success()
+        return self.round_success(wait=3)
 
     @node_from(from_name='移动交互')
     @node_notify(when=NotifyTiming.CURRENT_DONE)
@@ -70,7 +69,7 @@ class HouHouBakeryApp(ZApplication):
         # 2.当日已在其他项目(刮刮卡/卦象集录等)签到-点击盲盒后提示「今日已经完成过一次相同类型的奖励领取」-节点退出
         # 残留弹窗交由后续「返回大世界」统一处理。
         # 必须置于「确定/确认」分支之前: 否则弹窗自带的「确认」会被该分支误点,
-        #   关闭弹窗后退回集卡机 -> 再点盲盒 -> 又弹窗, 反复循环直至节点重试耗尽而失败(issue #2395)。
+        #   关闭弹窗后退回集卡机 -> 再点盲盒 -> 又弹窗, 反复循环直至节点重试耗尽而失败。
         result = self.round_by_ocr(self.last_screenshot, '同类型奖励')
         if result.is_success:
             status = '领取成功' if self.claimed else '今日已领取'
@@ -112,7 +111,7 @@ class HouHouBakeryApp(ZApplication):
 def __debug() -> None:
     """本地调试入口: 初始化上下文并直接运行一次吼吼饼铺签到。"""
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     app = HouHouBakeryApp(ctx)
     app.execute()
 

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -92,6 +92,7 @@ class RandomPlayApp(ZApplication):
 
         time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
+
         return self.round_success()
 
     @node_from(from_name='移动交互')

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -90,7 +90,7 @@ class RandomPlayApp(ZApplication):
                 return result
             self.ctx.controller.move_w(press=True, press_time=1, release=True)
 
-        time.sleep(1)
+        time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
         return self.round_success()
 

--- a/src/zzz_od/application/scratch_card/scratch_card_app.py
+++ b/src/zzz_od/application/scratch_card/scratch_card_app.py
@@ -49,8 +49,8 @@ class ScratchCardApp(ZApplication):
         :return:
         """
         self.ctx.controller.move_w(press=True, press_time=1, release=True)
-        time.sleep(1)
 
+        time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
         time.sleep(3)
 

--- a/src/zzz_od/application/scratch_card/scratch_card_app.py
+++ b/src/zzz_od/application/scratch_card/scratch_card_app.py
@@ -52,9 +52,8 @@ class ScratchCardApp(ZApplication):
 
         time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
-        time.sleep(3)
 
-        return self.round_success()
+        return self.round_success(wait=3)
 
     @node_from(from_name='等待加载', status='刮刮卡')
     @node_from(from_name='移动交互')
@@ -102,7 +101,7 @@ class ScratchCardApp(ZApplication):
             return self.round_retry(status=result.status, wait=1)
 
         areas = [
-            self.ctx.screen_loader.get_area('报刊亭', '刮层-%d' % i)
+            self.ctx.screen_loader.get_area('报刊亭', f'刮层-{i}')
             for i in range(1, 4)
         ]
 
@@ -125,7 +124,7 @@ class ScratchCardApp(ZApplication):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     app = ScratchCardApp(ctx)
     app.execute()
 

--- a/src/zzz_od/application/trigrams_collection/trigrams_collection_app.py
+++ b/src/zzz_od/application/trigrams_collection/trigrams_collection_app.py
@@ -5,7 +5,7 @@ from one_dragon.base.geometry.rectangle import Rect
 from one_dragon.base.matcher.ocr import ocr_utils
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
-from one_dragon.base.operation.operation_notify import node_notify, NotifyTiming
+from one_dragon.base.operation.operation_notify import NotifyTiming, node_notify
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from zzz_od.application.trigrams_collection import trigrams_collection_const
 from zzz_od.application.zzz_application import ZApplication
@@ -41,9 +41,8 @@ class TrigramsCollectionApp(ZApplication):
 
         time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
-        time.sleep(3)
 
-        return self.round_success()
+        return self.round_success(wait=3)
 
     @node_from(from_name='移动交互')
     @node_notify(when=NotifyTiming.CURRENT_DONE)
@@ -94,7 +93,7 @@ class TrigramsCollectionApp(ZApplication):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     app = TrigramsCollectionApp(ctx)
     app.execute()
 

--- a/src/zzz_od/application/trigrams_collection/trigrams_collection_app.py
+++ b/src/zzz_od/application/trigrams_collection/trigrams_collection_app.py
@@ -38,8 +38,8 @@ class TrigramsCollectionApp(ZApplication):
         :return:
         """
         # self.ctx.controller.move_w(press=True, press_time=1, release=True)
-        # time.sleep(1)
 
+        time.sleep(1) # 防止交互无效 issue #2405 #2395 #2328
         self.ctx.controller.interact(press=True, press_time=0.2, release=True)
         time.sleep(3)
 


### PR DESCRIPTION
close #2405 
close #2395  

Close #2328 as completed via #2373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整多个交互流程的等待时机：在点击前增加短暂等待，并统一在完成后按指定时间结束，提升交互稳定性。
  * 修正部分场景中可能出现的反复弹窗和点击无效问题。
  * 优化刮卡流程中的区域命名方式，保持结果一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->