### PR TITLE
feat: 防卫战重置点击确认兜底

### DIFF
--- a/src/zzz_od/application/shiyu_defense/shiyu_defense_app.py
+++ b/src/zzz_od/application/shiyu_defense/shiyu_defense_app.py
@@ -173,6 +173,13 @@ class ShiyuDefenseApp(ZApplication):
     @operation_node(name='识别弱点并计算配队', node_max_retry_times=10)
     def check_weakness(self) -> OperationRoundResult:
         if self.current_node_idx in MULTI_ROOM_NODES:
+            result = self.round_by_find_area(self.last_screenshot, '式舆防卫战-三间选择', '确认')
+            if result.is_success:
+                click = self.round_by_click_area('式舆防卫战-三间选择', '确认', success_wait=1)
+                if click.is_success:
+                    return self.round_wait('点击确认', wait=1)
+                return self.round_retry('点击确认失败', wait=1)
+
             # 等待多间模式画面加载
             result = self.round_by_find_area(self.last_screenshot, '式舆防卫战-三间选择', '本期最佳总分')
             if not result.is_success:
@@ -189,8 +196,7 @@ class ShiyuDefenseApp(ZApplication):
                     break
 
             if need_reset:
-                self.round_by_click_area('式舆防卫战-三间选择', '重置全部', success_wait=0.3)
-                self.round_by_click_area('式舆防卫战-三间选择', '确认', success_wait=1)
+                self.round_by_click_area('式舆防卫战-三间选择', '重置全部', success_wait=1)
                 return self.round_retry('已重置', wait=1)
 
             # 多间模式


### PR DESCRIPTION
## 变更说明
- 在式舆防卫战多间模式的弱点识别前，先检测并处理确认弹窗
- 点击重置后由下一轮优先处理确认，避免弹窗阻塞后续识别

## 验证
- 已完成代码审查
- 未进行本地游戏实机验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了多间模式下的界面操作流程，进入相关界面时会先处理确认步骤，减少卡在确认弹窗的情况。
  * 调整了重置后的等待时间，让重置操作后更稳定，降低后续操作失败的概率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->