### PR TITLE
feat(backend): analyze_screen 支持按截图文件/图名解析

### DIFF
--- a/docs/develop/zzz/backend/mcp.md
+++ b/docs/develop/zzz/backend/mcp.md
@@ -10,7 +10,7 @@
 |---|---|---|
 | `check_game_window` | `backend.check_window()` | 状态文本（`str`） |
 | `capture_game_screen` | `backend.capture()` | 截图绝对路径（落盘 `.debug/zzz_od_mcp/screenshot/`） |
-| `analyze_screen` | `backend.analyze()` | `AnalyzeScreenResult`（结构化 JSON；FastMCP 据返回注解自动生成 output schema） |
+| `analyze_screen(screenshot=None)` | `backend.analyze(screenshot)` | `AnalyzeScreenResult`（结构化 JSON；FastMCP 据返回注解自动生成 output schema） |
 | `open_and_enter_game(block=True)` | `backend.start_run('mcp', op_factory)` | `block=True`：结果文本（`str`）；`block=False`：已启动 JSON；并发拒绝时返错误 JSON |
 | `get_run_status` | `backend.query_status()` | `RunStatusResult`（运行中返当前节点/重试；终态返结果/失败定位） |
 | `stop_run` | `backend.stop()` | `{"stopped": bool, ...}`（仅表信号已发出，过渡期 `get_run_status` 仍显示 running） |
@@ -20,6 +20,7 @@
 
 - backend 实例**注入**（闭包捕获），不用全局单例，也不用 FastMCP lifespan 管 backend 生命周期（由入口管）。
 - `capture_game_screen` 落盘返路径,客户端读取该图片;`analyze_screen` 返结构化 dataclass,FastMCP 序列化为带嵌套 `OcrText` 的 JSON。
+- `analyze_screen(screenshot=...)`:省略 `screenshot` 走实时(截活窗口,精准命中回写 `current_screen_name`);传入则解析**本地截图**——绝对路径按路径读,纯名字补 `.debug/images/<名>.png`(复用 `debug_utils.get_debug_image_path`)。文件支**无需游戏在线**、**不回写**识别状态,用于离线校验/反哺 `screen_info`(`write_back = screenshot is None`)。
 - 长耗时 operation（`open_and_enter_game`）经 backend 共享 `RunSlot` 派发：`block=True` 用 `asyncio.wrap_future(future)` 阻塞 await 取结果，`block=False` 立刻返回已启动状态，后续用 `get_run_status` 查进度。MCP 与 HTTP（见 [http.md](http.md)）**对称暴露**这套运行态三件套（[design-principles.md](design-principles.md) P11）。
 - **中断安全**：`block=True` 时若调用方取消 await，中断的只是本次 await，底层 `RunSlot._run` 继续执行、结果入槽，可用 `get_run_status` 查到终态。
 - 单跑道：已有运行在进行时 `open_and_enter_game` 返回并发拒绝（含 `source` + 提示），保证同进程独占资源不冲突。

--- a/src/zzz_od/backend/backend_context.py
+++ b/src/zzz_od/backend/backend_context.py
@@ -18,10 +18,12 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from one_dragon.base.operation.operation_base import OperationResult
 from one_dragon.base.screen.screen_match import find_screen_matches
