### PR TITLE
fix: 修复随便观误报“点击兑换确认失败”

### DIFF
--- a/src/zzz_od/application/suibian_temple/operations/suibian_temple_good_goods.py
+++ b/src/zzz_od/application/suibian_temple/operations/suibian_temple_good_goods.py
@@ -83,7 +83,7 @@ class SuibianTempleGoodGoods(ZOperation):
             return self.round_success(status='购买成功')
 
         # 处理弹窗
-        if self.round_by_ocr(self.last_screenshot, '兑换确认').is_success:
+        if self.round_by_ocr(self.last_screenshot, '兑换确认', lcs_percent=0.75).is_success:
             # 直接使用精确坐标拖拽滑块到最大值
             start_point = Point(755, 672)
             end_point = Point(1300, 672)
@@ -201,7 +201,7 @@ class SuibianTempleGoodGoods(ZOperation):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     ctx.run_context.start_running()
     ctx.run_context.current_instance_idx = ctx.current_instance_idx
     ctx.run_context.current_app_id = 'suibian_temple'


### PR DESCRIPTION
测过了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 提升“获得/兑换确认”弹窗的文字识别准确性，减少误判情况。
  * 优化程序启动流程，增强初始化稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->