### PR TITLE
ci: 同步推送到 CNB

### DIFF
--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -1,0 +1,27 @@
+name: Sync to CNB
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: ${{ github.repository == 'OneDragon-Anything/ZenlessZoneZero-OneDragon' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Push to CNB
+        env:
+          CNB_TOKEN: ${{ secrets.CNB_GIT_TOKEN }}
+        run: |
+          git remote add cnb "https://cnb:${CNB_TOKEN}@cnb.cool/OneDragon-Anything/ZenlessZoneZero-OneDragon.git"
+          git push cnb "${GITHUB_REF}:${GITHUB_REF}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 新增一项自动化同步流程：在主分支更新、发布标签或手动触发时，可将当前版本同步到远端仓库。
  * 仅在指定仓库中启用，并限制了运行权限，提升了安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->