### PR TITLE
fix: 避免连续的商店过不去

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -599,7 +599,7 @@ class LostVoidRunLevel(ZOperation):
                 self.interact_target = LostVoidInteractTarget(name='未知', icon='感叹号', is_exclamation=True)
             op_result = interact_op.execute()
             if op_result.success:
-                if interact_type is not None:
+                if self.should_record_interact_type_as_visited(interact_type):
                     self.had_been_list.append(interact_type)
 
                 return self.round_wait(op_result.status, wait=2)
@@ -788,6 +788,16 @@ class LostVoidRunLevel(ZOperation):
         获取交互对象在本层内的唯一标识
         """
         return f'{target.icon}:{target.name}'
+
+    @staticmethod
+    def should_record_interact_type_as_visited(interact_type: str | None) -> bool:
+        """
+        判断交互后的类型是否需要加入已访问列表。
+        邦布商店/抽奖机交互完成后不会变成“已处理的入口类型”，
+        继续按类型级忽略会误伤后续同类入口。
+        """
+        return interact_type is not None and interact_type != '邦布商店'
+
 
     def move_after_interact(self) -> None:
         """


### PR DESCRIPTION
## 变更说明
- 修正迷失之地交互成功后把 `邦布商店` 整类加入 `had_been_list` 的逻辑
- 保留 `路径迭换` 等其他交互类型的原有过滤行为
- 避免商店或抽奖机交互后，后续同类入口被整类跳过

## 验证
- `uv run ruff check src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py`
- 静态校验 `should_record_interact_type_as_visited`：`邦布商店 => False`，`路径迭换 => True`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了部分交互完成后的访问记录规则，避免某些特定交互被错误标记为已访问。
  * 优化了已访问列表的更新逻辑，减少重复或不符合预期的记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->