### PR TITLE
fix: 应用退出时未正确停止自动战斗算子

### DIFF
--- a/src/zzz_od/application/battle_assistant/auto_battle/auto_battle_app.py
+++ b/src/zzz_od/application/battle_assistant/auto_battle/auto_battle_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from one_dragon.base.controller.pc_button import pc_button_utils
+from one_dragon.base.operation.operation_base import OperationResult
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
@@ -102,3 +103,7 @@ class AutoBattleApp(ZApplication):
     def handle_resume(self, e=None):
         if self.current_node.node is not None and self.current_node.node.cn == '画面识别':
             self.ctx.auto_battle_context.resume_auto_battle()
+
+    def after_operation_done(self, result: OperationResult) -> None:
+        self.ctx.auto_battle_context.stop_auto_battle()
+        ZApplication.after_operation_done(self, result)


### PR DESCRIPTION
修复了应用退出时，自动战斗算子没有正确停止的问题，避免资源泄漏。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自动战斗在操作完成后会自动停止，避免后续流程继续执行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->