### PR TITLE
fix: 脱困后无法重新检测丢失的虚空

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -198,7 +198,7 @@ class LostVoidMoveByDet(ZOperation):
         else:
             return self.round_retry('未在大世界画面')
 
-    @node_from(from_name='脱困')
+    @node_from(from_name='脱困', status=STATUS_CONTINUE)
     @node_from(from_name='无目标处理', status=STATUS_CONTINUE)
     @operation_node(name='移动前转向', node_max_retry_times=20, is_start_node=True)
     def turn_at_first(self) -> OperationRoundResult:


### PR DESCRIPTION
修复了角色脱困后，丢失的虚空无法重新被检测的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了“脱困”后的流程切换条件，只有在特定持续状态下才会继续进入后续移动前转向流程。
  * 减少了异常状态下的误转移，使流程表现更稳定、更符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->