### PR TITLE
fix: 修复副本战斗失败/撤退后返回大世界卡在退出战斗的死循环

### DIFF
--- a/src/zzz_od/operation/back_to_normal_world.py
+++ b/src/zzz_od/operation/back_to_normal_world.py
@@ -9,6 +9,7 @@ from zzz_od.context.zzz_context import ZContext
 from zzz_od.game_data.agent import AgentEnum
 from zzz_od.hollow_zero.event import hollow_event_utils
 from zzz_od.hollow_zero.hollow_exit_by_menu import HollowExitByMenu
+from zzz_od.operation.challenge_mission.exit_in_battle import ExitInBattle
 from zzz_od.operation.map_transport import MapTransport
 from zzz_od.operation.zzz_operation import ZOperation
 
@@ -33,7 +34,6 @@ class BackToNormalWorld(ZOperation):
 
     def handle_init(self) -> None:
         self.last_dialog_idx: int = -1  # 上次选择的对话选项下标
-        self.click_exit_battle: bool = False  # 是否点击了退出战斗
         self.prefer_dialog_confirm: bool = False  # 第一次优先取消，后续确认/取消轮流点击
 
     @node_from(from_name='打开地图', success=False)
@@ -75,15 +75,13 @@ class BackToNormalWorld(ZOperation):
 
 
         # 战斗菜单-退出战斗（完全通用，包括但不限于危局强袭战！）
-        result = self.round_by_find_and_click_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
+        # 交给 ExitInBattle 完成「点退出战斗 → 等确认框出现 → 点确认 → 等确认框消失」的闭环，
+        # 避免原来在本节点内直接点击时，因点击未生效而反复识别到同一「按钮-退出战斗」直到 60 次重试耗尽失败
+        # （复现：副本战斗失败/撤退后返回大世界，画面停在战斗菜单，'按钮-退出战斗' 被反复点击但确认框始终未处理）
+        result = self.round_by_find_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
         if result.is_success:
-            self.click_exit_battle = True
+            ExitInBattle(self.ctx).execute()
             return self.round_retry(result.status, wait=1)
-        if self.click_exit_battle:  # 必须置前，因为会被通用的"取消"误判
-            result = self.round_by_find_and_click_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗-确认')
-            if result.is_success:
-                return self.round_retry(result.status, wait=1)
-        self.click_exit_battle = False
 
         # 战斗菜单-脱离卡死（大世界-勘域不慎进入战斗状态时使用）
         result = self.round_by_find_and_click_area(self.last_screenshot, '战斗-菜单', '按钮-脱离卡死')


### PR DESCRIPTION
## 问题

一条龙在**副本战斗失败 / 撤退**后返回大世界时，`返回大世界`（`BackToNormalWorld`）会卡在「按钮-退出战斗」的识别循环，直到 `node_max_retry_times=60` 耗尽后整个算子失败。由于它是被到处调用的通用返回步骤，这一次卡死会**连锁导致后续多个日常应用失败**（体力刷本收尾、活跃度奖励、丽都城募、丽都周纪等）。

## 复现

`体力刷本` 的副本自动战斗**失败（战斗结果-撤退）**后，画面停在战斗菜单，`返回大世界` 连续约 50 轮恒为「按钮-退出战斗」直至失败：

```
[04:15:41] 指令[ 区域巡防 机师与叛甲 ] 节点 自动战斗 -> 战斗失败 返回状态 战斗结果-撤退
...
[04:16:09] 指令[ 返回大世界 ] 节点 画面识别 返回状态 按钮-退出战斗
[04:16:11] 指令[ 返回大世界 ] 节点 画面识别 返回状态 按钮-退出战斗
        …（约 50 轮，恒为「按钮-退出战斗」，全程未出现「按钮-退出战斗-确认」）…
[04:17:48] [ERROR] 指令[ 返回大世界 ] 执行失败 返回状态 按钮-退出战斗
[04:17:48] [ERROR] 指令[ 体力刷本 ] 执行失败 返回状态 按钮-退出战斗
```

## 根因

`check_screen_and_run`（单节点，`node_max_retry_times=60`）中退出战斗的分支：

```python
result = self.round_by_find_and_click_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
if result.is_success:
    self.click_exit_battle = True
    return self.round_retry(result.status, wait=1)
if self.click_exit_battle:  # 点确认框
    ...
```

`round_by_find_and_click_area` 的成功只代表**模板找到并点击**，不代表**点击生效、确认框已弹出**。当点击未真正推进时，下一轮仍会在第一处匹配到「按钮-退出战斗」并 `return`，使得点确认框的分支**永远够不到**，自锁到 60 轮耗尽。日志全程只有「按钮-退出战斗」、从未出现「按钮-退出战斗-确认」，正是此自锁的表现。

## 修复

复用仓库已有的 `ExitInBattle`——它用 `until_find_all` / `until_not_find_all` 做了「点退出战斗 → 等确认框出现 → 点确认 → 等确认框消失」的完整闭环，能保证点击真正生效后才推进：

```python
result = self.round_by_find_area(self.last_screenshot, '战斗-菜单', '按钮-退出战斗')
if result.is_success:
    ExitInBattle(self.ctx).execute()
    return self.round_retry(result.status, wait=1)
```

- 进入条件不变（同样先确认「按钮-退出战斗」可见），仅把「就地点击 + 有缺陷的确认逻辑」换成已验证的 `ExitInBattle` 闭环；
- 保留原有分支顺序（退出战斗仍在「脱离卡死」「返回 / 完成」之前，不影响 #2005 / #1357 的约束）；
- 移除不再需要的 `self.click_exit_battle` 状态。

## 测试

- `python -m py_compile` 通过，模块可正常 import（无循环 import）；
- 本地打补丁后运行，副本战斗失败 / 撤退场景不再卡死。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了战斗菜单中的“退出战斗”处理流程，点击后会更稳定地完成退出与确认框处理。
  * 保留原有重试机制，减少因弹窗状态变化导致的操作中断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->