### PR TITLE
feat(intel_board): 未选择编队时选择任意预备编队

### DIFF
--- a/src/zzz_od/application/intel_board/intel_board_app.py
+++ b/src/zzz_od/application/intel_board/intel_board_app.py
@@ -9,6 +9,7 @@ from one_dragon.base.operation.operation_round_result import (
     OperationRoundResultEnum,
 )
 from one_dragon.utils import cv2_utils
+from one_dragon.utils.log_utils import log
 from zzz_od.application.intel_board import intel_board_const
 from zzz_od.application.intel_board.intel_board_config import IntelBoardConfig
 from zzz_od.application.intel_board.intel_board_run_record import IntelBoardRunRecord
@@ -222,6 +223,7 @@ class IntelBoardApp(ZApplication):
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='选择预备编队')
+    @node_from(from_name='选择任意预备编队')
     @operation_node(name='点击出战')
     def click_deploy(self) -> OperationRoundResult:
         # 9. 编队选择完成后点击出战进入战斗
@@ -231,10 +233,25 @@ class IntelBoardApp(ZApplication):
     @operation_node(name='委托代行中弹窗')
     def click_commission_agent(self) -> OperationRoundResult:
         # 点击委托代行中弹窗的确定按钮（如果有的话）
+        result = self.round_by_ocr(self.last_screenshot, '至少选择1位代理人出战')
+        if result.is_success:
+            result = self.round_by_ocr_and_click(self.last_screenshot, '确认')
+            if result.is_success:
+                return self.round_success('未选择代理人', wait=1)
+            return result
+
         result = self.round_by_ocr(self.last_screenshot, '委托代行中')
         if result.is_success:
             return self.round_by_ocr_and_click(self.last_screenshot, '确认')
         return self.round_success('无弹窗')
+
+    @node_from(from_name='委托代行中弹窗', status='未选择代理人')
+    @operation_node(name='选择任意预备编队')
+    def choose_any_predefined_team(self) -> OperationRoundResult:
+        fallback_team = self.ctx.team_config.team_list[0]
+        log.warning(f'因未选择预备编队，当前副本没有代理人出战，使用预备编队 {fallback_team.name} 重新出战')
+        op = ChoosePredefinedTeam(self.ctx, [fallback_team.idx])
+        return self.round_by_op_result(op.execute())
 
     @node_from(from_name='委托代行中弹窗')
     @operation_node(name='加载自动战斗指令')


### PR DESCRIPTION
close #2473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 出战流程新增“选择任意预备编队”路径，操作更加顺畅。
  - 当未选择代理人时，系统会提示并引导确认。
  - 遇到委托代行等特殊状态时，系统可自动处理。
  - 未指定编队时，将自动选择预备编队中的首位代理人完成出战。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->