### PR TITLE
opt: 优化佩洛伊斯跳过快速支援的战斗操作模板

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -11218,6 +11218,9 @@
               "seconds": 2.0
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-佩洛伊斯-buff, 0, 200]"
           - "debug_name": "佩洛伊斯-终结技-下上buff"
             "operations":
@@ -11257,6 +11260,9 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
+            - "op_name": "设置状态"
               "state": "自定义-佩洛伊斯-buff"
             "states": ""
         - "debug_name": "佩洛伊斯-黄光招架"
@@ -11271,6 +11277,9 @@
             "seconds": 0.5
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-黄光切人, 0, 1]"
         - "debug_name": "佩洛伊斯-红光处理"
           "states": "[自定义-红光闪避, 0, 1]"
@@ -11288,6 +11297,9 @@
               "repeat": 15
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[佩洛伊斯-特殊技可用]"
           - "debug_name": "佩洛伊斯-红光闪A"
             "operations":
@@ -11303,6 +11315,9 @@
               "repeat": 10
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": ""
         - "debug_name": "佩洛伊斯-连携攻击"
           "operations":
@@ -11319,6 +11334,9 @@
             "state": "自定义-动作不打断"
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-连携换人, 0, 0.5]"
         - "debug_name": "佩洛伊斯-切人等待"
           "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -11329,6 +11347,9 @@
               "seconds": 0.3
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-快速支援换人, 0, 0.5]"
           - "debug_name": "佩洛伊斯-等切人动画"
             "operations":
@@ -11422,7 +11443,8 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
-              "state": "自定义-快速释放天光"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-佩洛伊斯-buff, 0, 200]"
           - "debug_name": "佩洛伊斯-终结技-下上buff"
             "operations":
@@ -11462,6 +11484,9 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
+            - "op_name": "设置状态"
               "state": "自定义-佩洛伊斯-buff"
             "states": ""
         - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -11477,6 +11502,9 @@
             "repeat": 15
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
         - "debug_name": "佩洛伊斯-默认普攻"
           "operations":
@@ -21701,6 +21729,9 @@
             "seconds": 2.0
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-佩洛伊斯-buff, 0, 200]"
         - "debug_name": "佩洛伊斯-终结技-下上buff"
           "operations":
@@ -21740,6 +21771,9 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
+          - "op_name": "设置状态"
             "state": "自定义-佩洛伊斯-buff"
           "states": ""
       - "debug_name": "佩洛伊斯-黄光招架"
@@ -21754,6 +21788,9 @@
           "seconds": 0.5
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-黄光切人, 0, 1]"
       - "debug_name": "佩洛伊斯-红光处理"
         "states": "[自定义-红光闪避, 0, 1]"
@@ -21771,6 +21808,9 @@
             "repeat": 15
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[佩洛伊斯-特殊技可用]"
         - "debug_name": "佩洛伊斯-红光闪A"
           "operations":
@@ -21786,6 +21826,9 @@
             "repeat": 10
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": ""
       - "debug_name": "佩洛伊斯-连携攻击"
         "operations":
@@ -21802,6 +21845,9 @@
           "state": "自定义-动作不打断"
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-连携换人, 0, 0.5]"
       - "debug_name": "佩洛伊斯-切人等待"
         "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -21812,6 +21858,9 @@
             "seconds": 0.3
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-快速支援换人, 0, 0.5]"
         - "debug_name": "佩洛伊斯-等切人动画"
           "operations":
@@ -21905,7 +21954,8 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
-            "state": "自定义-快速释放天光"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-佩洛伊斯-buff, 0, 200]"
         - "debug_name": "佩洛伊斯-终结技-下上buff"
           "operations":
@@ -21945,6 +21995,9 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
+          - "op_name": "设置状态"
             "state": "自定义-佩洛伊斯-buff"
           "states": ""
       - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -21960,6 +22013,9 @@
           "repeat": 15
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
       - "debug_name": "佩洛伊斯-默认普攻"
         "operations":

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -10245,6 +10245,9 @@
               "seconds": 2.0
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-佩洛伊斯-buff, 0, 200]"
           - "debug_name": "佩洛伊斯-终结技-下上buff"
             "operations":
