### PR TITLE
fix: 迷失之地 YOLO 推理前涂黑战斗头像

### DIFF
--- a/docs/develop/zzz/application/lost_void/det_model.md
+++ b/docs/develop/zzz/application/lost_void/det_model.md
@@ -25,7 +25,7 @@
 配置 → 业务检测器 → 框架加载:
 
 1. **配置**:`src/zzz_od/config/model_config.py` 的 `_DEFAULT_LOST_VOID_DET` / `_BACKUP_LOST_VOID_DET`。新模型无法下载时回退 backup。
-2. **业务封装**:`LostVoidDetector`(`src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py`),继承 `Yolov8Detector`,提供"感叹号 / 距离 / 入口"等业务判断。
+2. **业务封装**:`LostVoidDetector`(`src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py`),继承 `Yolov8Detector`,提供"感叹号 / 距离 / 入口"等业务判断。`run()` 在推理前会把战斗画面 `头像-3-1/3-2/3-3` 区域涂黑,避免角色头像被误检为目标。
 3. **框架加载与推理**:`Yolov8Detector`(`src/one_dragon/yolo/yolov8_onnx_det.py`):
    - 预处理 `onnx_utils.scale_input_image_u`:等比缩放、左上对齐的 letterbox,对 736×736 正方形自洽。
    - 后处理 `process_output`:`np.squeeze(output[0]).T` + 动态切片,不硬编码类别数,16 类开箱兼容。

--- a/docs/develop/zzz/application/lost_void/det_model.md
+++ b/docs/develop/zzz/application/lost_void/det_model.md
@@ -25,7 +25,7 @@
 配置 → 业务检测器 → 框架加载:
 
 1. **配置**:`src/zzz_od/config/model_config.py` 的 `_DEFAULT_LOST_VOID_DET` / `_BACKUP_LOST_VOID_DET`。新模型无法下载时回退 backup。
-2. **业务封装**:`LostVoidDetector`(`src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py`),继承 `Yolov8Detector`,提供"感叹号 / 距离 / 入口"等业务判断。`run()` 在推理前会把战斗画面 `头像-3-1/3-2/3-3` 区域涂黑,避免角色头像被误检为目标。
+2. **业务封装**:`LostVoidDetector`(`src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py`),继承 `Yolov8Detector`,提供"感叹号 / 距离 / 入口"等业务判断。
 3. **框架加载与推理**:`Yolov8Detector`(`src/one_dragon/yolo/yolov8_onnx_det.py`):
    - 预处理 `onnx_utils.scale_input_image_u`:等比缩放、左上对齐的 letterbox,对 736×736 正方形自洽。
    - 后处理 `process_output`:`np.squeeze(output[0]).T` + 动态切片,不硬编码类别数,16 类开箱兼容。

--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py
@@ -1,5 +1,8 @@
 from typing import ClassVar
 
+import cv2
+from cv2.typing import MatLike
+
 from one_dragon.utils import yolo_config_utils
 from one_dragon.yolo.detect_utils import DetectFrameResult, DetectObjectResult
 from one_dragon.yolo.yolo_utils import get_github_model_download_url
@@ -12,6 +15,14 @@ class LostVoidDetector(Yolov8Detector):
     CLASS_INTERACT: ClassVar[str] = '0000-感叹号'
     CLASS_DISTANCE: ClassVar[str] = '0001-距离'
     CLASS_ENTRY: ClassVar[str] = 'xxxx-入口'
