### PR TITLE
docs: 补充常见开发技能

### DIFF
--- a/skills/zzz-od-dev-character/SKILL.md
+++ b/skills/zzz-od-dev-character/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: agent-definition
-description: 角色模板配置指南 - 在一条龙中新增可自动战斗角色所需的 Agent 定义、头像模板、状态模板与自动战斗配置
+name: zzz-od-dev-character
+description: 绝区零一条龙新增可自动战斗角色指南，覆盖 Agent 定义、头像模板、状态模板与自动战斗配置
 version: 1.1.0
 author: OneDragon-Anything
 tags: [zzz, agent, character, auto-battle, development]

--- a/skills/zzz-od-dev-cv-method/SKILL.md
+++ b/skills/zzz-od-dev-cv-method/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: zzz-od-dev-cv-method
+description: 绝区零一条龙新增 CV 流水线步骤与目标状态解读方式指南
+version: 1.0.0
+author: OneDragon-Anything
+tags: [zzz, one-dragon, cv, image-analysis, development]
+---
+
+# 新增 CV 方法指南
+
+本项目有两层容易混淆：
+
+| 需求 | 修改位置 | 说明 |
+|---|---|---|
+| 新增图像处理步骤 | `src/one_dragon/base/cv_process/steps/` + `CvService.available_steps` | 例如颜色过滤、形态学、轮廓过滤、模板匹配 |
+| 新增状态解读方式 | `src/zzz_od/game_data/target_state.py` + `TargetStateChecker` | 例如把轮廓宽度转成百分比、OCR 文本转数值 |
+
+如果只是搭一条新识别流程，优先用现有步骤在图像分析工具里配置 `assets/image_analysis_pipelines/*.yml`，不要先写代码。
+
+## 1. CV 流水线基本结构
+
+核心类：
+
+- `CvStep`：原子步骤基类
+- `CvPipeline`：按顺序执行步骤
+- `CvPipelineContext`：步骤之间传递数据
+- `CvService`：加载、保存、运行 pipeline，并维护可用步骤注册表
+
+关键文件：
+
+```text
+src/one_dragon/base/cv_process/
+├── cv_step.py
+├── cv_pipeline.py
+├── cv_service.py
+└── steps/
+    ├── __init__.py
+    ├── step_filter_by_rgb.py
+    ├── step_find_contours.py
+    └── ...
+```
+
+流水线配置保存到：
+
+```text
+assets/image_analysis_pipelines/<pipeline_name>.yml
+```
+
+业务调用方式：
+
+```python
+cv_result = self.ctx.cv_service.run_pipeline(
+    'pipeline_name',
+    screen,
+    debug_mode=False,
+    timeout=1.0,
+)
+```
+
+## 2. `CvPipelineContext` 常用字段
+
+| 字段 | 用途 |
+|---|---|
+| `source_image` | 原始输入图像，只读 |
+| `display_image` | 当前步骤处理/显示用图像，可修改 |
+| `mask_image` | 二值掩码，供轮廓步骤或后续解读使用 |
+| `contours` | 当前轮廓列表 |
+| `match_result` | 模板匹配结果 |
+| `ocr_result` | OCR 结果 |
+| `crop_offset` | 当前裁剪图相对原图的左上角偏移 |
+| `analysis_results` | 分析输出文本 |
+| `error_str` / `success` | 流水线成败状态 |
+
+坐标类结果要考虑 `crop_offset`。如果轮廓来自裁剪后的图，输出绝对坐标时使用 `context.get_absolute_rects()` 或手动加偏移。
+
+## 3. 新增 `CvStep`
+
+### 3.1 新增步骤文件
+
+在 `src/one_dragon/base/cv_process/steps/` 下新增 `step_extract_red_channel.py`：
+
+```python
+import numpy as np
+
+from one_dragon.base.cv_process.cv_step import CvPipelineContext, CvStep
+
+
+class CvStepExtractRedChannel(CvStep):
+
+    def __init__(self):
+        CvStep.__init__(self, '提取红色通道')
+
+    def get_params(self) -> dict:
+        return {}
+
+    def _execute(self, context: CvPipelineContext, **kwargs) -> None:
+        red_channel = context.display_image[:, :, 0]
+        height, width = red_channel.shape
+        new_image = np.zeros((height, width, 3), dtype=np.uint8)
+        new_image[:, :, 0] = red_channel
+        context.display_image = new_image
+        context.analysis_results.append('已提取红色通道')
+```
+
+项目约定传入流水线的是 RGB 图像，红色通道是索引 `0`。通过 `cv2.imread` 读取离线图片时，需要先 `cv2.cvtColor(img, cv2.COLOR_BGR2RGB)`。
+
+### 3.2 暴露参数
+
+`get_params()` 返回 UI 可配置参数定义。示例：
+
+```python
+def get_params(self) -> dict:
+    return {
+        'threshold': {
+            'type': 'int',
+            'default': 127,
+            'label': '阈值',
+            'tooltip': '保留大于该值的像素',
+        },
+        'draw_result': {
+            'type': 'bool',
+            'default': True,
+            'label': '绘制结果',
+        },
+    }
+
+def _execute(
+    self,
+    context: CvPipelineContext,
+    threshold: int = 127,
+    draw_result: bool = True,
+    **kwargs,
+) -> None:
+    ...
+```
+
+已有参数类型可参考：
+
+- `step_threshold.py`
+- `step_filter_by_rgb.py`
+- `step_find_contours.py`
+- `step_template_matching.py`
+- `step_ocr.py`
+
+### 3.3 导出步骤类
+
+修改 `src/one_dragon/base/cv_process/steps/__init__.py`：
+
+```python
+from .step_extract_red_channel import CvStepExtractRedChannel
+```
+
+### 3.4 注册到 `CvService`
+
+修改 `src/one_dragon/base/cv_process/cv_service.py`：
+
+```python
+from one_dragon.base.cv_process.steps import (
+    CvStepExtractRedChannel,
+    ...
+)
+
+self.available_steps: Dict[str, Type[CvStep]] = {
+    '提取红色通道': CvStepExtractRedChannel,
+    ...
+}
+```
+
+注册名要与 `CvStep.__init__` 里的名字一致，否则保存/加载 pipeline 时会找不到步骤。
+
+## 4. 调试与集成流程
+
+1. 启动 GUI。
+2. 打开图像分析工具。
+3. 载入目标截图。
+4. 添加新步骤，调整参数。
+5. 保存为 `assets/image_analysis_pipelines/<pipeline_name>.yml`。
+6. 在业务代码中调用 `ctx.cv_service.run_pipeline('<pipeline_name>', image)`。
+7. 用 `cv_result.is_success`、`cv_result.contours`、`cv_result.ocr_result` 等字段做业务判断。
+
+自动战斗目标状态通常通过 `DetectionTask` 调度，不要在高频战斗循环里临时创建复杂 CV 对象。
+
+## 5. 新增目标状态解读方式
+
+当现有 pipeline 已经能输出轮廓、OCR 或模板结果，但缺少“怎么把结果变成状态”的规则时，新增 `TargetCheckWay`。
+
+### 5.1 增加枚举
+
+文件：`src/zzz_od/game_data/target_state.py`
+
+```python
+class TargetCheckWay(Enum):
+    MY_NEW_CHECK = 'my_new_check'
+```
+
+### 5.2 在 `TargetStateChecker` 注册处理器
+
+文件：`src/zzz_od/auto_battle/target_state/target_state_checker.py`
+
+```python
+self._check_way_handlers = {
+    TargetCheckWay.MY_NEW_CHECK: self._check_my_new_check,
+    ...
+}
+```
+
+### 5.3 实现处理函数
+
+```python
+def _check_my_new_check(
+    self,
+    cv_result: CvPipelineContext,
+    state_def: TargetStateDef,
+    _start_time: float,
+) -> tuple | bool | None:
+    if cv_result.check_timeout():
+        return None
+
+    params = state_def.check_params
+    # 命中且无数值：return True
+    # 命中且有数值：return True, value
+    # 未命中但要清状态：return None if state_def.clear_on_miss else False
+```
+
+返回约定：
+
+| 返回值 | 含义 |
+|---|---|
+| `True` | 状态命中 |
+| `(True, value)` | 状态命中，并记录数值 |
+| `False` | 状态未命中 |
+| `None` | 不更新状态，常用于超时或 `clear_on_miss=True` 的未命中 |
+
+### 5.4 在 `DETECTION_TASKS` 中使用
+
+```python
+DetectionTask(
+    task_id='my_task',
+    pipeline_name='my_pipeline',
+    interval=0,
+    is_async=True,
+    state_definitions=[
+        TargetStateDef(
+            '目标-我的状态',
+            TargetCheckWay.MY_NEW_CHECK,
+            {'min_count': 1},
+            clear_on_miss=True,
+        ),
+    ],
+)
+```
+
+## 6. 编写注意事项
+
+- 统一按 RGB 图像处理，只有调用 OpenCV 特定 API 时再显式转换。
+- 新步骤优先修改 `display_image`、`mask_image`、`contours` 这些标准字段，不要私自挂临时属性。
+- 裁剪步骤必须维护 `crop_offset`，否则后续坐标会偏。
+- 高频流程要注意 `timeout` 和性能，自动战斗里默认按 1 秒软超时处理。
+- ONNX / GPU session 不要并发直调多个 session，需要走项目既有执行器机制。
+- 能用现有 `CvStep` 组合解决时，不新增代码。
+
+## 7. 验证清单
+
+- [ ] 新 step 文件位于 `src/one_dragon/base/cv_process/steps/`。
+- [ ] `steps/__init__.py` 已导出新类。
+- [ ] `CvService.available_steps` 已注册，注册名与 step 名一致。
+- [ ] 图像分析工具能看到新步骤。
+- [ ] 保存后的 pipeline YAML 能被 `CvService.load_pipeline()` 重新加载。
+- [ ] 如果新增 `TargetCheckWay`，`TargetStateChecker._check_way_handlers` 已注册。
+- [ ] 对改动文件运行 `uv run --env-file .env ruff check <file>`。