+from one_dragon.utils import cv2_utils, debug_utils
 from zzz_od.backend.schemas import (
     AnalyzeScreenResult,
     OcrText,
@@ -282,27 +284,55 @@ class ZzzBackendContext:
             raise BackendNotReadyError('截图返回 None')
         return image
 
-    def analyze(self) -> AnalyzeScreenResult:
-        """分析游戏画面:截图 + 全图 OCR + 画面匹配(精准/模糊)。
+    @staticmethod
+    def _resolve_screenshot(screenshot: str) -> 'tuple[MatLike | None, str]':
+        """把 screenshot(绝对路径或 debug 图名)解析为(图像, 解析后完整路径)。
 
-        精准命中(``screens[0].is_precise=True``)后回写
-        ``ctx.screen_loader.update_current_screen_name``,为下次 BFS 提供起点;
-        模糊 / 异常不回写。
+        绝对路径按路径读;否则当 ``.debug/images`` 下的 debug 图名,自动补 ``.png``。
+        图像读不到时返回 ``(None, 解析后路径)``,由调用方报错。
 
-        对外无副作用(MCP tool annotations readOnly —— 回写的是 ctx 内存识别状态,
-        非外部资源)。Python GIL 下并发回写容忍(见 spec §2.3,无内存撕裂,
-        逻辑竞态由 BFS 全量兜底吸收)。
+        Args:
+            screenshot: 截图绝对路径,或 ``.debug/images`` 下的图名(不带后缀)。
+
+        Returns:
+            (image, resolved_path):image 为 RGB ndarray,文件不存在/不可读时为 None。
+        """
+        if Path(screenshot).is_absolute():
+            resolved = screenshot
+        else:
+            resolved = debug_utils.get_debug_image_path(screenshot)
+        return cv2_utils.read_image(resolved), resolved
+
+    def analyze(self, screenshot: str | None = None) -> AnalyzeScreenResult:
+        """分析画面:截图 + 全图 OCR + 画面匹配(精准/模糊)。
+
+        screenshot 省略 → 截当前游戏画面(需游戏窗口就绪);精准命中回写
+        ``ctx.screen_loader.update_current_screen_name``,为下次 BFS 提供起点。
+        screenshot 传入 → 解析指定截图,**无需游戏窗口就绪**:绝对路径按路径读,
+        纯名字到 ``.debug/images/<名字>.png`` 读;读不到返失败(error 带解析后完整路径)。
+        **不回写**识别状态(离线 / 可能是旧图,不污染实时识别)。
+
+        Args:
+            screenshot: 截图绝对路径,或 ``.debug/images`` 下的图名(不带后缀);
+                None 表示实时截当前画面。
 
         Returns:
             分析结果:成功标志、OCR 文本列表、画面匹配列表、错误描述。
         """
         self._ensure_ready()
-        controller = self._ctx.controller
-        if controller is None or not controller.is_game_window_ready:
-            return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error='游戏窗口未就绪')
-        image = controller.get_screenshot(independent=False)
-        if image is None:
-            return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error='截图失败')
+        if screenshot is None:
+            controller = self._ctx.controller
+            if controller is None or not controller.is_game_window_ready:
+                return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error='游戏窗口未就绪')
+            image = controller.get_screenshot(independent=False)
+            if image is None:
+                return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error='截图失败')
+            write_back = True
+        else:
+            image, resolved = self._resolve_screenshot(screenshot)
+            if image is None:
+                return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error=f'读取截图失败: {resolved}')
+            write_back = False
         try:
             # crop_first=False:与下方 find_screen_matches 内 find_area_with_detail(color_range=None)复用
             # 同一份全图 OCR 缓存(cache key 含 crop_first;True/False 不复用会触发两次全图 OCR)。
@@ -313,10 +343,10 @@ class ZzzBackendContext:
                 for r in ocr_result_list
             ]
             screens = find_screen_matches(self._ctx, image)
-            if screens and screens[0].is_precise:
+            if write_back and screens and screens[0].is_precise:
                 self._ctx.screen_loader.update_current_screen_name(screens[0].screen_name)
             return AnalyzeScreenResult(success=True, ocr_texts=ocr_texts, screens=screens, error=None)
-        except Exception as e:  # noqa: BLE001 OCR/匹配异常兜底:不回写,返失败(对齐 spec §2.3;OCR 也纳入兜底更稳,调用方统一见 error 字段)
+        except Exception as e:  # noqa: BLE001 OCR/匹配异常兜底:不回写,返失败
             return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error=str(e))
 
     def close_game(self) -> str:

--- a/src/zzz_od/backend/mcp/app.py
+++ b/src/zzz_od/backend/mcp/app.py
@@ -168,17 +168,21 @@ def create_mcp_server(backend: ZzzBackendContext, name: str = "zzz_od") -> FastM
         return path
 
     @mcp.tool()
-    def analyze_screen() -> AnalyzeScreenResult:
-        """分析画面（截图 + OCR + 画面匹配），返回结构化结果。
+    def analyze_screen(screenshot: str | None = None) -> AnalyzeScreenResult:
+        """分析画面(截图 + OCR + 画面匹配),返回结构化结果。观察类,不改游戏状态。
+
+        screenshot 省略 → 截当前游戏画面(需游戏在线),精准命中回写当前画面名;
+        screenshot 传入 → 解析指定截图、**无需游戏在线**:绝对路径按路径读 / 纯名字到
+        ``.debug/images/<名字>.png`` 读;**不回写**识别状态。用于离线校验/反哺 screen_info。
 
         Returns:
-            ``AnalyzeScreenResult``（成功标志、OCR 文本列表、画面匹配结果、错误描述）。
-            决策优先看 ``screens``（精准命中 1 个 ``is_precise=True``；否则 top_n 个候选）；
-            需要散落文本（未归类到任何 area 的 OCR 文本）再看 ``ocr_texts``。
+            ``AnalyzeScreenResult``(成功标志、OCR 文本列表、画面匹配结果、错误描述)。
+            决策优先看 ``screens``(精准命中 1 个 ``is_precise=True``;否则 top_n 个候选);
+            需要散落文本(未归类到任何 area 的 OCR 文本)再看 ``ocr_texts``。
         """
         try:
-            return backend.analyze()
-        except Exception as e:  # noqa: BLE001 工具层统一兜底
+            return backend.analyze(screenshot)
+        except Exception as e:  # noqa: BLE001 工具层统一兜底，避免异常透传到 MCP 框架
             return AnalyzeScreenResult(success=False, ocr_texts=[], screens=[], error=str(e))
 
     @mcp.tool()


### PR DESCRIPTION
## 背景
知识库建档工作流(`docs/game/`)中,加载/转场画面智能体无法精确实时截取。需要由人截好图、丢路径,让 server 跑识别器(OCR + 画面匹配),用于离线校验/反哺 `screen_info`。

## 改动
给 `analyze_screen` / `ZzzBackendContext.analyze` 增加可选 `screenshot: str | None = None`:

| 入参 | 行为 |
|---|---|
| 省略(`None`) | 实时截活窗口(原行为不变),精准命中回写 `current_screen_name` |
| 绝对路径 | 按路径读 |
| 纯名字 | 自动补 `.debug/images/<名>.png`(复用 `debug_utils.get_debug_image_path`) |

传入 `screenshot` 时:**无需游戏窗口在线**、**不回写**识别状态(`write_back = screenshot is None`)。

## 为什么是 MCP(P1/P5)
智能体能看图(vision),但跑不了 OCR/screen_match 模型推理(onnx session 在 server,`gpu_executor` 串行)→ 「对指定截图跑识别器」是必须经 MCP 的活运行时能力,不与「智能体能自己读文件」冲突。

## 改动文件
- `src/zzz_od/backend/backend_context.py`:`analyze()` 加 `screenshot` 参 + 抽 `_resolve_screenshot` 静态方法
- `src/zzz_od/backend/mcp/app.py`:`analyze_screen` 加参透传 + docstring
- `docs/develop/zzz/backend/mcp.md`:工具表 + 要点补充

## 验证
- ruff(2 文件)`All checks passed!`
- `_resolve_screenshot` 三模式:绝对路径 / debug 图名 / 缺失(返 None + 解析路径)均符合预期
- 端到端 `analyze(screenshot=<菜单图>)`:`success=True`,OCR 31 条,`screens=[('菜单', is_precise=True)]`
- 部署后 MCP 客户端实测:`tools/list` 确认 schema 含 `screenshot`;`tools/call` 文件模式与无参实时模式均正常(无参实时分支向后兼容)

## 不做(YAGNI)
- 不新增 tool/方法名(用可选参;契约不浑)
- 不接 HTTP `/game/analyze?screenshot=`(逻辑在 backend 共享层,后续对称接很容易)
- 不写测试(backend 测试本地跑、依赖真实 ZContext;薄适配,手动验证)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持通过传入截图进行离线识别，方便在不依赖实时窗口的情况下分析画面。
  * 保留原有实时识别方式，并可继续自动更新识别结果。

* **文档**
  * 更新了截图分析接口说明，补充了“实时分析”和“离线分析”两种使用方式及其差异。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->