+
+    # 战斗画面头像区域(1080p)，与 assets/game_data/screen_info/battle.yml 中 头像-3-1/3-2/3-3 一致
+    # 角色头像易被误检为目标，推理前统一涂黑
+    BATTLE_AVATAR_MASK_RECTS: ClassVar[tuple[tuple[int, int, int, int], ...]] = (
+        (104, 40, 274, 110),  # 头像-3-1
+        (559, 40, 662, 91),   # 头像-3-2
+        (741, 40, 844, 91),   # 头像-3-3
+    )
 
     def __init__(self,
                  model_name: str,
@@ -40,6 +51,39 @@ class LostVoidDetector(Yolov8Detector):
             personal_proxy=personal_proxy,
             gpu=gpu,
             keep_result_seconds=keep_result_seconds
+        )
+
+    def mask_battle_avatars(self, image: MatLike) -> MatLike:
+        """
+        将战斗画面左上角色头像区域涂黑，避免 YOLO 误检
+        :param image: 原始游戏画面
+        :return: 涂黑头像后的画面副本
+        """
+        masked = image.copy()
+        for x1, y1, x2, y2 in LostVoidDetector.BATTLE_AVATAR_MASK_RECTS:
+            cv2.rectangle(masked, (x1, y1), (x2, y2), (0, 0, 0), thickness=-1)
+        return masked
+
+    def run(
+        self,
+        image: MatLike,
+        conf: float = 0.6,
+        iou: float = 0.5,
+        run_time: float | None = None,
+        label_list: list[str] | None = None,
+        category_list: list[str] | None = None,
+    ) -> DetectFrameResult:
+        """
+        对图片进行识别；推理前先涂黑战斗头像区域
+        """
+        return Yolov8Detector.run(
+            self,
+            image=self.mask_battle_avatars(image),
+            conf=conf,
+            iou=iou,
+            run_time=run_time,
+            label_list=label_list,
+            category_list=category_list,
         )
 
     def is_frame_with_all(self, frame_result: DetectFrameResult | None = None) -> tuple[bool, bool, bool]:

--- a/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/context/lost_void_detector.py
@@ -16,13 +16,9 @@ class LostVoidDetector(Yolov8Detector):
     CLASS_DISTANCE: ClassVar[str] = '0001-距离'
     CLASS_ENTRY: ClassVar[str] = 'xxxx-入口'
 
-    # 战斗画面头像区域(1080p)，与 assets/game_data/screen_info/battle.yml 中 头像-3-1/3-2/3-3 一致
+    # 战斗画面左上头像整片区域(1080p)，包住 头像-3-1/3-2/3-3
     # 角色头像易被误检为目标，推理前统一涂黑
-    BATTLE_AVATAR_MASK_RECTS: ClassVar[tuple[tuple[int, int, int, int], ...]] = (
-        (104, 40, 274, 110),  # 头像-3-1
-        (559, 40, 662, 91),   # 头像-3-2
-        (741, 40, 844, 91),   # 头像-3-3
-    )
+    BATTLE_AVATAR_MASK_RECT: ClassVar[tuple[int, int, int, int]] = (104, 40, 844, 110)
 
     def __init__(self,
                  model_name: str,
@@ -60,8 +56,8 @@ class LostVoidDetector(Yolov8Detector):
         :return: 涂黑头像后的画面副本
         """
         masked = image.copy()
-        for x1, y1, x2, y2 in LostVoidDetector.BATTLE_AVATAR_MASK_RECTS:
-            cv2.rectangle(masked, (x1, y1), (x2, y2), (0, 0, 0), thickness=-1)
+        x1, y1, x2, y2 = LostVoidDetector.BATTLE_AVATAR_MASK_RECT
+        cv2.rectangle(masked, (x1, y1), (x2, y2), (0, 0, 0), thickness=-1)
         return masked
 
     def run(


### PR DESCRIPTION
## Summary
- 在 `LostVoidDetector.run()` 入口，对战斗画面 `头像-3-1/3-2/3-3` 区域涂黑后再做 YOLO 推理
- 避免角色头像被误检为迷失之地目标
- 同步补充检测模型文档说明

## Testing
- 本地用 debug 图 `_1783595904619` 跑过涂黑与 26n 推理，头像区域涂黑正常
- `ruff check` 已通过修改文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化目标识别：在推理前自动遮挡战斗头像区域，降低头像被误识别为目标的概率。
  * 提升相关场景下识别的准确性与稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->