### PR TITLE
feat: 移除体力计划历史记录，不再无限增长与重复写盘

### DIFF
--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -79,9 +79,6 @@ class ChargePlanItem:
             and (include_plan_id or item.name != 'plan_id')
         }
 
-    def to_history_dict(self) -> dict[str, str | int | None]:
-        return self.to_dict(include_plan_id=False)
-
     @classmethod
     def from_dict(cls, data: dict) -> 'ChargePlanItem':
         return cls(**data)
@@ -105,29 +102,11 @@ class ChargePlanConfig(ApplicationConfig):
     def save(self):
         plan_list = []
 
-        new_history_list = []
-
         for plan_item in self.plan_list:
             plan_data = plan_item.to_dict()
-            history_data = plan_item.to_history_dict()
-
-            new_history_list.append(history_data)
             plan_list.append(plan_data)
 
-        old_history_list = self.history_list
-        for old_history_data in old_history_list:
-            old_history = ChargePlanItem(**old_history_data)
-            with_new = False
-            for plan in self.plan_list:
-                if self._is_same_plan(plan, old_history, compare_plan_id=False):
-                    with_new = True
-                    break
-
-            if not with_new:
-                new_history_list.append(old_history.to_history_dict())
-
         self.data['plan_list'] = plan_list
-        self.data['history_list'] = new_history_list
 
         YamlConfig.save(self)
 
@@ -297,17 +276,6 @@ class ChargePlanConfig(ApplicationConfig):
             return x.plan_id == y.plan_id
 
         return x == y
-
-    @property
-    def history_list(self) -> list[dict]:
-        return self.get('history_list', [])
-
-    def get_history_by_uid(self, plan: ChargePlanItem) -> ChargePlanItem | None:
-        history_list = self.history_list
-        for history_data in history_list:
-            history = ChargePlanItem(**history_data)
-            if self._is_same_plan(history, plan, compare_plan_id=False):
-                return history
 
     @property
     def loop(self) -> bool:

--- a/src/zzz_od/application/charge_plan/charge_plan_config.py
+++ b/src/zzz_od/application/charge_plan/charge_plan_config.py
@@ -71,12 +71,11 @@ class ChargePlanItem:
             return 60
         return 0  # 未知类型，在副本内检查
 
-    def to_dict(self, *, include_plan_id: bool = True) -> dict[str, str | int | None]:
+    def to_dict(self) -> dict[str, str | int | None]:
         return {
             item.name: getattr(self, item.name)
             for item in fields(self)
             if item.metadata.get('persist', True)
-            and (include_plan_id or item.name != 'plan_id')
         }
 
     @classmethod

--- a/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
+++ b/src/zzz_od/gui/view/one_dragon/charge_plan_interface.py
@@ -219,8 +219,6 @@ class ChargePlanCard(DraggableListItem):
         self.init_card_num_box()
         self.init_notorious_hunt_buff_num_opt()
 
-        self.update_by_history()
-
         self._emit_value()
 
     def _on_mission_type_changed(self, idx: int) -> None:
@@ -229,14 +227,12 @@ class ChargePlanCard(DraggableListItem):
 
         self.init_mission_combo_box()
 
-        self.update_by_history()
         self._emit_value()
 
     def _on_mission_changed(self, idx: int) -> None:
         mission_name = self.mission_combo_box.itemData(idx)
         self.plan.mission_name = mission_name
 
-        self.update_by_history()
         self._emit_value()
 
     def _on_card_num_changed(self, idx: int) -> None:
@@ -275,25 +271,6 @@ class ChargePlanCard(DraggableListItem):
     def _on_del_clicked(self) -> None:
         self.delete.emit(self.idx)
 
-    def update_by_history(self) -> None:
-        """
-        根据历史记录更新
-        """
-        history = self.config.get_history_by_uid(self.plan)
-        if history is None:
-            return
-
-        self.plan.card_num = history.card_num
-        self.plan.notorious_hunt_buff_num = history.notorious_hunt_buff_num
-        self.plan.predefined_team_idx = history.predefined_team_idx
-        self.plan.auto_battle_config = history.auto_battle_config
-        self.plan.plan_times = history.plan_times
-
-        self.init_card_num_box()
-        self.init_notorious_hunt_buff_num_opt()
-        self.init_predefined_team_opt()
-        self.init_auto_battle_box()
-        self.init_plan_times_input()
 
 
 class DoubleRewardEventConfigCard(MultiLineSettingCard):


### PR DESCRIPTION
- 删除 ChargePlanItem.to_history_dict()
- 删除 ChargePlanConfig.history_list / get_history_by_uid()
- 简化 save()，不再合并写入历史记录
- 删除 ChargePlanCard.update_by_history() 及调用

Closes #2381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整充能计划的保存逻辑：现在仅保存当前计划内容，不再自动维护/合并历史记录，避免历史数据干扰更新结果。
  * 优化充能计划界面联动：修改分类、任务类型或任务选择后，只更新当前计划字段并立即生效，不再基于历史回填覆盖界面输入项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->