### PR TITLE
ci: dev也推送到cnb

### DIFF
--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -2,7 +2,7 @@ name: Sync to CNB
 
 on:
   push:
-    branches: [main]
+    branches: [main, test]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -24,4 +24,4 @@ jobs:
           CNB_TOKEN: ${{ secrets.CNB_GIT_TOKEN }}
         run: |
           git remote add cnb "https://cnb:${CNB_TOKEN}@cnb.cool/OneDragon-Anything/ZenlessZoneZero-OneDragon.git"
-          git push cnb "${GITHUB_REF}:${GITHUB_REF}"
+          git push -f cnb "${GITHUB_REF}:${GITHUB_REF}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 同步流程现已支持在 `main` 和 `test` 分支触发，覆盖范围更广。
  * 同步动作的推送方式已调整，减少因分支状态不同导致的同步失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->