--- a/skills/zzz-od-dev-plugin/SKILL.md
+++ b/skills/zzz-od-dev-plugin/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: zzz-od-dev-plugin
+description: 绝区零一条龙新增内置应用与第三方插件指南，覆盖工厂、常量、运行记录、设置界面和 screen_info 接入
+version: 1.0.0
+author: OneDragon-Anything
+tags: [zzz, one-dragon, application, plugin, development]
+---
+
+# 新增应用 / 插件开发指南
+
+本项目的“插件”本质上是可被 `ApplicationFactoryManager` 自动发现的 `ApplicationFactory`。有两种落点：
+
+| 类型 | 目录 | 是否提交 | 导入方式 |
+|---|---|---:|---|
+| 内置应用 | `src/zzz_od/application/<app>/` | 是 | 绝对导入 |
+| 第三方插件 | `plugins/<plugin>/` | 否，`plugins/` 被 gitignore | 插件内可相对导入 |
+
+第三方插件必须放在 `plugins/` 的子目录，不能把 `_factory.py` 直接放在 `plugins/` 根目录。
+
+## 1. 最小文件结构
+
+### 内置应用
+
+```text
+src/zzz_od/application/my_app/
+├── __init__.py
+├── my_app_const.py
+├── my_app_factory.py
+├── my_app.py
+└── my_app_run_record.py        # 需要运行记录时添加
+```
+
+### 第三方插件
+
+```text
+plugins/my_plugin/
+├── __init__.py
+├── my_plugin_const.py
+├── my_plugin_factory.py
+├── my_plugin.py
+└── my_plugin_run_record.py     # 需要运行记录时添加
+```
+
+## 2. const 文件
+
+`ApplicationFactory` 要求 const 模块必须有：
+
+```python
+APP_ID = 'my_plugin'
+APP_NAME = '我的插件'
+DEFAULT_GROUP = True
+NEED_NOTIFY = True
+```
+
+字段含义：
+
+| 字段 | 含义 |
+|---|---|
+| `APP_ID` | 全局唯一应用 ID，重复会被拒绝 |
+| `APP_NAME` | GUI 展示名称 |
+| `DEFAULT_GROUP` | `True` 进入一条龙默认运行列表；`False` 作为独立工具 |
+| `NEED_NOTIFY` | 是否需要通知能力 |
+
+第三方插件可额外提供 GUI 元数据：
+
+```python
+PLUGIN_AUTHOR = '作者名'
+PLUGIN_HOMEPAGE = 'https://github.com/author/my_plugin'
+PLUGIN_VERSION = '1.0.0'
+PLUGIN_DESCRIPTION = '插件功能描述'
+```
+
+## 3. Application 类
+
+应用继承 `ZApplication`，状态机写法与普通 `ZOperation` 一致。
+
+```python
+from one_dragon.base.operation.operation_edge import node_from
+from one_dragon.base.operation.operation_node import operation_node
+from one_dragon.base.operation.operation_round_result import OperationRoundResult
+from zzz_od.application.zzz_application import ZApplication
+from zzz_od.context.zzz_context import ZContext
+
+from . import my_plugin_const
+
+
+class MyPlugin(ZApplication):
+
+    def __init__(self, ctx: ZContext):
+        ZApplication.__init__(
+            self,
+            ctx=ctx,
+            app_id=my_plugin_const.APP_ID,
+            op_name=my_plugin_const.APP_NAME,
+        )
+
+    @operation_node(name='开始', is_start_node=True)
+    def start(self) -> OperationRoundResult:
+        return self.round_success()
+```
+
+内置应用按项目规范使用绝对导入：
+
+```python
+from zzz_od.application.my_app import my_app_const
+```
+
+第三方插件内部可以使用相对导入：
+
+```python
+from . import my_plugin_const
+```
+
+## 4. Factory 类
+
+工厂文件必须以 `_factory.py` 结尾，同一个目录最多一个 `_factory.py`。
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from one_dragon.base.operation.application.application_factory import ApplicationFactory
+from one_dragon.base.operation.application_base import Application
+
+from . import my_plugin_const
+from .my_plugin import MyPlugin
+
+if TYPE_CHECKING:
+    from zzz_od.context.zzz_context import ZContext
+
+
+class MyPluginFactory(ApplicationFactory):
+
+    def __init__(self, ctx: ZContext):
+        ApplicationFactory.__init__(self, my_plugin_const)
+        self.ctx: ZContext = ctx
+
+    def create_application(self, instance_idx: int, group_id: str) -> Application:
+        return MyPlugin(self.ctx)
+```
+
+如果应用需要运行记录，再实现 `create_run_record`。
+
+```python
+from one_dragon.base.operation.application_run_record import AppRunRecord
+from .my_plugin_run_record import MyPluginRunRecord
+
+    def create_run_record(self, instance_idx: int) -> AppRunRecord:
+        return MyPluginRunRecord(
+            instance_idx=instance_idx,
+            game_refresh_hour_offset=self.ctx.game_account_config.game_refresh_hour_offset,
+        )
+```
+
+如果应用需要配置，再实现 `create_config` 并返回 `ApplicationConfig` 子类。
+
+## 5. 运行记录
+
+```python
+from one_dragon.base.operation.application_run_record import AppRunRecord
+
+
+class MyPluginRunRecord(AppRunRecord):
+
+    def __init__(self, instance_idx: int | None = None, game_refresh_hour_offset: int = 0):
+        AppRunRecord.__init__(
+            self,
+            'my_plugin',
+            instance_idx=instance_idx,
+            game_refresh_hour_offset=game_refresh_hour_offset,
+        )
+```
+
+`AppRunRecord` 的 app id 要与 `APP_ID` 一致。
+
+## 6. 设置界面
+
+需要设置入口时，新增 `*_app_setting.py`，模式参考：
+
+- `src/zzz_od/application/coffee/coffee_app_setting.py`
+- `src/zzz_od/application/suibian_temple/suibian_temple_app_setting.py`
+- `docs/develop/guides/application_setting_guide.md`
+
+设置界面扫描器会复用已发现的插件信息，不需要自己全盘扫描。
+
+## 7. 插件 screen_info
+
+第三方插件可以携带自己的 screen YAML：
+
+```text
+plugins/my_plugin/
+└── screen_info/
+    └── my_screen.yml
+```
+
+`app_id` 可省略，加载时会自动使用插件的 `APP_ID`。示例：
+
+```yaml
+screen_id: my_plugin_main
+screen_name: 我的插件-主界面
+area_list:
+  - area_name: 按钮-开始
+    pc_rect: [100, 100, 200, 80]
+    text: 开始
+```
+
+插件 screen 会进入对应应用的局部命名空间，避免污染其他应用。
+
+## 8. 发现与刷新规则
+
+扫描入口：`src/one_dragon/base/operation/application/application_factory_manager.py`
+
+规则：
+
+- 扫描所有 `_factory.py`。
+- 同一目录存在多个 `_factory.py` 或多个 `_const.py` 时，该目录跳过。
+- 每个 factory 模块最多一个 `ApplicationFactory` 子类。
+- `APP_ID` 重复时，后注册者会被拒绝。
+- 第三方插件通过 `plugins/` 作为 module root 加入 `sys.path`。
+- 运行时可调用 `ctx.refresh_application_registration()` 重新扫描。
+
+## 9. zip 包结构
+
+GUI 导入第三方插件时，zip 顶层应包含插件目录：
+
+```text
+my_plugin.zip
+└── my_plugin/
+    ├── __init__.py
+    ├── my_plugin_const.py
+    ├── my_plugin_factory.py
+    └── my_plugin.py
+```
+
+不要把文件直接压在 zip 根目录。
+
+## 10. 验证清单
+
+- [ ] `APP_ID` 全局唯一，且与运行记录 app id 一致。
+- [ ] 同一目录只有一个 `_factory.py` 和一个 `_const.py`。
+- [ ] factory 类继承 `ApplicationFactory`，并实现 `create_application`。
+- [ ] 应用类继承 `ZApplication`，构造函数传入 `app_id` 和 `op_name`。
+- [ ] 状态机只有一个 `is_start_node=True`。
+- [ ] 第三方插件位于 `plugins/<plugin>/`，不是 `plugins/` 根目录。
+- [ ] 如有设置界面，文件名为 `*_app_setting.py`。
+- [ ] 如有 screen_info，区域名和代码中的 `round_by_find_area` / `round_by_click_area` 一致。
+- [ ] 修改代码后只对改动文件运行 `uv run --env-file .env ruff check <file>`。

--- a/skills/zzz-od-dev-state-machine/SKILL.md
+++ b/skills/zzz-od-dev-state-machine/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: zzz-od-dev-state-machine
+description: 绝区零一条龙 Operation 状态机开发指南，说明如何用节点、边和轮次结果编排自动化流程
+version: 1.0.0
+author: OneDragon-Anything
+tags: [zzz, one-dragon, operation, state-machine, development]
+---
+
+# Operation 状态机开发指南
+
+本项目的“状态机”通常指 `Operation` 节点图：
+
+- 普通流程继承 `ZOperation`：`src/zzz_od/operation/zzz_operation.py`
+- 完整应用继承 `ZApplication`：`src/zzz_od/application/zzz_application.py`
+- 底层执行引擎：`src/one_dragon/base/operation/operation.py`
+- 节点声明：`operation_node`
+- 边声明：`node_from`
+- 单轮结果：`OperationRoundResult`
+
+## 1. 最小结构
+
+```python
+from one_dragon.base.operation.operation_edge import node_from
+from one_dragon.base.operation.operation_node import operation_node
+from one_dragon.base.operation.operation_round_result import OperationRoundResult
+from zzz_od.context.zzz_context import ZContext
+from zzz_od.operation.zzz_operation import ZOperation
+
+
+class MyOperation(ZOperation):
+
+    def __init__(self, ctx: ZContext):
+        ZOperation.__init__(self, ctx, op_name='我的流程')
+
+    @operation_node(name='入口', is_start_node=True)
+    def start(self) -> OperationRoundResult:
+        return self.round_success('下一步')
+
+    @node_from(from_name='入口', status='下一步')
+    @operation_node(name='处理')
+    def do_work(self) -> OperationRoundResult:
+        return self.round_success()
+```
+
+## 2. 节点与边
+
+### `@operation_node`
+
+常用参数：
+
+| 参数 | 用途 |
+|---|---|
+| `name` | 节点名，必须稳定，`node_from.from_name` 会精确匹配 |
+| `is_start_node` | 入口节点，一个流程只应有一个 |
+| `node_max_retry_times` | 当前节点最大重试次数 |
+| `timeout_seconds` | 当前节点超时时间 |
+| `mute` | 高频节点不输出过多日志 |
+| `save_status` | 保存节点状态，供后续节点读取 |
+| `screenshot_before_round` | 当前节点每一轮执行前是否自动截图，默认 `True` |
+
+### `@node_from`
+
+常用匹配方式：
+
+```python
+@node_from(from_name='入口')                      # 上游成功即可进入
+@node_from(from_name='入口', success=False)       # 上游失败进入
+@node_from(from_name='入口', status='指定状态')    # 上游 status 精确匹配
+@node_from(from_name='入口', success=True, status='指定状态')
+```
+
+同一个节点可以声明多个 `@node_from`，表示多个入口都能流转到这里。
+
+## 3. 轮次结果怎么选
+
+| 方法 | 含义 | 典型场景 |
+|---|---|---|
+| `round_success(status=None)` | 当前节点完成，进入下一条匹配边 | 点击成功、识别到目标、分支选择完成 |
+| `round_retry(status=None, wait=...)` | 当前节点失败一次，消耗重试次数 | 暂时没识别到按钮、等待页面加载 |
+| `round_wait(status=None, wait=...)` | 当前节点等待，不消耗重试次数 | 高频轮询、等待动画、持续战斗检测 |
+| `round_fail(status=None)` | 当前 Operation 失败终止 | 必要条件缺失、没有可执行方案 |
+
+规则：
+
+- 需要继续停在当前节点时，用 `round_retry` 或 `round_wait`。
+- 等待外部状态变化且不希望耗尽重试次数时，用 `round_wait`。
+- `status` 是流转条件的一部分；被 `@node_from(status=...)` 使用的字符串不要随意改。
+
+## 4. 截图时机
+
+`Operation.execute()` 每次循环调用 `_execute_one_round()`。如果当前节点是 `@operation_node` 方法，且该节点的 `screenshot_before_round=True`，框架会在调用节点方法前执行一次 `self.screenshot()`，更新：
+
+- `self.last_screenshot`
+- `self.last_screenshot_time`
+
+默认 `screenshot_before_round=True`。
+
+### 4.1 返回值和截图关系
+
+| 返回值 | 下一步 | 是否会自动重新截图 |
+|---|---|---|
+| `round_retry(...)` | 继续执行同一个节点的下一轮，消耗重试次数 | 下一轮进入同一节点前会重新截图 |
+| `round_wait(...)` | 继续执行同一个节点的下一轮，不消耗重试次数 | 下一轮进入同一节点前会重新截图 |
+| `round_success(...)` | 查找匹配的下一节点；没有下一节点则 Operation 成功结束 | 有下一节点时，下一轮进入下一节点前会重新截图 |
+| `round_fail(...)` | 查找失败分支；没有下一节点则 Operation 失败结束 | 有下一节点时，下一轮进入下一节点前会重新截图 |
+
+结论：返回值本身不会截图；它只决定是否进入下一轮。真正截图发生在下一轮节点方法执行前。
+
+### 4.2 同一个节点方法内部不会自动重新截图
+
+在一次节点方法调用期间，`self.last_screenshot` 是同一张图，除非你显式调用：
+
+```python
+screen = self.screenshot()
+```
+
+因此同一个节点里连续写多次识别，默认都基于同一张截图：
+
+```python
+@operation_node(name='识别并点击', is_start_node=True)
+def check_and_click(self) -> OperationRoundResult:
+    # 这里使用本轮开始前自动截取的 last_screenshot
+    result = self.round_by_find_area(self.last_screenshot, '画面', '按钮')
+    if result.is_success:
+        self.round_by_click_area('画面', '按钮')
+
+    # 这里仍然是同一轮的 last_screenshot，不会因为刚才点击过就自动刷新
+    result = self.round_by_find_area(self.last_screenshot, '画面', '点击后出现的按钮')
+    return self.round_retry('等待点击后界面刷新', wait=1)
+```
+
+这种场景应拆成两个节点，或在点击后显式截图：
+
+```python
+self.round_by_click_area('画面', '按钮')
+self.screenshot()
+return self.round_by_find_area(self.last_screenshot, '画面', '点击后出现的按钮')
+```
+
+### 4.3 辅助方法默认不主动截图
+
+多数 `round_by_find_area`、`round_by_find_and_click_area`、`round_by_goto_screen`、`round_by_ocr...` 辅助方法在 `screen=None` 时使用 `self.last_screenshot`。不要误以为传 `None` 就会立即截图。
+
+需要新画面时，先调用 `self.screenshot()`，或让本轮返回 `round_retry` / `round_wait`，等下一轮自动截图。
+
+## 5. 常见状态机模式
+
+### 5.1 入口识别后分流
+
+```python
+@operation_node(name='画面识别', is_start_node=True)
+def check_screen(self) -> OperationRoundResult:
+    current = self.check_and_update_current_screen(self.last_screenshot)
+    if current == '大世界':
+        return self.round_success('已在大世界')
+    if current == '菜单':
+        return self.round_success('需要返回')
+    return self.round_retry('未识别当前画面', wait=1)
+
+@node_from(from_name='画面识别', status='需要返回')
+@operation_node(name='返回大世界')
+def back_to_world(self) -> OperationRoundResult:
+    ...
+```
+
+### 5.2 调用子 Operation
+
+```python
+@operation_node(name='返回大世界', is_start_node=True)
+def back_to_world(self) -> OperationRoundResult:
+    op = BackToNormalWorld(self.ctx)
+    return self.round_by_op_result(op.execute())
+```
+
+适合把通用流程拆成可复用 Operation。不要把子 Operation 的内部节点复制到当前类里。
+
+### 5.3 查找并点击画面区域
+
+```python
+@operation_node(name='点击按钮')
+def click_button(self) -> OperationRoundResult:
+    return self.round_by_find_and_click_area(
+        self.last_screenshot,
+        '快捷手册',
+        '今日最大活跃度',
+        success_wait=1,
+        retry_wait=1,
+    )
+```
+
+区域名来自 `assets/game_data/screen_info/`。新增或改动区域时，要同步检查 screen YAML。
+
+### 5.4 高频轮询
+
+```python
+@operation_node(name='画面识别', mute=True)
+def check_screen(self) -> OperationRoundResult:
+    self.ctx.auto_battle_context.check_battle_state(self.last_screenshot)
+    return self.round_wait(wait_round_time=self.ctx.battle_assistant_config.screenshot_interval)
+```
+
+高频节点建议设置 `mute=True`，避免日志淹没真正错误。
+
+### 5.5 失败兜底
+
+```python
+@node_from(from_name='确认', success=False)
+@operation_node(name='返回大世界')
+def back_after_fail(self) -> OperationRoundResult:
+    op = BackToNormalWorld(self.ctx)
+    op.execute()
+    return self.round_fail('确认失败，已尝试返回')
+```
+
+失败兜底可以清理现场，但不要把业务失败伪装成成功。
+
+## 6. Application 写法
+
+应用状态机继承 `ZApplication`，节点写法与 `ZOperation` 相同。
+
+```python
+from zzz_od.application.zzz_application import ZApplication
+
+
+class MyApp(ZApplication):
+
+    def __init__(self, ctx: ZContext):
+        ZApplication.__init__(
+            self,
+            ctx=ctx,
+            app_id=my_app_const.APP_ID,
+            op_name=my_app_const.APP_NAME,
+        )
+```
+
+应用还需要工厂、常量、可选配置和运行记录。新增应用/插件见 `zzz-od-dev-plugin`。
+
+## 7. 编写检查清单
+
+- [ ] 节点名稳定，`@node_from(from_name=...)` 能精确对应。
+- [ ] 只有一个 `is_start_node=True`。
+- [ ] 所有会被边匹配的 `status` 都是固定字符串或类常量。
+- [ ] 等待外部变化用 `round_wait`，失败重试用 `round_retry`。
+- [ ] 需要点击后识别新画面时，拆节点或显式调用 `self.screenshot()`。
+- [ ] 子流程优先封装为子 `Operation`，通过 `round_by_op_result` 接入。
+- [ ] 高频轮询节点使用 `mute=True`。
+- [ ] 失败节点返回 `round_fail`，不要吞掉关键错误。
+- [ ] 修改代码后只对改动文件运行 `ruff check`。


### PR DESCRIPTION
## 概要

- 补充常见开发 Skill 文档：角色、CV 方法、插件、状态机等。
- 新增 `new-config` 脚本，自动扫描 `skills/*/SKILL.md` 并更新 `AGENTS.md` 末尾的 Skill 注入清单。
- 生成 `AGENTS.md` 中的当前 Skill 注入清单。

## 验证

- 运行 `powershell -NoProfile -ExecutionPolicy Bypass -File skills/new-config/generate-skill-injection-manifest.ps1 -DryRun`。
- 运行 `powershell -NoProfile -ExecutionPolicy Bypass -File skills/new-config/generate-skill-injection-manifest.ps1` 两次，确认清单可替换更新且不重复追加。
- 运行 `git diff --check`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 新增多份开发指南，覆盖角色接入、CV 方法、插件开发和状态机编排。
  * 补充更完整的配置流程、目录结构、示例用法和校验清单，帮助更快完成接入与排查。
  * 更新现有指南内容，扩展了模板、状态识别、自动战斗接入等说明，并提升了示例与常见问题覆盖面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->