### PR TITLE
fix: 优化脱困阈值和首层选择目标算法

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_context.py
@@ -56,11 +56,13 @@ class LostVoidContext:
         self.priority_updated: bool = False  # 动态优先级是否已经更新
         self.dynamic_priority_list: list[str] = []  # 动态获取的优先级列表
         self.dynamic_abandon_list: list[str] = []  # 动态放弃组
+        self.had_interacted_ophelia_on_current_level: bool = False  # 当前层是否已交互过奥菲莉亚
 
     def init_before_run(self) -> None:
         self.priority_updated = False
         self.dynamic_priority_list = []
         self.dynamic_abandon_list = []
+        self.had_interacted_ophelia_on_current_level = False
         self.init_lost_void_det_model()
         self.load_artifact_data()
         self.load_challenge_config()
@@ -881,21 +883,35 @@ class LostVoidContext:
 
         return result
 
-    def get_entry_by_priority(self, entry_list: list[MoveTargetWrapper]) -> MoveTargetWrapper | None:
+    def get_entry_by_priority(
+        self,
+        entry_list: list[MoveTargetWrapper],
+        ignore_entry_list: list[str] | None = None,
+    ) -> MoveTargetWrapper | None:
         """
         根据优先级 返回一个前往的入口
         多个相同入口时选择最右 (因为丢失寻找目标的时候是往左转找)
         :param entry_list:
+        :param ignore_entry_list:
         :return:
         """
         if entry_list is None or len(entry_list) == 0:
             return None
 
+        ignore_entry_set: set[str] = set(ignore_entry_list) if ignore_entry_list is not None else set()
+        if self.had_interacted_ophelia_on_current_level:
+            ignore_entry_set.add(LostVoidRegionType.ELITE.value.value)
+
         for priority in self.challenge_config.region_type_priority:
+            if priority in ignore_entry_set:
+                continue
+
             target: MoveTargetWrapper | None = None
 
             for entry in entry_list:
                 for target_name in entry.target_name_list:
+                    if target_name in ignore_entry_set:
+                        continue
                     if target_name != priority:
                         continue
 
@@ -907,6 +923,8 @@ class LostVoidContext:
 
         target: MoveTargetWrapper | None = None
         for entry in entry_list:
+            if any(target_name in ignore_entry_set for target_name in entry.target_name_list):
+                continue
             if target is None or entry.entire_rect.x1 > target.entire_rect.x1:
                 target = entry
 

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -855,11 +855,13 @@ class LostVoidApp(ZApplication):
         op_result = op.execute()
         if op_result.success:
             if op_result.status == LostVoidRunLevel.STATUS_NEXT_LEVEL:
+                self.ctx.lost_void.had_interacted_ophelia_on_current_level = False
                 if op_result.data is not None:
                     self.next_region_type = LostVoidRegionType.from_value(op_result.data)
                 else:
                     self.next_region_type = LostVoidRegionType.ENTRY
             elif op_result.status == LostVoidRunLevel.STATUS_COMPLETE:
+                self.ctx.lost_void.had_interacted_ophelia_on_current_level = False
                 self.next_region_type = LostVoidRegionType.ENTRY
 
         return self.round_by_op_result(op_result)

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -573,9 +573,10 @@ class LostVoidMoveByDet(ZOperation):
             self.ctx.controller.normal_attack(press=True, press_time=0.2, release=True)
             time.sleep(1)
 
-        backward_press_time = min(max(self.stuck_times - 1, 0) * 0.5, 2)
-        side_press_time = min(self.stuck_times * 0.2, 2)
-        forward_press_time = min(max(self.stuck_times - 1, 0) * 0.2, 2)
+        escape_phase = (self.stuck_times - 1) % 8
+        backward_press_time = min(escape_phase * 0.5, 2)
+        side_press_time = min((escape_phase + 1) * 0.2, 2)
+        forward_press_time = min(escape_phase * 0.2, 2)
 
         self.ctx.controller.move_s(press=True, press_time=backward_press_time, release=True)
         if self.prefer_left_escape:

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -566,9 +566,9 @@ class LostVoidMoveByDet(ZOperation):
             self.ctx.controller.normal_attack(press=True, press_time=0.2, release=True)
             time.sleep(1)
 
-        backward_press_time = min(self.stuck_times - 1 * 0.5, 2)
-        side_press_time = min(self.stuck_times * 0.5, 2)
-        forward_press_time = min(max(self.stuck_times - 1, 0) * 0.5, 2)
+        backward_press_time = min(max(self.stuck_times - 1, 0) * 0.5, 2)
+        side_press_time = min(self.stuck_times * 0.2, 2)
+        forward_press_time = min(max(self.stuck_times - 1, 0) * 0.2, 2)
 
         self.ctx.controller.move_s(press=True, press_time=backward_press_time, release=True)
         if self.prefer_left_escape:

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -532,14 +532,15 @@ class LostVoidMoveByDet(ZOperation):
         )
 
         if all_visible_targets_static:
