### PR TITLE
fix: 修复迷失之地与ocrv6的兼容性，补挑战结果分支

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5016,10 +5016,10 @@
   - area_name: 按钮-确定
     id_mark: true
     pc_rect:
-    - 847
-    - 762
-    - 1125
-    - 975
+    - 466
+    - 758
+    - 1406
+    - 977
     text: 确定
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -4927,10 +4927,10 @@
   - area_name: 标题-挑战结果
     id_mark: true
     pc_rect:
-    - 566
-    - 92
-    - 1340
-    - 286
+    - 581
+    - 24
+    - 1354
+    - 289
     text: 挑战结果
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -4941,10 +4941,10 @@
   - area_name: 按钮-确定
     id_mark: false
     pc_rect:
-    - 1054
-    - 900
-    - 1276
-    - 966
+    - 936
+    - 855
+    - 1338
+    - 997
     text: 确定
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/lost_void_battle_result.yml
+++ b/assets/game_data/screen_info/lost_void_battle_result.yml
@@ -6,10 +6,10 @@ area_list:
 - area_name: 标题-挑战结果
   id_mark: true
   pc_rect:
-  - 566
-  - 92
-  - 1340
-  - 286
+  - 581
+  - 24
+  - 1354
+  - 289
   text: 挑战结果
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -20,10 +20,10 @@ area_list:
 - area_name: 按钮-确定
   id_mark: false
   pc_rect:
-  - 1054
-  - 900
-  - 1276
-  - 966
+  - 936
+  - 855
+  - 1338
+  - 997
   text: 确定
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/lost_void_choose_common.yml
+++ b/assets/game_data/screen_info/lost_void_choose_common.yml
@@ -20,10 +20,10 @@ area_list:
 - area_name: 按钮-确定
   id_mark: true
   pc_rect:
-  - 847
-  - 762
-  - 1125
-  - 975
+  - 466
+  - 758
+  - 1406
+  - 977
   text: 确定
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/src/onnxocr/predict_det.py
+++ b/src/onnxocr/predict_det.py
@@ -117,7 +117,7 @@ class TextDetector(PredictBase):
         input_feed = self.get_input_feed(self.det_input_name, img)
         t0 = time.time()
         outputs = self.run_onnx_session(self.det_onnx_session, self.det_output_name, input_feed=input_feed)
-        log.debug("Detection inference time: {:.3f}s", time.time() - t0)
+        # log.debug("Detection inference time: {:.3f}s", time.time() - t0)
 
         preds = {}
         preds["maps"] = outputs[0]

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -569,6 +569,7 @@ class LostVoidRunLevel(ZOperation):
                 '迷失之地-邦布商店',
                 '迷失之地-路径迭换',
                 '迷失之地-抽奖机',
+                '迷失之地-挑战结果',
                 '迷失之地-大世界'
             ]
         )
@@ -587,6 +588,8 @@ class LostVoidRunLevel(ZOperation):
         elif screen_name == '迷失之地-抽奖机':
             interact_type = '邦布商店'  # TODO 1.6新增的抽奖机图标 会被误判成商店 等待后续模型更新
             interact_op = LostVoidLottery(self.ctx)
+        elif screen_name == '迷失之地-挑战结果':
+            return self.round_success('迷失之地-挑战结果')
         elif screen_name == '迷失之地-大世界':
             return self.round_success('迷失之地-大世界')
 

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -599,7 +599,7 @@ class LostVoidRunLevel(ZOperation):
                 if interact_type is not None:
                     self.had_been_list.append(interact_type)
 
-                return self.round_wait(op_result.status, wait=1)
+                return self.round_wait(op_result.status, wait=2)
             else:
                 return self.round_fail(op_result.status)
 


### PR DESCRIPTION
包含改动：
1. ocrv6需要更大的OCR框（适配迷失之地通用选择界面）
2. 清理predict_det冗余日志
3. 兼容连续购买商店的卡顿动画（加长确认后等待时间）
4. 补上遗漏的挑战结果分支，战斗奖励界面不会再被try_talk误拦截

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了「迷失之地」相关界面的识别区域，提升结果页与确认按钮的识别稳定性。
  * 优化了交互后的屏幕判断，新增对挑战结果页的直接识别，减少流程卡顿或误判。
  * 交互完成后的等待时间略有延长，使后续界面切换更稳定。
  * 关闭了一条检测耗时调试输出，减少不必要的日志干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->