### PR TITLE
ci: 新增包含模型的集成启动器发布包

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -256,7 +256,8 @@ jobs:
           - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Full-Environment.zip` 为带环境的完整包，不需要额外下载资源。
           - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Full.zip` 为完整包，解压后选择解压目录为安装目录，只需要下载环境依赖。
           - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Installer.exe` 为精简安装程序，运行后会自动下载所需的资源。
-          - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-WithRuntime.zip` 为内嵌运行时 + 源码的独立包（无需安装 Python），解压即用。
+          - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-WithRuntime-Full.zip` 为内嵌运行时 + 源码 + 模型的完整独立包（无需安装 Python，也无需额外下载模型），解压即用。
+          - `ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-WithRuntime.zip` 为内嵌运行时 + 源码的精简独立包（无需安装 Python，模型按需下载），解压即用。
           - 如果你想更新启动器，前往主程序【设置】-【资源下载】页面更新，或者下载 `ZenlessZoneZero-OneDragon-Launcher.zip`，解压后替换。
           - `ZenlessZoneZero-OneDragon-RuntimeLauncher.zip` 为集成启动器更新包（exe + .runtime），用于已有环境的就地升级。
           - __不要下载Source Code__
@@ -286,6 +287,7 @@ jobs:
           ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Full-Environment.zip
           ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Full.zip
           ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-Installer.exe
+          ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-WithRuntime-Full.zip
           ZenlessZoneZero-OneDragon-${{ needs.version.outputs.version }}-WithRuntime.zip
           ZenlessZoneZero-OneDragon-Environment.zip
           ZenlessZoneZero-OneDragon-Launcher.zip

--- a/.github/workflows/mirrorchyan_uploading.yml
+++ b/.github/workflows/mirrorchyan_uploading.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: MirrorChyan/uploading-action@v1
         with:
           filetype: latest-release
-          filename: ${{ format('ZenlessZoneZero-OneDragon-*-{0}*', matrix.type) }}
+          filename: ${{ format('ZenlessZoneZero-OneDragon-*-{0}.zip', matrix.type) }}
           mirrorchyan_rid: ZZZ-OneDragon
 
           arch: ${{ matrix.arch }}

--- a/.github/workflows/mirrorchyan_uploading.yml
+++ b/.github/workflows/mirrorchyan_uploading.yml
@@ -17,7 +17,7 @@ jobs:
         arch: [x86_64, aarch64]
         include:
           - arch: x86_64
-            type: WithRuntime
+            type: WithRuntime-Full
           - arch: aarch64
             type: Full-Environment
     steps:

--- a/docs/develop/one_dragon/runtime_launcher.md
+++ b/docs/develop/one_dragon/runtime_launcher.md
@@ -126,10 +126,11 @@ CI 构建生成以下集成启动器相关产物：
 
 | 文件 | 内容 | 用途 |
 |------|------|------|
-| `{version}-WithRuntime.zip` | 集成启动器 exe + .runtime + src | 首次部署，解压即用 |
+| `{version}-WithRuntime-Full.zip` | 集成启动器 exe + .runtime + src + 模型 | 首次部署，解压即用且无需额外下载模型 |
+| `{version}-WithRuntime.zip` | 集成启动器 exe + .runtime + src | 首次部署，模型按需下载 |
 | `RuntimeLauncher.zip` | 集成启动器 exe + .runtime（不含 src） | 就地升级已有环境 |
 
-WithRuntime 包含 src/ 是因为首次部署时还没有 .git 目录，无法通过 git clone 获取源码。用户解压 WithRuntime 后首次启动，集成启动器会自动初始化 git 仓库并设置远程跟踪。
+两个 WithRuntime 包都包含 src/，因为首次部署时还没有 .git 目录，无法通过 git clone 获取源码。用户解压后首次启动，集成启动器会自动初始化 git 仓库并设置远程跟踪。WithRuntime-Full 复用普通 Full 包准备好的模型，将其写入压缩包的 `assets/models/`；CI 不会因此重复下载模型。
 
 ## 启动器下载卡（UI）
 

--- a/tools/ci/prepare_release_assets.py
+++ b/tools/ci/prepare_release_assets.py
@@ -132,16 +132,46 @@ def _zip_dir_contents(
     if zip_path.exists():
         zip_path.unlink()
 
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        _write_dir_contents(
+            zf,
+            root_dir,
+            root_prefix=root_prefix,
+            exclude_prefixes=exclude_prefixes,
+        )
+
+
+def _write_dir_contents(
+    zf: zipfile.ZipFile,
+    root_dir: Path,
+    *,
+    root_prefix: str,
+    exclude_prefixes: set[str] | None = None,
+) -> None:
+    """把目录内容写入已打开的 zip，支持多个来源复用同一压缩包。"""
     prefix = root_prefix.strip("/\\")
 
+    for path in root_dir.rglob("*"):
+        if not path.is_file():
+            continue
+
+        relative_path = path.relative_to(root_dir).as_posix()
+        if exclude_prefixes and any(relative_path.startswith(item) for item in exclude_prefixes):
+            continue
+
+        arcname = f"{prefix}/{relative_path}" if prefix else relative_path
+        zf.write(path, arcname)
+
+
+def _zip_runtime_with_models(runtime_launcher_dir: Path, model_dir: Path, zip_path: Path) -> None:
+    """打包集成启动器，并把 Full 包已准备好的模型叠加到 assets/models。"""
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    if zip_path.exists():
+        zip_path.unlink()
+
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
-        for p in root_dir.rglob("*"):
-            if p.is_file():
-                rel = p.relative_to(root_dir).as_posix()
-                if exclude_prefixes and any(rel.startswith(ep) for ep in exclude_prefixes):
-                    continue
-                arcname = f"{prefix}/{rel}" if prefix else rel
-                zf.write(p, arcname)
+        _write_dir_contents(zf, runtime_launcher_dir, root_prefix="")
+        _write_dir_contents(zf, model_dir, root_prefix="assets/models")
 
 
 def _zip_single_file(file_path: Path, zip_path: Path) -> None:
@@ -216,7 +246,9 @@ def _download_models(model_base: Path, temp_dir: Path, *, token: str | None) -> 
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Prepare release assets and package Full/Full-Environment.")
+    parser = argparse.ArgumentParser(
+        description="Prepare release assets and package Full/Full-Environment/WithRuntime-Full."
+    )
     parser.add_argument("--repo-root", default=".", help="Repository root (default: .)")
     parser.add_argument("--release-version", required=True, help="Release version")
     parser.add_argument("--dist-src", default="deploy/dist", help="Downloaded dist artifact directory")
@@ -314,12 +346,18 @@ def main() -> int:
         shutil.rmtree(temp_dir)
     temp_dir.mkdir(parents=True, exist_ok=True)
 
-    _download_models(repo_root / "assets/models", temp_dir, token=token or None)
+    model_dir = repo_root / "assets/models"
+    _download_models(model_dir, temp_dir, token=token or None)
 
-    # 清理临时模型目录（避免打包进 Full/Full-Environment）
+    # 清理模型下载临时目录，只保留解压后的模型用于后续多个完整包
     shutil.rmtree(temp_dir, ignore_errors=True)
 
-    # 7. Full 包清单 + 打包（在 repo_root 下打包全部内容；zip 输出在 dist_dir 以避免自包含）
+    # 7. WithRuntime-Full：复用 Full 已准备的模型，不重复下载或复制到构建目录
+    with_runtime_full_zip = dist_dir / f"ZenlessZoneZero-OneDragon-{release_version}-WithRuntime-Full.zip"
+    _log(f"Create WithRuntime-Full zip: {with_runtime_full_zip}")
+    _zip_runtime_with_models(runtime_launcher_dir, model_dir, with_runtime_full_zip)
+
+    # 8. Full 包清单 + 打包（在 repo_root 下打包全部内容；zip 输出在 dist_dir 以避免自包含）
     _log("Generate install manifest (Full)")
     _run([sys.executable, "tools/ci/generate_install_manifest.py"], cwd=repo_root)
 
@@ -327,7 +365,7 @@ def main() -> int:
     _log(f"Create Full zip: {full_zip}")
     _zip_dir_contents(repo_root, full_zip, root_prefix=f"ZenlessZoneZero-OneDragon-{release_version}-Full")
 
-    # 8. Full-Environment：把环境包放入 .install 后重新生成清单并打包
+    # 9. Full-Environment：把环境包放入 .install 后重新生成清单并打包
     env_zip = dist_dir / "ZenlessZoneZero-OneDragon-Environment.zip"
     if not env_zip.exists():
         raise SystemExit(f"Missing {env_zip}")
@@ -341,10 +379,10 @@ def main() -> int:
     _log(f"Create Full-Environment zip: {full_env_zip}")
     _zip_dir_contents(repo_root, full_env_zip, root_prefix=f"ZenlessZoneZero-OneDragon-{release_version}-Full-Environment")
 
-    # 9. 复制安装器到版本化文件名
+    # 10. 复制安装器到版本化文件名
     shutil.copy2(repo_root / "OneDragon-Installer.exe", repo_root / f"ZenlessZoneZero-OneDragon-{release_version}-Installer.exe")
 
-    # 10. 把 dist_dir 下所有 zip 移到 repo_root，供 release step 上传
+    # 11. 把 dist_dir 下所有 zip 移到 repo_root，供 release step 上传
     for z in dist_dir.glob("*.zip"):
         _log(f"Move zip to repo root: {z.name}")
         shutil.move(str(z), str(repo_root / z.name))


### PR DESCRIPTION
## Summary

- 新增 `ZenlessZoneZero-OneDragon-{version}-WithRuntime-Full.zip`，包含集成运行时、源码和模型
- 复用普通 Full 包的模型准备结果，将同一份模型叠加到集成启动器压缩包的 `assets/models/`
- 更新 Release 产物列表和说明，并收紧 Mirror酱的 WithRuntime 文件匹配，避免匹配到两个包
- 同步更新 RuntimeLauncher 发行文档

## Testing

- `uvx --offline ruff check tools/ci/prepare_release_assets.py`
- `python -m py_compile tools/ci/prepare_release_assets.py`
- 本地压缩冒烟测试：校验 RuntimeLauncher、源码和模型的归档路径，并确认更新包仍排除 `src/`
- `git diff --check`

Closes #2504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `WithRuntime-Full` 发行包：内置运行环境、源代码及模型，首次部署解压即用，无需额外下载模型。
  - `WithRuntime` 系列发行包包含必要源代码，优化无预检目录场景下的首次部署体验。
- **发布改进**
  - 新增 `WithRuntime-Full` 已纳入 GitHub Release 发布清单。
  - 更精确的发行包匹配与上传规则，确保对应压缩包正确被发布。
- **文档**
  - 更新运行器集成与产物清单说明，补充 `WithRuntime` 两种包的内容差异及模型复用方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->