-            increase_count = 0.1 if len(visible_target_list) == 1 else 1
+            increase_count = 0.2 if len(visible_target_list) == 1 else 1
             self.same_target_times += increase_count
         else:
             self.same_target_times = 0
 
         self.last_visible_target_list = visible_target_list
+        stuck_threshold = 5 if len(visible_target_list) == 1 else 20
 
-        if self.same_target_times >= 10:
+        if self.same_target_times >= stuck_threshold:
             self.ctx.controller.stop_moving_forward()
             self.stuck_times += 1
             self._reset_stuck_status()

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -487,14 +487,14 @@ class LostVoidMoveByDet(ZOperation):
             return False, f'目标数量变化 last={len(last_target_list)} current={len(new_target_list)}'
 
         used_idx_set: set[int] = set()
+        class_changed: bool = False
         for new_target in new_target_list:
             matched_idx: int | None = None
             matched_distance: float | None = None
+            matched_last_target: MoveTargetWrapper | None = None
 
             for idx, last_target in enumerate(last_target_list):
                 if idx in used_idx_set:
-                    continue
-                if last_target.leftest_target_name != new_target.leftest_target_name:
                     continue
 
                 dis = cal_utils.distance_between(last_target.entire_rect.center, new_target.entire_rect.center)
@@ -504,6 +504,7 @@ class LostVoidMoveByDet(ZOperation):
                 if matched_distance is None or dis < matched_distance:
                     matched_idx = idx
                     matched_distance = dis
+                    matched_last_target = last_target
 
             if matched_idx is None:
                 return False, (
@@ -511,9 +512,15 @@ class LostVoidMoveByDet(ZOperation):
                     f'center={new_target.entire_rect.center}'
                 )
 
+            if matched_last_target is not None and matched_last_target.leftest_target_name != new_target.leftest_target_name:
+                class_changed = True
+
             used_idx_set.add(matched_idx)
 
-        return True, '全部可见目标位移都在阈值内'
+        if class_changed:
+            return True, '全部可见目标位移都在阈值内，且存在类别抖动'
+        else:
+            return True, '全部可见目标位移都在阈值内'
 
     def check_stuck(self, frame_result: DetectFrameResult, new_target: MoveTargetWrapper) -> OperationRoundResult | None:
         """

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -448,6 +448,13 @@ class LostVoidMoveByDet(ZOperation):
             if i.merge_parent is None
         ]
 
+        if self.ctx.lost_void.had_interacted_ophelia_on_current_level:
+            entry_list = [
+                item
+                for item in entry_list
+                if LostVoidRegionType.ELITE.value.value not in item.target_name_list
+            ]
+
         if self.last_target_result is not None:  # 优先保持与上次一致的目标
             result = self.get_same_as_last_target(entry_list)
             if result is not None:
@@ -456,9 +463,9 @@ class LostVoidMoveByDet(ZOperation):
         not_mixed_entry_list = [item for item in entry_list if not item.is_mixed]
         mixed_entry_list = [item for item in entry_list if item.is_mixed]
         if len(not_mixed_entry_list) > 0:
-            return self.ctx.lost_void.get_entry_by_priority(not_mixed_entry_list)
+            return self.ctx.lost_void.get_entry_by_priority(not_mixed_entry_list, self.ignore_entry_list)
         elif len(mixed_entry_list) > 0:
-            return self.ctx.lost_void.get_entry_by_priority(mixed_entry_list)
+            return self.ctx.lost_void.get_entry_by_priority(mixed_entry_list, self.ignore_entry_list)
         else:
             return None
 

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -754,6 +754,8 @@ class LostVoidRunLevel(ZOperation):
                 self.interacted_target_key_list.append(target_key)
 
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):
+            if self.interact_target is not None and self.interact_target.name == LostVoidInteractNPC.AO_FEI_LI_YA.value:
+                self.ctx.lost_void.had_interacted_ophelia_on_current_level = True
             if not (self.boss_pre_battle
                     and self.interact_target is not None
                     and not self.interact_target.after_battle):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 交互后重置并重新筛选本层目标，避免精英目标干扰，提升入口选择匹配准确度。
  * 改进可见目标“整体静止”判断：新增类别抖动检测，降低误判并让说明更贴合实际。
  * 调整“卡住”检测阈值与计数累加逻辑，单目标更敏感、脱困更及时。
  * 优化脱困按键节奏，采用分段取模计算，减少无效按键与停滞。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->