### PR TITLE
fix: 修复驱动盘拆解页面识别失败

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -2477,11 +2477,11 @@
   - area_name: 标题-驱动盘拆解
     id_mark: true
     pc_rect:
-    - 184
-    - 4
-    - 326
-    - 102
-    text: 驱动盘拆解
+    - 168
+    - 17
+    - 432
+    - 92
+    text: 驱动
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''
@@ -2491,10 +2491,10 @@
   - area_name: 按钮-快速选择
     id_mark: true
     pc_rect:
-    - 166
-    - 1000
-    - 342
-    - 1054
+    - 134
+    - 968
+    - 407
+    - 1068
     text: 快速选择
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/drive_disc_dismantle.yml
+++ b/assets/game_data/screen_info/drive_disc_dismantle.yml
@@ -6,28 +6,30 @@ area_list:
 - area_name: 标题-驱动盘拆解
   id_mark: true
   pc_rect:
-  - 184
-  - 4
-  - 326
-  - 102
-  text: 驱动盘拆解
+  - 168
+  - 17
+  - 432
+  - 92
+  text: 驱动
   lcs_percent: 0.5
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-快速选择
   id_mark: true
   pc_rect:
-  - 166
-  - 1000
-  - 342
-  - 1054
+  - 134
+  - 968
+  - 407
+  - 1068
   text: 快速选择
   lcs_percent: 0.5
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-全选已弃置
   id_mark: false
@@ -41,6 +43,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-A及以下
   id_mark: false
@@ -54,6 +57,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-S及以下
   id_mark: false
@@ -67,6 +71,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-快速选择-确认
   id_mark: false
@@ -80,6 +85,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-拆解
   id_mark: false
@@ -93,6 +99,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-拆解-确认
   id_mark: false
@@ -106,6 +113,7 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []
 - area_name: 按钮-B
   id_mark: false
@@ -119,4 +127,5 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+  color_range: null
   goto_list: []


### PR DESCRIPTION
ocr v6 对于文字识别需要外边框
减少识别要求，没必要全字匹配

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了驱动盘拆解页面的识别区域，提升标题和“快速选择”等按钮的命中准确性。
  * 更新了部分按钮的匹配范围，减少点击或识别偏差。
  * 统一了相关区域配置结构，提升页面识别稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->