@@ -10284,6 +10287,9 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
+            - "op_name": "设置状态"
               "state": "自定义-佩洛伊斯-buff"
             "states": ""
         - "debug_name": "佩洛伊斯-黄光招架"
@@ -10298,6 +10304,9 @@
             "seconds": 0.5
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-黄光切人, 0, 1]"
         - "debug_name": "佩洛伊斯-红光处理"
           "states": "[自定义-红光闪避, 0, 1]"
@@ -10315,6 +10324,9 @@
               "repeat": 15
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[佩洛伊斯-特殊技可用]"
           - "debug_name": "佩洛伊斯-红光闪A"
             "operations":
@@ -10330,6 +10342,9 @@
               "repeat": 10
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": ""
         - "debug_name": "佩洛伊斯-连携攻击"
           "operations":
@@ -10346,6 +10361,9 @@
             "state": "自定义-动作不打断"
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-连携换人, 0, 0.5]"
         - "debug_name": "佩洛伊斯-切人等待"
           "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -10356,6 +10374,9 @@
               "seconds": 0.3
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
+            - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-快速支援换人, 0, 0.5]"
           - "debug_name": "佩洛伊斯-等切人动画"
             "operations":
@@ -10449,7 +10470,8 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
-              "state": "自定义-快速释放天光"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
             "states": "[自定义-佩洛伊斯-buff, 0, 200]"
           - "debug_name": "佩洛伊斯-终结技-下上buff"
             "operations":
@@ -10489,6 +10511,9 @@
             - "op_name": "设置状态"
               "state": "自定义-快速释放天光"
             - "op_name": "设置状态"
+              "seconds": 0.5
+              "state": "自定义-不使用快速支援"
+            - "op_name": "设置状态"
               "state": "自定义-佩洛伊斯-buff"
             "states": ""
         - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -10504,6 +10529,9 @@
             "repeat": 15
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
         - "debug_name": "佩洛伊斯-默认普攻"
           "operations":

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -9314,6 +9314,9 @@
           "seconds": 2.0
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-佩洛伊斯-buff, 0, 200]"
       - "debug_name": "佩洛伊斯-终结技-下上buff"
         "operations":
@@ -9353,6 +9356,9 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
+        - "op_name": "设置状态"
           "state": "自定义-佩洛伊斯-buff"
         "states": ""
     - "debug_name": "佩洛伊斯-黄光招架"
@@ -9367,6 +9373,9 @@
         "seconds": 0.5
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-黄光切人, 0, 1]"
     - "debug_name": "佩洛伊斯-红光处理"
       "states": "[自定义-红光闪避, 0, 1]"
@@ -9384,6 +9393,9 @@
           "repeat": 15
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[佩洛伊斯-特殊技可用]"
       - "debug_name": "佩洛伊斯-红光闪A"
         "operations":
@@ -9399,6 +9411,9 @@
           "repeat": 10
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": ""
     - "debug_name": "佩洛伊斯-连携攻击"
       "operations":
@@ -9415,6 +9430,9 @@
         "state": "自定义-动作不打断"
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-连携换人, 0, 0.5]"
     - "debug_name": "佩洛伊斯-切人等待"
       "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -9425,6 +9443,9 @@
           "seconds": 0.3
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-快速支援换人, 0, 0.5]"
       - "debug_name": "佩洛伊斯-等切人动画"
         "operations":
@@ -9518,7 +9539,8 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
-          "state": "自定义-快速释放天光"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-佩洛伊斯-buff, 0, 200]"
       - "debug_name": "佩洛伊斯-终结技-下上buff"
         "operations":
@@ -9558,6 +9580,9 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
+        - "op_name": "设置状态"
           "state": "自定义-佩洛伊斯-buff"
         "states": ""
     - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -9573,6 +9598,9 @@
         "repeat": 15
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
     - "debug_name": "佩洛伊斯-默认普攻"
       "operations":
@@ -18973,6 +19001,9 @@
           "seconds": 2.0
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-佩洛伊斯-buff, 0, 200]"
       - "debug_name": "佩洛伊斯-终结技-下上buff"
         "operations":
