### PR TITLE
chore: 使用 ppocrv6 OCR 模型

### DIFF
--- a/src/one_dragon/base/config/basic_model_config.py
+++ b/src/one_dragon/base/config/basic_model_config.py
@@ -40,7 +40,7 @@ class BasicModelConfig(YamlConfig):
         pass
 
 def get_ocr_opts() -> list[ConfigItem]:
-    models_list = [DEFAULT_OCR_MODEL_NAME, PPOCRV6_MODEL_NAME]
+    models_list = ['ppocrv5', PPOCRV6_MODEL_NAME]
     config_list: list[ConfigItem] = []
     for model in models_list:
         model_dir = get_ocr_model_dir(model)

--- a/src/one_dragon/base/config/basic_model_config.py
+++ b/src/one_dragon/base/config/basic_model_config.py
@@ -1,7 +1,6 @@
 from one_dragon.base.config.config_item import ConfigItem
 from one_dragon.base.config.yaml_config import YamlConfig
 from one_dragon.base.matcher.ocr.onnx_ocr_matcher import (
-    DEFAULT_OCR_MODEL_NAME,
     PPOCRV6_MODEL_NAME,
     get_final_file_list,
     get_ocr_download_url_gitee,
@@ -18,7 +17,10 @@ class BasicModelConfig(YamlConfig):
 
     @property
     def ocr(self) -> str:
-        return self.get('ocr', DEFAULT_OCR_MODEL_NAME)
+        current = self.get('ocr', PPOCRV6_MODEL_NAME)
+        if current != PPOCRV6_MODEL_NAME:
+            self.ocr = PPOCRV6_MODEL_NAME
+        return PPOCRV6_MODEL_NAME
 
     @ocr.setter
     def ocr(self, new_value: str) -> None:
@@ -40,7 +42,7 @@ class BasicModelConfig(YamlConfig):
         pass
 
 def get_ocr_opts() -> list[ConfigItem]:
-    models_list = ['ppocrv5', PPOCRV6_MODEL_NAME]
+    models_list = [PPOCRV6_MODEL_NAME]
     config_list: list[ConfigItem] = []
     for model in models_list:
         model_dir = get_ocr_model_dir(model)

--- a/src/one_dragon/base/matcher/ocr/onnx_ocr_matcher.py
+++ b/src/one_dragon/base/matcher/ocr/onnx_ocr_matcher.py
@@ -18,7 +18,7 @@ from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 
 DEFAULT_OCR_MODEL_NAME: str = 'ppocrv6'
-PPOCRV6_MODEL_NAME: str = DEFAULT_OCR_MODEL_NAME
+PPOCRV6_MODEL_NAME: str = 'ppocrv6'
 GITHUB_DOWNLOAD_URL: str = 'https://github.com/OneDragon-Anything/OneDragon-Env/releases/download'
 GITEE_DOWNLOAD_URL: str = 'https://gitee.com/OneDragon-Anything/OneDragon-Env/releases/download'
 

--- a/src/one_dragon/base/matcher/ocr/onnx_ocr_matcher.py
+++ b/src/one_dragon/base/matcher/ocr/onnx_ocr_matcher.py
@@ -17,8 +17,8 @@ from one_dragon.utils import os_utils, str_utils
 from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 
-DEFAULT_OCR_MODEL_NAME: str = 'ppocrv5'
-PPOCRV6_MODEL_NAME: str = 'ppocrv6'
+DEFAULT_OCR_MODEL_NAME: str = 'ppocrv6'
+PPOCRV6_MODEL_NAME: str = DEFAULT_OCR_MODEL_NAME
 GITHUB_DOWNLOAD_URL: str = 'https://github.com/OneDragon-Anything/OneDragon-Env/releases/download'
 GITEE_DOWNLOAD_URL: str = 'https://gitee.com/OneDragon-Anything/OneDragon-Env/releases/download'
 

--- a/src/onnxocr/onnx_paddleocr.py
+++ b/src/onnxocr/onnx_paddleocr.py
@@ -33,7 +33,7 @@ def _normalize_ppocrv6_model_name(model_name: str) -> str:
 
 
 def _build_ppocrv6_defaults(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """为 PP-OCRv6 模型构建默认参数。如果不是 v6 模型则返回空字典，保证 v5 兼容。"""
+    """为 PP-OCRv6 模型构建默认参数。如果不是 v6 模型则返回空字典。"""
     model_name = kwargs.pop("ocr_model_name", None)
     if not model_name:
         kwargs.pop("ocr_model_size", None)
@@ -205,14 +205,14 @@ def __debug():
 
     from one_dragon.utils import debug_utils, os_utils
 
-    models_dir = os_utils.get_path_under_work_dir('assets', 'models', 'onnx_ocr', 'ppocrv5')
+    models_dir = os_utils.get_path_under_work_dir('assets', 'models', 'onnx_ocr', 'ppocrv6')
 
     model = ONNXPaddleOcr(
                     use_angle_cls=False, use_gpu=False,
                     det_model_dir=os.path.join(models_dir, 'det.onnx'),
                     rec_model_dir=os.path.join(models_dir, 'rec.onnx'),
                     cls_model_dir=os.path.join(models_dir, 'cls.onnx'),
-                    rec_char_dict_path=os.path.join(models_dir, 'ppocrv5_dict.txt'),
+                    rec_char_dict_path=os.path.join(models_dir, 'ppocrv6_dict.txt'),
                     vis_font_path=os.path.join(models_dir, 'simfang.ttf'),
                 )
 

--- a/src/onnxocr/utils.py
+++ b/src/onnxocr/utils.py
@@ -269,7 +269,7 @@ def infer_args():
     parser.add_argument(
         "--det_model_dir",
         type=str,
-        default=str(module_dir / "models/ppocrv5/det.onnx"),
+        default=str(module_dir / "models/ppocrv6/det.onnx"),
     )
     parser.add_argument("--det_limit_side_len", type=float, default=960)
     parser.add_argument("--det_limit_type", type=str, default="max")
@@ -310,7 +310,7 @@ def infer_args():
     parser.add_argument(
         "--rec_model_dir",
         type=str,
-        default=str(module_dir / "models/ppocrv5/rec.onnx"),
+        default=str(module_dir / "models/ppocrv6/rec.onnx"),
     )
     parser.add_argument("--rec_image_inverse", type=str2bool, default=True)
     parser.add_argument("--rec_image_shape", type=str, default="3, 48, 320")
@@ -319,7 +319,7 @@ def infer_args():
     parser.add_argument(
         "--rec_char_dict_path",
         type=str,
-        default=str(module_dir / "models/ppocrv5/ppocrv5_dict.txt"),
+        default=str(module_dir / "models/ppocrv6/ppocrv6_dict.txt"),
     )
     parser.add_argument("--use_space_char", type=str2bool, default=True)
     parser.add_argument(

--- a/tools/ci/prepare_release_assets.py
+++ b/tools/ci/prepare_release_assets.py
@@ -187,12 +187,12 @@ def _zip_single_file(file_path: Path, zip_path: Path) -> None:
 
 _MODEL_CONFIGS: list[dict[str, str]] = [
     {
-        "label": "ppocrv5",
+        "label": "ppocrv6",
         "repo": "OneDragon-Anything/OneDragon-Env",
-        "pattern": r"ppocrv5\.zip$",
+        "pattern": r"ppocrv6\.zip$",
         "dest_folder": "onnx_ocr",
-        "fallback_url": "https://github.com/OneDragon-Anything/OneDragon-Env/releases/download/ppocrv5/ppocrv5.zip",
-        "fallback_name": "ppocrv5",
+        "fallback_url": "https://github.com/OneDragon-Anything/OneDragon-Env/releases/download/ppocrv6/ppocrv6.zip",
+        "fallback_name": "ppocrv6",
     },
     {
         "label": "flash",


### PR DESCRIPTION
本地使用 ppocrv6，测试通过；CI 使用默认 ppocrv5，把 99 识别成 9，测试失败
<img width="1337" height="964" alt="image" src="https://github.com/user-attachments/assets/56785d02-e878-435f-82cf-59f3ea3aaf7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进

* 默认 OCR 模型已更新为 **PP-OCRv6**，提升 OCR 识别流程的一致性。
* OCR 相关配置、调试流程及资源下载配置已同步切换至 **PP-OCRv6**。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->