### PR TITLE
feat: 将迷失之地检测模型默认切换为yolo26n-20260630

### DIFF
--- a/src/zzz_od/config/model_config.py
+++ b/src/zzz_od/config/model_config.py
@@ -19,8 +19,8 @@ _BACKUP_FLASH_CLASSIFIER = 'yolov8n-640-flash-20250906'
 _DEFAULT_HOLLOW_ZERO_EVENT = 'yolov8s-736-hollow-zero-event-0126'
 _BACKUP_HOLLOW_ZERO_EVENT = 'yolov8s-736-hollow-zero-event-1130'
 
-_DEFAULT_LOST_VOID_DET = 'yolov8n-736-lost-void-det-20250921'
-_BACKUP_LOST_VOID_DET = 'yolov8n-736-lost-void-det-20250622'
+_DEFAULT_LOST_VOID_DET = 'yolov26n-736-lost-void-det-20260630'
+_BACKUP_LOST_VOID_DET = 'yolov8n-736-lost-void-det-20250921'
 
 
 class ModelConfig(BasicModelConfig):


### PR DESCRIPTION
将迷失之地检测的默认模型更新为yolo26n-736-lost-void-det-20260630，备份模型相应更新为yolov8n-736-lost-void-det-20250921。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 更新了默认识别模型配置，切换到新的主模型，并同步调整备用模型。
  * 提升了相关场景下的识别稳定性与一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->