@@ -19012,6 +19043,9 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
+        - "op_name": "设置状态"
           "state": "自定义-佩洛伊斯-buff"
         "states": ""
     - "debug_name": "佩洛伊斯-黄光招架"
@@ -19026,6 +19060,9 @@
         "seconds": 0.5
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-黄光切人, 0, 1]"
     - "debug_name": "佩洛伊斯-红光处理"
       "states": "[自定义-红光闪避, 0, 1]"
@@ -19043,6 +19080,9 @@
           "repeat": 15
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[佩洛伊斯-特殊技可用]"
       - "debug_name": "佩洛伊斯-红光闪A"
         "operations":
@@ -19058,6 +19098,9 @@
           "repeat": 10
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": ""
     - "debug_name": "佩洛伊斯-连携攻击"
       "operations":
@@ -19074,6 +19117,9 @@
         "state": "自定义-动作不打断"
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-连携换人, 0, 0.5]"
     - "debug_name": "佩洛伊斯-切人等待"
       "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -19084,6 +19130,9 @@
           "seconds": 0.3
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-快速支援换人, 0, 0.5]"
       - "debug_name": "佩洛伊斯-等切人动画"
         "operations":
@@ -19177,7 +19226,8 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
-          "state": "自定义-快速释放天光"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-佩洛伊斯-buff, 0, 200]"
       - "debug_name": "佩洛伊斯-终结技-下上buff"
         "operations":
@@ -19217,6 +19267,9 @@
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
         - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
+        - "op_name": "设置状态"
           "state": "自定义-佩洛伊斯-buff"
         "states": ""
     - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -19232,6 +19285,9 @@
         "repeat": 15
       - "op_name": "设置状态"
         "state": "自定义-快速释放天光"
+      - "op_name": "设置状态"
+        "seconds": 0.5
+        "state": "自定义-不使用快速支援"
       "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
     - "debug_name": "佩洛伊斯-默认普攻"
       "operations":

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -9279,6 +9279,9 @@
             "seconds": 2.0
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-佩洛伊斯-buff, 0, 200]"
         - "debug_name": "佩洛伊斯-终结技-下上buff"
           "operations":
@@ -9318,6 +9321,9 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
+          - "op_name": "设置状态"
             "state": "自定义-佩洛伊斯-buff"
           "states": ""
       - "debug_name": "佩洛伊斯-黄光招架"
@@ -9332,6 +9338,9 @@
           "seconds": 0.5
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-黄光切人, 0, 1]"
       - "debug_name": "佩洛伊斯-红光处理"
         "states": "[自定义-红光闪避, 0, 1]"
@@ -9349,6 +9358,9 @@
             "repeat": 15
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[佩洛伊斯-特殊技可用]"
         - "debug_name": "佩洛伊斯-红光闪A"
           "operations":
@@ -9364,6 +9376,9 @@
             "repeat": 10
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": ""
       - "debug_name": "佩洛伊斯-连携攻击"
         "operations":
@@ -9380,6 +9395,9 @@
           "state": "自定义-动作不打断"
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-连携换人, 0, 0.5]"
       - "debug_name": "佩洛伊斯-切人等待"
         "states": "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -9390,6 +9408,9 @@
             "seconds": 0.3
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
+          - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-快速支援换人, 0, 0.5]"
         - "debug_name": "佩洛伊斯-等切人动画"
           "operations":
@@ -9483,7 +9504,8 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
-            "state": "自定义-快速释放天光"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
           "states": "[自定义-佩洛伊斯-buff, 0, 200]"
         - "debug_name": "佩洛伊斯-终结技-下上buff"
           "operations":
@@ -9523,6 +9545,9 @@
           - "op_name": "设置状态"
             "state": "自定义-快速释放天光"
           - "op_name": "设置状态"
+            "seconds": 0.5
+            "state": "自定义-不使用快速支援"
+          - "op_name": "设置状态"
             "state": "自定义-佩洛伊斯-buff"
           "states": ""
       - "debug_name": "佩洛伊斯-失衡强化特殊"
@@ -9538,6 +9563,9 @@
           "repeat": 15
         - "op_name": "设置状态"
           "state": "自定义-快速释放天光"
