### PR TITLE
fix: 提前加载恶名狩猎/情报板识别模型

### DIFF
--- a/docs/develop/zzz/application/lost_void/det_model.md
+++ b/docs/develop/zzz/application/lost_void/det_model.md
@@ -32,6 +32,8 @@
    - **标签加载** `_load_detect_classes`:**只读 `labels.csv`**(`idx,label`);框架全线(`yolo_config_utils.is_model_existed` 等)都不认 `model_label.txt`。
 4. **本地目录**:`assets/models/lost_void_det/<模型名>/`(gitignore),必须含 `labels.csv` + `model.onnx`。
 
+模型由迷失之地、恶名狩猎和情报板共同使用。三个应用都在各自流程的 `初始化加载` 节点调用 `LostVoidContext.init_lost_void_det_model`;模型尚未创建或 GPU 配置变化时同步初始化，否则直接复用。战斗前移动只消费已经初始化的模型，不在进入战斗画面后临时加载。
+
 ## 4. 模型获取与发布规范
 
 **下载与解压**:`OnnxModelLoader`(`src/one_dragon/yolo/onnx_model_loader.py`)从 `zzz_model` release 下载 `<模型名>.zip`,`extractall` 到 `assets/models/lost_void_det/<模型名>/`。

--- a/src/zzz_od/application/intel_board/intel_board_app.py
+++ b/src/zzz_od/application/intel_board/intel_board_app.py
@@ -44,7 +44,16 @@ class IntelBoardApp(ZApplication):
         self.current_commission_type: CommissionType | None = None
         self.has_filtered: bool = False
 
-    @operation_node(name='返回录像店', is_start_node=True)
+    @operation_node(name='初始化加载', is_start_node=True)
+    def init_for_intel_board(self) -> OperationRoundResult:
+        try:
+            self.ctx.lost_void.init_lost_void_det_model()
+        except Exception:
+            return self.round_fail('初始化失败')
+        return self.round_success()
+
+    @node_from(from_name='初始化加载')
+    @operation_node(name='返回录像店')
     def back_to_world(self) -> OperationRoundResult:
         op = Transport(self.ctx, '录像店', '房间')
         return self.round_by_op_result(op.execute())

--- a/src/zzz_od/operation/compendium/notorious_hunt.py
+++ b/src/zzz_od/operation/compendium/notorious_hunt.py
@@ -79,6 +79,14 @@ class NotoriousHunt(ZOperation):
         self.use_charge_power: bool = use_charge_power  # 是否使用电量 深度追猎
         self.can_run_times: int = -1
 
+    @operation_node(name='初始化加载', is_start_node=True)
+    def init_for_notorious_hunt(self) -> OperationRoundResult:
+        try:
+            self.ctx.lost_void.init_lost_void_det_model()
+        except Exception:
+            return self.round_fail('初始化失败')
+        return self.round_success()
+
     def _match_mission_type(self, target_name: str, ocr_result: str) -> bool:
         """
         匹配任务类型名称（支持别名双向查找）
@@ -94,6 +102,7 @@ class NotoriousHunt(ZOperation):
                     break
         return any(str_utils.find_by_lcs(gt(n, 'game'), ocr_result, percent=0.5) for n in names)
 
+    @node_from(from_name='初始化加载')
     @operation_node(name='等待入口加载', node_max_retry_times=60)
     def wait_entry_load(self) -> OperationRoundResult:
         r1 = self.round_by_find_area(self.last_screenshot, '恶名狩猎', '当期剩余奖励次数')

--- a/src/zzz_od/operation/compendium/notorious_hunt_move.py
+++ b/src/zzz_od/operation/compendium/notorious_hunt_move.py
@@ -39,14 +39,7 @@ class NotoriousHuntMove(ZOperation):
         self.move_times: int = 0
         self.no_dis_times: int = 0
 
-    @operation_node(name='初始化模型', is_start_node=True)
-    def init_model(self) -> OperationRoundResult:
-        """加载迷失之地检测模型 用于识别距离白点"""
-        self.ctx.lost_void.init_lost_void_det_model()
-        return self.round_success()
-
-    @node_from(from_name='初始化模型')
-    @operation_node(name='移动靠近交互', node_max_retry_times=10)
+    @operation_node(name='移动靠近交互', node_max_retry_times=10, is_start_node=True)
     def first_move(self) -> OperationRoundResult:
         result = self._move_by_hint()
         if result.is_success:


### PR DESCRIPTION
close #2443 

当前实现迷失之地/恶名狩猎/情报板三个地方都是同步阻塞，不是异步

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **优化**
  * 调整恶名狩猎的起始流程：进入后可直接进入靠近交互逻辑，并沿用后续转向/重试/失败处理。
  * 情报板与恶名狩猎新增“初始化加载”步骤：启动时先同步检测模型，失败会直接中止并返回失败结果。
* **文档更新**
  * 补充说明迷失之地/恶名狩猎/情报板共享检测模型的初始化与复用规则，战斗前仅消费已就绪模型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->