### PR TITLE
fix: 强化迷失之地寻路日志，增加目标切换的灵活性

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -181,6 +181,13 @@ class LostVoidMoveByDet(ZOperation):
         self.same_target_times = 0
         self.last_visible_target_list = []
 
+    def _get_detected_class_names(self, frame_result: DetectFrameResult) -> list[str]:
+        return [result.detect_class.class_name for result in frame_result.results]
+
+    def _get_detected_class_summary(self, frame_result: DetectFrameResult) -> str:
+        class_name_list = self._get_detected_class_names(frame_result)
+        return '无' if len(class_name_list) == 0 else ', '.join(class_name_list)
+
     def handle_not_in_world(self, screen: MatLike) -> OperationRoundResult:
         """
         处理不在大世界的情况
@@ -208,6 +215,8 @@ class LostVoidMoveByDet(ZOperation):
 
         frame_result = self.ctx.lost_void.detect_to_go(self.last_screenshot, screenshot_time=self.last_screenshot_time,
                                                        ignore_list=self.ignore_entry_list)
+        log.info('寻路节点[%s] 当前目标=%s 检测结果=%s',
+                 '移动前转向', self.target_type, self._get_detected_class_summary(frame_result))
 
         if self.check_interact_stop(self.last_screenshot, frame_result):
             return self.round_success(LostVoidMoveByDet.STATUS_ARRIVAL, data=self.last_target_name)
@@ -215,6 +224,19 @@ class LostVoidMoveByDet(ZOperation):
         target_result = self.get_move_target(frame_result)
 
         if target_result is None:
+            if self.target_type == LostVoidDetector.CLASS_ENTRY:
+                detected_class_name_list = self._get_detected_class_names(frame_result)
+                if LostVoidDetector.CLASS_INTERACT in detected_class_name_list:
+                    log.info('寻路节点[%s] 当前目标=%s 未检测到入口，但检测到更高优先级目标=%s，返回上层重识别',
+                             '移动前转向', self.target_type, LostVoidDetector.CLASS_INTERACT)
+                    return self.round_success(LostVoidMoveByDet.STATUS_NEED_DETECT)
+                if LostVoidDetector.CLASS_DISTANCE in detected_class_name_list:
+                    log.info('寻路节点[%s] 当前目标=%s 未检测到入口，但检测到更高优先级目标=%s，返回上层重识别',
+                             '移动前转向', self.target_type, LostVoidDetector.CLASS_DISTANCE)
+                    return self.round_success(LostVoidMoveByDet.STATUS_NEED_DETECT)
+
+            log.info('寻路节点[%s] 当前目标=%s 未识别到可追踪目标，检测结果=%s',
+                     '移动前转向', self.target_type, self._get_detected_class_summary(frame_result))
             if self.last_target_result is not None:
                 self._reset_turn_calibration_status()  # 丢失目标，重置校准
                 self._reset_stuck_status()
@@ -243,6 +265,8 @@ class LostVoidMoveByDet(ZOperation):
         frame_result: DetectFrameResult = self.ctx.lost_void.detect_to_go(
             self.last_screenshot, screenshot_time=self.last_screenshot_time,
             ignore_list=self.ignore_entry_list)
+        log.info('寻路节点[%s] 当前目标=%s 检测结果=%s',
+                 '移动', self.target_type, self._get_detected_class_summary(frame_result))
 
         if self.check_interact_stop(self.last_screenshot, frame_result):
             self.ctx.controller.stop_moving_forward()
@@ -263,12 +287,18 @@ class LostVoidMoveByDet(ZOperation):
                 # 调用的时候识别的是入口 但进入之后发现有其他优先级更高的 退出执行
                 another_result = self.ctx.lost_void.detector.get_result_by_x(frame_result, LostVoidDetector.CLASS_DISTANCE)
                 if another_result is not None:
+                    log.info('寻路节点[%s] 当前目标=%s 未检测到入口，但检测到更高优先级目标=%s，返回上层重识别',
+                             '移动', self.target_type, LostVoidDetector.CLASS_DISTANCE)
                     return self.round_success(status=LostVoidMoveByDet.STATUS_NEED_DETECT)
 
                 another_result = self.ctx.lost_void.detector.get_result_by_x(frame_result, LostVoidDetector.CLASS_INTERACT)
                 if another_result is not None:
+                    log.info('寻路节点[%s] 当前目标=%s 未检测到入口，但检测到更高优先级目标=%s，返回上层重识别',
+                             '移动', self.target_type, LostVoidDetector.CLASS_INTERACT)
                     return self.round_success(status=LostVoidMoveByDet.STATUS_NEED_DETECT)
 
+            log.info('寻路节点[%s] 当前目标=%s 未识别到可追踪目标，检测结果=%s',
+                     '移动', self.target_type, self._get_detected_class_summary(frame_result))
             self.lost_target_during_move_times += 1
             # 移动过程中多次丢失目标 通常是因为识别不准
             # 游戏1.6版本出现了可以因为丢失目标转动镜头而一直无法进入脱困 issues #867
@@ -600,6 +630,9 @@ class LostVoidMoveByDet(ZOperation):
             self.last_screenshot, screenshot_time=self.last_screenshot_time,
             ignore_list=self.ignore_entry_list,
         )
+        if self.target_type == LostVoidDetector.CLASS_INTERACT:
+            return self.round_success(LostVoidMoveByDet.STATUS_NEED_DETECT)
+
         distance_result = self.ctx.lost_void.detector.get_result_by_x(frame_result, LostVoidDetector.CLASS_DISTANCE)
         if distance_result is not None:
             return self.round_success(LostVoidMoveByDet.STATUS_NEED_DETECT)


### PR DESCRIPTION
## 问题

迷失之地寻路在部分场景下会卡在子流程里，现有日志无法直接看出当前目标、当前检测结果和状态跳转原因。

## 修复

- 为 `LostVoidMoveByDet` 的关键节点补充当前目标、检测结果和决策原因日志
- 补齐入口分支在 `移动前转向` 阶段遇到更高优先级目标时回上层重识别的逻辑
- 调整感叹号目标进入脱困后的出口，避免在子流程内反复自循环

## 测试

- `uv run ruff check src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py`

Closes #2466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化寻路过程中的目标识别与重识别逻辑，减少入口、交互目标与距离目标之间的误判。
  * 当入口未识别到且本帧存在更高优先级交互或距离目标时，会更及时触发重新检测，提升路径切换稳定性。
  * 脱困阶段对交互目标新增特殊处理，避免执行不合适的后续流程。
  * 增强识别相关日志输出，提供目标类型与类别摘要，便于排查与定位问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->