### PR TITLE
ci: 全量同步仓库到cnb镜像

### DIFF
--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -2,8 +2,6 @@ name: Sync to CNB
 
 on:
   push:
-    branches: [main, test]
-    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -14,14 +12,12 @@ jobs:
     if: ${{ github.repository == 'OneDragon-Anything/ZenlessZoneZero-OneDragon' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Push to CNB
         env:
           CNB_TOKEN: ${{ secrets.CNB_GIT_TOKEN }}
         run: |
-          git remote add cnb "https://cnb:${CNB_TOKEN}@cnb.cool/OneDragon-Anything/ZenlessZoneZero-OneDragon.git"
-          git push -f cnb "${GITHUB_REF}:${GITHUB_REF}"
+          git clone --bare "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" repository.git
+          git -C repository.git remote add cnb "https://cnb:${CNB_TOKEN}@cnb.cool/OneDragon-Anything/ZenlessZoneZero-OneDragon.git"
+          git -C repository.git push --force --prune cnb \
+            '+refs/heads/*:refs/heads/*' \
+            '+refs/tags/*:refs/tags/*'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新代码同步流程，现可同步所有分支和标签。
  * 同步时会强制覆盖目标端对应内容，并清理已不存在的远端引用。
  * 同步任务的触发范围扩大，不再仅限于指定分支或版本标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->