### PR TITLE
录像店经营，失败时自动重试整个流程

### DIFF
--- a/src/zzz_od/application/coffee/coffee_app.py
+++ b/src/zzz_od/application/coffee/coffee_app.py
@@ -331,6 +331,8 @@ class CoffeeApp(ZApplication):
         to_choose_list = self._get_coffee_to_choose(day)
 
         area = self.ctx.screen_loader.get_area('咖啡店', '右侧选项区域')
+        # 先让鼠标显形（绝区零按钮特性：需要先拖鼠标才能让按钮响应点击）
+        self.ctx.controller.drag_to(start=area.left_top, end=area.center, duration=0.2)
         result = self.round_by_ocr_and_click_by_priority(to_choose_list, area=area)
         if result.is_success:
             self.chosen_coffee = self.ctx.compendium_service.name_2_coffee[result.status]

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -11,6 +11,7 @@ from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_notify import NotifyTiming, node_notify
+from one_dragon.base.operation.operation_base import OperationResult
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils import cv2_utils
 from one_dragon.utils.i18_utils import gt
@@ -63,17 +64,23 @@ class RandomPlayApp(ZApplication):
         self.turn_compensator: AngleTurnCompensator = AngleTurnCompensator(self.ctx.controller)
         self.retried_transport: bool = False
 
-    def execute(self, max_retry_times: int = 3):
+    def execute(self, max_retry_times: int = 3) -> OperationResult:
         """
         执行录像店经营，失败时自动重试整个流程（从传送重新开始）
         :param max_retry_times: 最大重试次数，默认 3 次
+        :return: 执行结果
+        :raises ValueError: 当 max_retry_times < 1 时
         """
+        if max_retry_times < 1:
+            raise ValueError(f'max_retry_times 必须 >= 1，当前传入: {max_retry_times}')
+        result: OperationResult | None = None
         for attempt in range(1, max_retry_times + 1):
             result = super().execute()
             if result.success:
                 return result
             if attempt < max_retry_times:
                 log.error(f'{self.op_name} 执行失败（第{attempt}次），即将重试整个流程...')
+        assert result is not None  # max_retry_times >= 1 时循环至少执行一次
         return result
 
     @node_from(from_name='等待经营画面加载', success=False)

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -63,6 +63,19 @@ class RandomPlayApp(ZApplication):
         self.turn_compensator: AngleTurnCompensator = AngleTurnCompensator(self.ctx.controller)
         self.retried_transport: bool = False
 
+    def execute(self, max_retry_times: int = 3):
+        """
+        执行录像店经营，失败时自动重试整个流程（从传送重新开始）
+        :param max_retry_times: 最大重试次数，默认 3 次
+        """
+        for attempt in range(1, max_retry_times + 1):
+            result = super().execute()
+            if result.success:
+                return result
+            if attempt < max_retry_times:
+                log.error(f'{self.op_name} 执行失败（第{attempt}次），即将重试整个流程...')
+        return result
+
     @node_from(from_name='等待经营画面加载', success=False)
     @operation_node(name='传送', is_start_node=True)
     def transport(self) -> OperationRoundResult:


### PR DESCRIPTION
录像店经营，失败时自动重试整个流程，最多3次，现在有的时候第一次执行的时候收玩菜，然后就卡在选择代理人的地方了，现在直接再运行一次，第2次的时候就能成功。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 经营执行流程新增可配置重试机制：`max_retry_times` 支持传入，默认最多重试 3 次；成功即停止，失败将返回最后一次结果。
- **改进**
  - 在选咖啡对话流程中，新增OCR前的区域轻微拖拽提示鼠标可见性，以提升识别与点击稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->