+        - "op_name": "设置状态"
+          "seconds": 0.5
+          "state": "自定义-不使用快速支援"
         "states": "[自定义-失衡时间, 0, 10] & [佩洛伊斯-特殊技可用]"
       - "debug_name": "佩洛伊斯-默认普攻"
         "operations":

--- a/config/auto_battle_operation/佩洛伊斯-强化特殊技.sample.yml
+++ b/config/auto_battle_operation/佩洛伊斯-强化特殊技.sample.yml
@@ -11,3 +11,6 @@ operations:
     repeat: 15
   - op_name: "设置状态"
     state: "自定义-快速释放天光"
+  - op_name: "设置状态"
+    state: "自定义-不使用快速支援"
+    seconds: 0.5

--- a/config/auto_battle_operation/佩洛伊斯-终结技-上.sample.yml
+++ b/config/auto_battle_operation/佩洛伊斯-终结技-上.sample.yml
@@ -37,3 +37,6 @@ operations:
     seconds: 2.0
   - op_name: "设置状态"
     state: "自定义-快速释放天光"
+  - op_name: "设置状态"
+    state: "自定义-不使用快速支援"
+    seconds: 0.5

--- a/config/auto_battle_operation/佩洛伊斯-终结技-下.sample.yml
+++ b/config/auto_battle_operation/佩洛伊斯-终结技-下.sample.yml
@@ -35,3 +35,6 @@ operations:
     seconds: 0.1
   - op_name: "设置状态"
     state: "自定义-快速释放天光"
+  - op_name: "设置状态"
+    state: "自定义-不使用快速支援"
+    seconds: 0.5

--- a/config/auto_battle_state_handler/速切模板-佩洛伊斯.sample.yml
+++ b/config/auto_battle_state_handler/速切模板-佩洛伊斯.sample.yml
@@ -25,6 +25,9 @@ handlers:
           - operation_template: "通用-支援攻击"
           - op_name: "设置状态"
             state: "自定义-快速释放天光"
+          - op_name: "设置状态"
+            state: "自定义-不使用快速支援"
+            seconds: 0.5
 
       # 红光闪光 → 特殊技/闪A
       - states: "[自定义-红光闪避, 0, 1]"
@@ -40,6 +43,9 @@ handlers:
               - operation_template: "通用-闪A"
               - op_name: "设置状态"
                 state: "自定义-快速释放天光"
+              - op_name: "设置状态"
+                state: "自定义-不使用快速支援"
+                seconds: 0.5
 
       # 连携换人
       - states: "[自定义-连携换人, 0, 0.5]"
@@ -48,6 +54,9 @@ handlers:
           - operation_template: "佩洛伊斯-连携攻击"
           - op_name: "设置状态"
             state: "自定义-快速释放天光"
+          - op_name: "设置状态"
+            state: "自定义-不使用快速支援"
+            seconds: 0.5
 
       # 切人后等待
       - states: "([按键-切换角色-下一个, 0, 0.3]|[按键-切换角色-上一个, 0, 0.3])"
@@ -60,6 +69,9 @@ handlers:
                 seconds: 0.3
               - op_name: "设置状态"
                 state: "自定义-快速释放天光"
+              - op_name: "设置状态"
+                state: "自定义-不使用快速支援"
+                seconds: 0.5
           - states: ""
             debug_name: "佩洛伊斯-等切人动画"
             operations:
@@ -89,8 +101,6 @@ handlers:
             debug_name: "佩洛伊斯-终结技-上"
             operations:
               - operation_template: "佩洛伊斯-终结技-上"
-              - op_name: "设置状态"
-                state: "自定义-快速释放天光"
           - states: ""
             debug_name: "佩洛伊斯-终结技-下上buff"
             operations:


### PR DESCRIPTION
优化佩洛伊斯战斗模板，在快速释放天光后设置不使用快速支援状态并等待0.5秒，避免连招序列错乱。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了多套自动战斗配置中的状态切换逻辑，在特定动作后短暂禁用“快速支援”，减少后续流程被误触发的情况。
  * 更新了佩洛伊斯相关操作模板与示例，使终结技、招架、连携、切人等待等场景的状态表现更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->