### PR TITLE
chore: 删除战斗画面中无用的区域

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -408,20 +408,6 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-  - area_name: 按键-切换后援
-    id_mark: false
-    pc_rect:
-    - 1615
-    - 776
-    - 1726
-    - 877
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: battle
-    template_id: btn_switch_backup_1
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
   - area_name: 连携技-1
     id_mark: false
     pc_rect:
@@ -8452,6 +8438,194 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+- screen_id: shiyu_defense_select_3
+  screen_name: 式舆防卫战-三间选择
+  app_id: shiyu_defense
+  pc_alt: false
+  area_list:
+  - area_name: 第一间
+    id_mark: false
+    pc_rect:
+    - 907
+    - 224
+    - 1024
+    - 272
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 第二间
+    id_mark: false
+    pc_rect:
+    - 907
+    - 447
+    - 1036
+    - 496
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 第三间
+    id_mark: false
+    pc_rect:
+    - 907
+    - 669
+    - 1045
+    - 720
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 第一间属性
+    id_mark: false
+    pc_rect:
+    - 1317
+    - 258
+    - 1791
+    - 406
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 第二间属性
+    id_mark: false
+    pc_rect:
+    - 1318
+    - 481
+    - 1788
+    - 631
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 第三间属性
+    id_mark: false
+    pc_rect:
+    - 1317
+    - 703
+    - 1788
+    - 847
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 前往第一间
+    id_mark: false
+    pc_rect:
+    - 1319
+    - 224
+    - 1425
+    - 264
+    text: 属性
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 前往第二间
+    id_mark: false
+    pc_rect:
+    - 1315
+    - 446
+    - 1419
+    - 486
+    text: 属性
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 前往第三间
+    id_mark: false
+    pc_rect:
+    - 1313
+    - 664
+    - 1433
+    - 707
+    text: 属性
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 返回
+    id_mark: false
+    pc_rect:
+    - 62
+    - 15
+    - 173
+    - 94
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: menu
+    template_id: back
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 式舆防卫战
+  - area_name: 本期最佳总分
+    id_mark: true
+    pc_rect:
+    - 122
+    - 218
+    - 322
+    - 268
+    text: 总分
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 重置全部
+    id_mark: false
+    pc_rect:
+    - 1248
+    - 1009
+    - 1495
+    - 1045
+    text: 重置
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 确认
+    id_mark: false
+    pc_rect:
+    - 1038
+    - 624
+    - 1222
+    - 665
+    text: 确认
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
 - screen_id: storage_drive_disc
   screen_name: 仓库-驱动仓库
   app_id: drive_disc_dismantle
@@ -9623,194 +9797,6 @@
     - 1650
     - 640
     text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-- screen_id: shiyu_defense_select_3
-  screen_name: 式舆防卫战-三间选择
-  app_id: shiyu_defense
-  pc_alt: false
-  area_list:
-  - area_name: 第一间
-    id_mark: false
-    pc_rect:
-    - 907
-    - 224
-    - 1024
-    - 272
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 第二间
-    id_mark: false
-    pc_rect:
-    - 907
-    - 447
-    - 1036
-    - 496
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 第三间
-    id_mark: false
-    pc_rect:
-    - 907
-    - 669
-    - 1045
-    - 720
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 第一间属性
-    id_mark: false
-    pc_rect:
-    - 1317
-    - 258
-    - 1791
-    - 406
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 第二间属性
-    id_mark: false
-    pc_rect:
-    - 1318
-    - 481
-    - 1788
-    - 631
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 第三间属性
-    id_mark: false
-    pc_rect:
-    - 1317
-    - 703
-    - 1788
-    - 847
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 前往第一间
-    id_mark: false
-    pc_rect:
-    - 1319
-    - 224
-    - 1425
-    - 264
-    text: 属性
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 前往第二间
-    id_mark: false
-    pc_rect:
-    - 1315
-    - 446
-    - 1419
-    - 486
-    text: 属性
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 前往第三间
-    id_mark: false
-    pc_rect:
-    - 1313
-    - 664
-    - 1433
-    - 707
-    text: 属性
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 返回
-    id_mark: false
-    pc_rect:
-    - 62
-    - 15
-    - 173
-    - 94
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: menu
-    template_id: back
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list:
-    - 式舆防卫战
-  - area_name: 本期最佳总分
-    id_mark: true
-    pc_rect:
-    - 122
-    - 218
-    - 322
-    - 268
-    text: 总分
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 重置全部
-    id_mark: false
-    pc_rect:
-    - 1248
-    - 1009
-    - 1495
-    - 1045
-    text: 重置
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 确认
-    id_mark: false
-    pc_rect:
-    - 1038
-    - 624
-    - 1222
-    - 665
-    text: 确认
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''

--- a/assets/game_data/screen_info/battle.yml
+++ b/assets/game_data/screen_info/battle.yml
@@ -44,20 +44,6 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
-- area_name: 按键-切换后援
-  id_mark: false
-  pc_rect:
-  - 1615
-  - 776
-  - 1726
-  - 877
-  text: ''
-  lcs_percent: 0.5
-  template_sub_dir: battle
-  template_id: btn_switch_backup_1
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
 - area_name: 连携技-1
   id_mark: false
   pc_rect:

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -214,7 +214,6 @@ class AutoBattleContext:
         self.area_btn_special: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-特殊攻击')
         self.area_btn_ultimate: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-终结技')
         self.area_btn_switch: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-切换角色')
-        self.area_btn_switch_backup: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-切换后援')
         self.area_btn_switch_backup_mark: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-切换后援标记')
         self.area_btn_switch_backup_gray: ScreenArea = self.ctx.screen_loader.get_area('战斗画面', '按键-切换后援灰度区域')
 


### PR DESCRIPTION
## 概要

删除战斗画面中未被后援可用检测实际使用的 `按键-切换后援` screen area，并同步更新合并文件。

## 变更内容

- 删除 `battle.yml` 中未使用的 `按键-切换后援`
- 删除 `AutoBattleContext` 中对应的无效 `get_area` 加载
- 重新生成 `_od_merged.yml`

## 测试

- `uv run ruff check src/zzz_od/auto_battle/auto_battle_context.py`

Closes #2463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了战斗界面相关识别区域，移除了不再需要的后援切换按键项，减少误识别与异常点击。
  * 优化了式舆防卫战“三间选择”界面的区域配置，提升该界面元素识别的一致性与稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->