### PR TITLE
fix(lost_void): 重构入口一系列screen连通路径

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5381,6 +5381,86 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 按钮-周期
+    id_mark: false
+    pc_rect:
+    - 1453
+    - 26
+    - 1567
+    - 72
+    text: 周期
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 探索收集
+    id_mark: true
+    pc_rect:
+    - 1658
+    - 991
+    - 1804
+    - 1064
+    text: 探索收集
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+- screen_id: lost_void_entry_periodic
+  screen_name: 迷失之地-入口-周期
+  app_id: lost_void
+  pc_alt: false
+  area_list:
+  - area_name: 按钮-周期
+    id_mark: true
+    pc_rect:
+    - 1453
+    - 26
+    - 1567
+    - 72
+    text: 周期
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 探索收集
+    id_mark: true
+    pc_rect:
+    - 1658
+    - 991
+    - 1804
+    - 1064
+    text: 探索收集
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+- screen_id: lost_void_entry_standard
+  screen_name: 迷失之地-入口-常规
+  app_id: lost_void
+  pc_alt: false
+  area_list:
+  - area_name: 按钮-常规
+    id_mark: false
+    pc_rect:
+    - 1616
+    - 19
+    - 1740
+    - 89
+    text: 常规
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
   - area_name: 按钮-战线肃清
     id_mark: false
     pc_rect:
@@ -5411,14 +5491,14 @@
     color_range: null
     goto_list:
     - 迷失之地-特遣调查
-  - area_name: 按钮-周期
-    id_mark: false
+  - area_name: 作战潜能
+    id_mark: true
     pc_rect:
-    - 1453
-    - 26
-    - 1567
-    - 72
-    text: 周期
+    - 909
+    - 979
+    - 1037
+    - 1064
+    text: 作战潜能
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5325,34 +5325,6 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-  - area_name: 区域-矩阵行动
-    id_mark: false
-    pc_rect:
-    - 745
-    - 233
-    - 907
-    - 288
-    text: 矩阵行动
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 按钮-前往挑战
-    id_mark: false
-    pc_rect:
-    - 1142
-    - 746
-    - 1384
-    - 809
-    text: 前往挑战
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
   - area_name: 按钮-下一步
     id_mark: false
     pc_rect:
@@ -5395,20 +5367,6 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-  - area_name: 探索收集
-    id_mark: true
-    pc_rect:
-    - 1658
-    - 991
-    - 1804
-    - 1064
-    text: 探索收集
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
 - screen_id: lost_void_entry_periodic
   screen_name: 迷失之地-入口-周期
   app_id: lost_void
@@ -5436,6 +5394,34 @@
     - 1804
     - 1064
     text: 探索收集
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 区域-矩阵行动
+    id_mark: false
+    pc_rect:
+    - 745
+    - 233
+    - 907
+    - 288
+    text: 矩阵行动
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 按钮-前往挑战
+    id_mark: false
+    pc_rect:
+    - 1142
+    - 746
+    - 1384
+    - 809
+    text: 前往挑战
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''
@@ -5553,7 +5539,7 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list:
-    - 迷失之地-入口
+    - 迷失之地-入口-常规
   - area_name: 按钮-特遣任务
     id_mark: true
     pc_rect:

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5416,6 +5416,21 @@
     color_range: null
     goto_list:
     - 迷失之地-入口-周期
+  - area_name: 下一步
+    id_mark: false
+    pc_rect:
+    - 1633
+    - 998
+    - 1811
+    - 1052
+    text: 下一步
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 迷失之地-矩阵行动-编队选择
 - screen_id: lost_void_entry_periodic
   screen_name: 迷失之地-入口-周期
   app_id: lost_void
@@ -5503,7 +5518,8 @@
     template_id: ''
     template_match_threshold: 0.7
     color_range: null
-    goto_list: []
+    goto_list:
+    - 迷失之地-矩阵行动
 - screen_id: lost_void_entry_purge
   screen_name: 迷失之地-战线肃清
   app_id: lost_void

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5275,7 +5275,7 @@
     - 1181
     - 19
     - 1346
-    - 70
+    - 65
     text: 悬赏委托
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -5367,6 +5367,55 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+- screen_id: lost_void_entry_matrix_action
+  screen_name: 迷失之地-矩阵行动
+  app_id: lost_void
+  pc_alt: false
+  area_list:
+  - area_name: 标题-矩阵行动
+    id_mark: true
+    pc_rect:
+    - 960
+    - 156
+    - 1161
+    - 256
+    text: 矩阵行动
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 按钮-街区
+    id_mark: true
+    pc_rect:
+    - 234
+    - 26
+    - 390
+    - 80
+    text: 街区
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 大世界-普通
+  - area_name: 菜单-返回
+    id_mark: true
+    pc_rect:
+    - 82
+    - 13
+    - 150
+    - 90
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: menu
+    template_id: back
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 迷失之地-入口-周期
 - screen_id: lost_void_entry_periodic
   screen_name: 迷失之地-入口-周期
   app_id: lost_void
@@ -5392,6 +5441,27 @@
       - 255
       - 255
     goto_list: []
+  - area_name: 按钮-常规
+    id_mark: false
+    pc_rect:
+    - 1616
+    - 19
+    - 1740
+    - 89
+    text: 常规
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range:
+    - - 40
+      - 40
+      - 40
+    - - 255
+      - 255
+      - 255
+    goto_list:
+    - 迷失之地-入口-常规
   - area_name: 探索收集
     id_mark: true
     pc_rect:
@@ -5434,6 +5504,139 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+- screen_id: lost_void_entry_purge
+  screen_name: 迷失之地-战线肃清
+  app_id: lost_void
+  pc_alt: false
+  area_list:
+  - area_name: 标题-战线肃清
+    id_mark: true
+    pc_rect:
+    - 986
+    - 208
+    - 1694
+    - 262
+    text: 战线肃清
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 按钮-街区
+    id_mark: true
+    pc_rect:
+    - 234
+    - 26
+    - 390
+    - 80
+    text: 街区
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 大世界-普通
+  - area_name: 菜单-返回
+    id_mark: true
+    pc_rect:
+    - 82
+    - 13
+    - 150
+    - 90
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: menu
+    template_id: back
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list:
+    - 迷失之地-入口-常规
+  - area_name: 周期增益-第一个
+    id_mark: false
+    pc_rect:
+    - 1000
+    - 388
+    - 1750
+    - 524
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 周期增益-第二个
+    id_mark: false
+    pc_rect:
+    - 1000
+    - 536
+    - 1750
+    - 654
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 周期增益-第三个
+    id_mark: false
+    pc_rect:
+    - 1000
+    - 678
+    - 1750
+    - 808
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 按钮-难度
+    id_mark: false
+    pc_rect:
+    - 1578
+    - 22
+    - 1818
+    - 82
+    text: 难度
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 区域-难度列表
+    id_mark: false
+    pc_rect:
+    - 1566
+    - 94
+    - 1818
+    - 434
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
+  - area_name: 按钮-调查战略
+    id_mark: false
+    pc_rect:
+    - 1708
+    - 198
+    - 1796
+    - 296
+    text: ''
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
 - screen_id: lost_void_entry_standard
   screen_name: 迷失之地-入口-常规
   app_id: lost_void
@@ -5453,6 +5656,27 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 按钮-周期
+    id_mark: false
+    pc_rect:
+    - 1453
+    - 26
+    - 1567
+    - 72
+    text: 周期
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range:
+    - - 40
+      - 40
+      - 40
+    - - 255
+      - 255
+      - 255
+    goto_list:
+    - 迷失之地-入口-周期
   - area_name: 按钮-战线肃清
     id_mark: false
     pc_rect:
@@ -5530,7 +5754,7 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list:
-    - 大世界
+    - 大世界-普通
   - area_name: 菜单-返回
     id_mark: true
     pc_rect:
@@ -5969,124 +6193,6 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-- screen_id: lost_void_purge
-  screen_name: 迷失之地-战线肃清
-  app_id: lost_void
-  pc_alt: false
-  area_list:
-  - area_name: 标题-战线肃清
-    id_mark: true
-    pc_rect:
-    - 986
-    - 208
-    - 1694
-    - 262
-    text: 战线肃清
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 按钮-街区
-    id_mark: true
-    pc_rect:
-    - 234
-    - 26
-    - 390
-    - 80
-    text: 街区
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list:
-    - 大世界-普通
-  - area_name: 周期增益-第一个
-    id_mark: false
-    pc_rect:
-    - 1000
-    - 388
-    - 1750
-    - 524
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 周期增益-第二个
-    id_mark: false
-    pc_rect:
-    - 1000
-    - 536
-    - 1750
-    - 654
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 周期增益-第三个
-    id_mark: false
-    pc_rect:
-    - 1000
-    - 678
-    - 1750
-    - 808
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 按钮-难度
-    id_mark: false
-    pc_rect:
-    - 1578
-    - 22
-    - 1818
-    - 82
-    text: 难度
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 区域-难度列表
-    id_mark: false
-    pc_rect:
-    - 1566
-    - 94
-    - 1818
-    - 434
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 按钮-调查战略
-    id_mark: false
-    pc_rect:
-    - 1708
-    - 198
-    - 1796
-    - 296
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
 - screen_id: lost_void_route_change
   screen_name: 迷失之地-路径迭换
   app_id: lost_void
@@ -6166,8 +6272,8 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-- screen_id: matrix_action
-  screen_name: 迷失之地-矩阵行动
+- screen_id: matrix_action_team_select
+  screen_name: 迷失之地-矩阵行动-编队选择
   app_id: lost_void
   pc_alt: false
   area_list:

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -5384,7 +5384,13 @@
     template_sub_dir: ''
     template_id: ''
     template_match_threshold: 0.7
-    color_range: null
+    color_range:
+    - - 120
+      - 120
+      - 0
+    - - 255
+      - 255
+      - 255
     goto_list: []
   - area_name: 探索收集
     id_mark: true

--- a/assets/game_data/screen_info/lost_void_entry.yml
+++ b/assets/game_data/screen_info/lost_void_entry.yml
@@ -73,34 +73,6 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
-- area_name: 区域-矩阵行动
-  id_mark: false
-  pc_rect:
-  - 745
-  - 233
-  - 907
-  - 288
-  text: 矩阵行动
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
-- area_name: 按钮-前往挑战
-  id_mark: false
-  pc_rect:
-  - 1142
-  - 746
-  - 1384
-  - 809
-  text: 前往挑战
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
 - area_name: 按钮-下一步
   id_mark: false
   pc_rect:
@@ -137,20 +109,6 @@ area_list:
   - 1567
   - 72
   text: 周期
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
-- area_name: 探索收集
-  id_mark: true
-  pc_rect:
-  - 1658
-  - 991
-  - 1804
-  - 1064
-  text: 探索收集
   lcs_percent: 0.5
   template_sub_dir: ''
   template_id: ''

--- a/assets/game_data/screen_info/lost_void_entry.yml
+++ b/assets/game_data/screen_info/lost_void_entry.yml
@@ -23,7 +23,7 @@ area_list:
   - 1181
   - 19
   - 1346
-  - 70
+  - 65
   text: 悬赏委托
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/lost_void_entry.yml
+++ b/assets/game_data/screen_info/lost_void_entry.yml
@@ -129,36 +129,6 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
-- area_name: 按钮-战线肃清
-  id_mark: false
-  pc_rect:
-  - 878
-  - 318
-  - 1069
-  - 365
-  text: 战线肃清
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list:
-  - 迷失之地-战线肃清
-- area_name: 按钮-特遣调查
-  id_mark: false
-  pc_rect:
-  - 1425
-  - 311
-  - 1613
-  - 362
-  text: 特遣调查
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list:
-  - 迷失之地-特遣调查
 - area_name: 按钮-周期
   id_mark: false
   pc_rect:

--- a/assets/game_data/screen_info/lost_void_entry_matrix_action.yml
+++ b/assets/game_data/screen_info/lost_void_entry_matrix_action.yml
@@ -1,0 +1,64 @@
+screen_id: lost_void_entry_matrix_action
+screen_name: 迷失之地-矩阵行动
+app_id: lost_void
+pc_alt: false
+area_list:
+- area_name: 标题-矩阵行动
+  id_mark: true
+  pc_rect:
+  - 960
+  - 156
+  - 1161
+  - 256
+  text: 矩阵行动
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 按钮-街区
+  id_mark: true
+  pc_rect:
+  - 234
+  - 26
+  - 390
+  - 80
+  text: 街区
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 大世界-普通
+- area_name: 菜单-返回
+  id_mark: true
+  pc_rect:
+  - 82
+  - 13
+  - 150
+  - 90
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: menu
+  template_id: back
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 迷失之地-入口-周期
+- area_name: 下一步
+  id_mark: false
+  pc_rect:
+  - 1633
+  - 998
+  - 1811
+  - 1052
+  text: 下一步
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 迷失之地-矩阵行动-编队选择

--- a/assets/game_data/screen_info/lost_void_entry_periodic.yml
+++ b/assets/game_data/screen_info/lost_void_entry_periodic.yml
@@ -15,7 +15,13 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
-  color_range: null
+  color_range:
+  - - 120
+    - 120
+    - 0
+  - - 255
+    - 255
+    - 255
   goto_list: []
 - area_name: 探索收集
   id_mark: true

--- a/assets/game_data/screen_info/lost_void_entry_periodic.yml
+++ b/assets/game_data/screen_info/lost_void_entry_periodic.yml
@@ -1,0 +1,33 @@
+screen_id: lost_void_entry_periodic
+screen_name: 迷失之地-入口-周期
+app_id: lost_void
+pc_alt: false
+area_list:
+- area_name: 按钮-周期
+  id_mark: true
+  pc_rect:
+  - 1453
+  - 26
+  - 1567
+  - 72
+  text: 周期
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 探索收集
+  id_mark: true
+  pc_rect:
+  - 1658
+  - 991
+  - 1804
+  - 1064
+  text: 探索收集
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/lost_void_entry_periodic.yml
+++ b/assets/game_data/screen_info/lost_void_entry_periodic.yml
@@ -23,6 +23,27 @@ area_list:
     - 255
     - 255
   goto_list: []
+- area_name: 按钮-常规
+  id_mark: false
+  pc_rect:
+  - 1616
+  - 19
+  - 1740
+  - 89
+  text: 常规
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range:
+  - - 40
+    - 40
+    - 40
+  - - 255
+    - 255
+    - 255
+  goto_list:
+  - 迷失之地-入口-常规
 - area_name: 探索收集
   id_mark: true
   pc_rect:

--- a/assets/game_data/screen_info/lost_void_entry_periodic.yml
+++ b/assets/game_data/screen_info/lost_void_entry_periodic.yml
@@ -85,4 +85,5 @@ area_list:
   template_id: ''
   template_match_threshold: 0.7
   color_range: null
-  goto_list: []
+  goto_list:
+  - 迷失之地-矩阵行动

--- a/assets/game_data/screen_info/lost_void_entry_periodic.yml
+++ b/assets/game_data/screen_info/lost_void_entry_periodic.yml
@@ -31,3 +31,31 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 区域-矩阵行动
+  id_mark: false
+  pc_rect:
+  - 745
+  - 233
+  - 907
+  - 288
+  text: 矩阵行动
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 按钮-前往挑战
+  id_mark: false
+  pc_rect:
+  - 1142
+  - 746
+  - 1384
+  - 809
+  text: 前往挑战
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/lost_void_entry_purge.yml
+++ b/assets/game_data/screen_info/lost_void_entry_purge.yml
@@ -1,4 +1,4 @@
-screen_id: lost_void_purge
+screen_id: lost_void_entry_purge
 screen_name: 迷失之地-战线肃清
 app_id: lost_void
 pc_alt: false

--- a/assets/game_data/screen_info/lost_void_entry_standard.yml
+++ b/assets/game_data/screen_info/lost_void_entry_standard.yml
@@ -17,6 +17,27 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
+- area_name: 按钮-周期
+  id_mark: false
+  pc_rect:
+  - 1453
+  - 26
+  - 1567
+  - 72
+  text: 周期
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range:
+  - - 40
+    - 40
+    - 40
+  - - 255
+    - 255
+    - 255
+  goto_list:
+  - 迷失之地-入口-周期
 - area_name: 按钮-战线肃清
   id_mark: false
   pc_rect:

--- a/assets/game_data/screen_info/lost_void_entry_standard.yml
+++ b/assets/game_data/screen_info/lost_void_entry_standard.yml
@@ -1,0 +1,77 @@
+screen_id: lost_void_entry_standard
+screen_name: 迷失之地-入口-常规
+app_id: lost_void
+pc_alt: false
+area_list:
+- area_name: 按钮-常规
+  id_mark: false
+  pc_rect:
+  - 1616
+  - 19
+  - 1740
+  - 89
+  text: 常规
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 按钮-战线肃清
+  id_mark: false
+  pc_rect:
+  - 878
+  - 318
+  - 1069
+  - 365
+  text: 战线肃清
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 迷失之地-战线肃清
+- area_name: 按钮-特遣调查
+  id_mark: false
+  pc_rect:
+  - 1425
+  - 311
+  - 1613
+  - 362
+  text: 特遣调查
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 迷失之地-特遣调查
+- area_name: 作战潜能
+  id_mark: true
+  pc_rect:
+  - 909
+  - 979
+  - 1037
+  - 1064
+  text: 作战潜能
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 探索收集
+  id_mark: true
+  pc_rect:
+  - 1658
+  - 991
+  - 1804
+  - 1064
+  text: 探索收集
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []

--- a/assets/game_data/screen_info/lost_void_entry_task_force.yml
+++ b/assets/game_data/screen_info/lost_void_entry_task_force.yml
@@ -17,7 +17,7 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list:
-  - 大世界
+  - 大世界-普通
 - area_name: 菜单-返回
   id_mark: true
   pc_rect:
@@ -32,7 +32,7 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list:
-  - 迷失之地-入口
+  - 迷失之地-入口-常规
 - area_name: 按钮-特遣任务
   id_mark: true
   pc_rect:

--- a/assets/game_data/screen_info/lost_void_purge.yml
+++ b/assets/game_data/screen_info/lost_void_purge.yml
@@ -32,6 +32,21 @@ area_list:
   color_range: null
   goto_list:
   - 大世界-普通
+- area_name: 菜单-返回
+  id_mark: true
+  pc_rect:
+  - 82
+  - 13
+  - 150
+  - 90
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: menu
+  template_id: back
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list:
+  - 迷失之地-入口-常规
 - area_name: 周期增益-第一个
   id_mark: false
   pc_rect:

--- a/assets/game_data/screen_info/matrix_action_team_select.yml
+++ b/assets/game_data/screen_info/matrix_action_team_select.yml
@@ -1,5 +1,5 @@
-screen_id: matrix_action
-screen_name: 迷失之地-矩阵行动
+screen_id: matrix_action_team_select
+screen_name: 迷失之地-矩阵行动-编队选择
 app_id: lost_void
 pc_alt: false
 area_list:

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -101,7 +101,7 @@ class LostVoidApp(ZApplication):
             return self.round_success('可前往副本画面')
 
         # 特殊兼容：在入口区域开始，接力运行
-        if screen_name == '迷失之地-入口':
+        if screen_name in ['迷失之地-入口-周期', '迷失之地-入口-常规']:
             return self.round_success('迷失之地-入口')
 
         # 未识别到画面；走快捷手册传送流程
@@ -136,8 +136,9 @@ class LostVoidApp(ZApplication):
         if result.is_success:
             return self.round_retry(result.status, wait=0.5)
 
-        screen_name = self.check_and_update_current_screen(self.last_screenshot, screen_name_list=['迷失之地-入口'])
-        if screen_name != '迷失之地-入口':
+        screen_name_list = ['迷失之地-入口-周期', '迷失之地-入口-常规']
+        screen_name = self.check_and_update_current_screen(self.last_screenshot, screen_name_list=screen_name_list)
+        if screen_name not in screen_name_list:
             return self.round_wait(status='等待画面加载', wait=1)
         return self.round_success(status=screen_name)
 
@@ -161,9 +162,9 @@ class LostVoidApp(ZApplication):
                 return self.round_success(LostVoidApp.STATUS_AGAIN_MATRIX)
             return self.round_success(LostVoidApp.STATUS_AGAIN)
 
-        result = self.round_by_find_area(self.last_screenshot, '迷失之地-入口', '按钮-常规')
+        result = self.round_by_find_area(self.last_screenshot, '迷失之地-入口', '按钮-悬赏委托')
         if not result.is_success:
-            return self.round_retry('未识别到常规按钮', wait=0.5)
+            return self.round_retry('未识别到悬赏委托', wait=0.5)
 
         TARGET_SCORE = '8000'  # 目标分数文本
 
@@ -197,7 +198,7 @@ class LostVoidApp(ZApplication):
     @node_from(from_name='识别悬赏委托完成进度', status=STATUS_AGAIN_MATRIX)
     @operation_node(name='矩阵行动-前往入口')
     def matrix_goto_entry(self) -> OperationRoundResult:
-        return self.round_by_goto_screen(screen_name='迷失之地-入口')
+        return self.round_by_goto_screen(screen_name='迷失之地-入口-周期')
 
     @node_from(from_name='矩阵行动-前往入口')
     @operation_node(name='入口OCR-点击周期')
@@ -205,7 +206,7 @@ class LostVoidApp(ZApplication):
         """在入口页点击周期标签。"""
         result = self.round_by_find_area(
             self.last_screenshot,
-            '迷失之地-入口',
+            '迷失之地-入口-周期',
             '按钮-前往挑战',
         )
         if result.is_success:
@@ -213,9 +214,9 @@ class LostVoidApp(ZApplication):
 
         result = self.round_by_find_and_click_area(
             self.last_screenshot,
-            '迷失之地-入口',
+            '迷失之地-入口-周期',
             '按钮-周期',
-            until_find_all=[('迷失之地-入口', '按钮-前往挑战')],
+            until_find_all=[('迷失之地-入口-周期', '按钮-前往挑战')],
             success_wait=0.3,
             retry_wait=0.1,
         )
@@ -229,7 +230,7 @@ class LostVoidApp(ZApplication):
         """在矩阵行动入口点击前往挑战。"""
         return self.round_by_find_and_click_area(
             self.last_screenshot,
-            '迷失之地-入口',
+            '迷失之地-入口-周期',
             '按钮-前往挑战',
             success_wait=1,
             retry_wait=1,
@@ -277,7 +278,6 @@ class LostVoidApp(ZApplication):
         # 初始为较高的匹配阈值，如果超过5次匹配失败则改用0.5的阈值兜底
         lcs_percent = 0.7 if self.node_retry_times < 5 else 0.5
 
-        area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '编队列表')
         main_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '主战编队槽')
 
         # 获取目标编队名称
@@ -489,7 +489,7 @@ class LostVoidApp(ZApplication):
         # 已显示目标副本时，常规按钮可能不会显示，直接进入下一步
         result = self.round_by_find_area(
             self.last_screenshot,
-            '迷失之地-入口',
+            '迷失之地-入口-常规',
             mission_area_name,
         )
         if result.is_success:
@@ -499,7 +499,7 @@ class LostVoidApp(ZApplication):
             self.last_screenshot,
             '迷失之地-入口',
             '按钮-常规',
-            until_find_all=[('迷失之地-入口', mission_area_name)],
+            until_find_all=[('迷失之地-入口-常规', mission_area_name)],
             success_wait=0.3,
             retry_wait=0.1,
         )
@@ -623,7 +623,8 @@ class LostVoidApp(ZApplication):
                 if digit_context.is_success and digit_context.contours:
                     for digit_contour in digit_context.contours:
                         M = cv2.moments(digit_contour)
-                        if M["m00"] == 0: continue
+                        if M["m00"] == 0:
+                            continue
                         center_x = int(M["m10"] / M["m00"])
                         center_y = int(M["m01"] / M["m00"])
 

--- a/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/lost_void_app.py
@@ -100,10 +100,6 @@ class LostVoidApp(ZApplication):
         if can_go or screen_name == f'迷失之地-{mission_name}':
             return self.round_success('可前往副本画面')
 
-        # 特殊兼容：在入口区域开始，接力运行
-        if screen_name in ['迷失之地-入口-周期', '迷失之地-入口-常规']:
-            return self.round_success('迷失之地-入口')
-
         # 未识别到画面；走快捷手册传送流程
         can_go = self.check_current_can_go('快捷手册-作战')
         if can_go:
@@ -123,7 +119,6 @@ class LostVoidApp(ZApplication):
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='识别初始画面', status='可前往副本画面')
-    @node_from(from_name='识别初始画面', status='迷失之地-入口')
     @node_from(from_name='前往迷失之地-入口')
     @operation_node(name='开始前等待入口加载')
     def wait_lost_void_entry(self) -> OperationRoundResult:
@@ -198,62 +193,14 @@ class LostVoidApp(ZApplication):
     @node_from(from_name='识别悬赏委托完成进度', status=STATUS_AGAIN_MATRIX)
     @operation_node(name='矩阵行动-前往入口')
     def matrix_goto_entry(self) -> OperationRoundResult:
-        return self.round_by_goto_screen(screen_name='迷失之地-入口-周期')
+        return self.round_by_goto_screen(screen_name='迷失之地-矩阵行动-编队选择')
 
     @node_from(from_name='矩阵行动-前往入口')
-    @operation_node(name='入口OCR-点击周期')
-    def click_period_in_entry(self) -> OperationRoundResult:
-        """在入口页点击周期标签。"""
-        result = self.round_by_find_area(
-            self.last_screenshot,
-            '迷失之地-入口-周期',
-            '按钮-前往挑战',
-        )
-        if result.is_success:
-            return self.round_success('已开放前往挑战')
-
-        result = self.round_by_find_and_click_area(
-            self.last_screenshot,
-            '迷失之地-入口-周期',
-            '按钮-周期',
-            until_find_all=[('迷失之地-入口-周期', '按钮-前往挑战')],
-            success_wait=0.3,
-            retry_wait=0.1,
-        )
-        if result.is_success:
-            return self.round_success('已开放前往挑战')
-        return result
-
-    @node_from(from_name='入口OCR-点击周期', status='已开放前往挑战')
-    @operation_node(name='矩阵行动-前往挑战')
-    def matrix_goto_challenge(self) -> OperationRoundResult:
-        """在矩阵行动入口点击前往挑战。"""
-        return self.round_by_find_and_click_area(
-            self.last_screenshot,
-            '迷失之地-入口-周期',
-            '按钮-前往挑战',
-            success_wait=1,
-            retry_wait=1,
-        )
-
-    @node_from(from_name='矩阵行动-前往挑战')
-    @operation_node(name='矩阵行动-点击下一步')
-    def matrix_click_next_step(self) -> OperationRoundResult:
-        """在矩阵行动入口点击下一步。"""
-        return self.round_by_find_and_click_area(
-            self.last_screenshot,
-            '迷失之地-入口',
-            '按钮-下一步',
-            success_wait=1,
-            retry_wait=1,
-        )
-
-    @node_from(from_name='矩阵行动-点击下一步')
     @operation_node(name='矩阵行动-点击预备编队')
     def matrix_click_preset_team(self) -> OperationRoundResult:
         if self.ctx.lost_void.challenge_config.manually_choose_agent:
             return self.round_success('手动选取角色')
-        area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '预备编队')
+        area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '预备编队')
         if area is not None:
             part = cv2_utils.crop_image_only(self.last_screenshot, area.rect)
             if cv2_utils.is_colorful(part):
@@ -263,7 +210,7 @@ class LostVoidApp(ZApplication):
         # 按钮还是灰度，需要点击
         result = self.round_by_find_and_click_area(
             self.last_screenshot,
-            '迷失之地-矩阵行动',
+            '迷失之地-矩阵行动-编队选择',
             '预备编队',
             success_wait=1,
         )
@@ -278,7 +225,7 @@ class LostVoidApp(ZApplication):
         # 初始为较高的匹配阈值，如果超过5次匹配失败则改用0.5的阈值兜底
         lcs_percent = 0.7 if self.node_retry_times < 5 else 0.5
 
-        main_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '主战编队槽')
+        main_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '主战编队槽')
 
         # 获取目标编队名称
         predefined_idx = self.ctx.lost_void.challenge_config.predefined_team_idx
@@ -312,7 +259,7 @@ class LostVoidApp(ZApplication):
                     return self.round_success(success_msg, wait=1)
             return self.round_retry('未找到主战', wait=0.5)
 
-        self.scroll_area(screen_name='迷失之地-矩阵行动', area_name='编队列表', direction='down')
+        self.scroll_area(screen_name='迷失之地-矩阵行动-编队选择', area_name='编队列表', direction='down')
         return self.round_retry(f'未找到{team_name}, 尝试向下滚动', wait=0.3)
 
     @node_from(from_name='矩阵行动-点击预备编队', status='手动选取角色')
@@ -324,8 +271,8 @@ class LostVoidApp(ZApplication):
         # 记录角色在第几页的哪个位置
         agent_page_match_list: list[[int, Point] | None] = [None] * len(agent_list_str)
 
-        agent_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '代理人列表')
-        main_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '主战编队槽')
+        agent_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '代理人列表')
+        main_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '主战编队槽')
 
         # 1. 取消主战代理人
         ocr_result_list = self.ctx.ocr_service.get_ocr_result_list(
@@ -391,7 +338,7 @@ class LostVoidApp(ZApplication):
         """在矩阵行动页面点击协战代理人。"""
         return self.round_by_find_and_click_area(
             self.last_screenshot,
-            '迷失之地-矩阵行动',
+            '迷失之地-矩阵行动-编队选择',
             '协战代理人',
             success_wait=1,
             retry_wait=1,
@@ -408,9 +355,9 @@ class LostVoidApp(ZApplication):
     @node_from(from_name='矩阵行动-等待代理人列表')
     @operation_node(name='矩阵行动-选择协战代理人')
     def matrix_select_support_agent(self) -> OperationRoundResult:
-        area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '代理人列表')
-        support_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '协战编队槽')
-        support_team_property = self.ctx.screen_loader.get_area('迷失之地-矩阵行动', '协战代理人属性')
+        area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '代理人列表')
+        support_team_area = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '协战编队槽')
+        support_team_property = self.ctx.screen_loader.get_area('迷失之地-矩阵行动-编队选择', '协战代理人属性')
         ocr_result_list = self.ctx.ocr_service.get_ocr_result_list(
             image=self.last_screenshot,
             rect=area.rect,
@@ -464,7 +411,7 @@ class LostVoidApp(ZApplication):
         """在矩阵行动页面点击开始挑战。"""
         return self.round_by_find_and_click_area(
             self.last_screenshot,
-            '迷失之地-矩阵行动',
+            '迷失之地-矩阵行动-编队选择',
             '按钮-开始挑战',
             success_wait=1,
             retry_wait=1,
@@ -473,51 +420,11 @@ class LostVoidApp(ZApplication):
     # ========== 常规副本入口流程节点 ==========
 
     @node_from(from_name='识别悬赏委托完成进度', status=STATUS_AGAIN)
-    @operation_node(name='前往副本画面', node_max_retry_times=60)
+    @operation_node(name='前往副本画面')
     def goto_mission_screen(self) -> OperationRoundResult:
-        mission_name = self.config.mission_name
-        if mission_name in ['战线肃清', '特遣调查']:
-            return self.round_success('需OCR入口导航')
-        return self.round_by_goto_screen(screen_name=f'迷失之地-{mission_name}')
-
-    @node_from(from_name='前往副本画面', status='需OCR入口导航')
-    @operation_node(name='入口OCR-点击常规')
-    def click_regular_in_matrix_explore(self) -> OperationRoundResult:
-        """在入口页点击常规标签。"""
-        mission_area_name = f'按钮-{self.config.mission_name}'
-
-        # 已显示目标副本时，常规按钮可能不会显示，直接进入下一步
-        result = self.round_by_find_area(
-            self.last_screenshot,
-            '迷失之地-入口-常规',
-            mission_area_name,
-        )
-        if result.is_success:
-            return self.round_success('已显示目标副本入口')
-
-        result = self.round_by_find_and_click_area(
-            self.last_screenshot,
-            '迷失之地-入口',
-            '按钮-常规',
-            until_find_all=[('迷失之地-入口-常规', mission_area_name)],
-            success_wait=0.3,
-            retry_wait=0.1,
-        )
-        if result.is_success:
-            return self.round_success('已显示目标副本入口')
-        return result
-
-    @node_from(from_name='入口OCR-点击常规', status='已显示目标副本入口')
-    @operation_node(name='入口OCR-点击目标副本')
-    def click_target_mission_in_matrix_explore(self) -> OperationRoundResult:
-        """在入口页点击目标副本入口。"""
-        return self.round_by_goto_screen(
-            screen_name=f'迷失之地-{self.config.mission_name}',
-            retry_wait=0.5,
-        )
+        return self.round_by_goto_screen(screen_name=f'迷失之地-{self.config.mission_name}')
 
     @node_from(from_name='前往副本画面')
-    @node_from(from_name='入口OCR-点击目标副本')
     @operation_node(name='副本画面识别')
     def check_for_mission(self) -> OperationRoundResult:
         """


### PR DESCRIPTION
fixes: #2529 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化“迷失之地”入口：新增“入口-周期”“入口-常规”独立页面，并补齐“战线肃清”等入口流程。
  * 新增“矩阵行动-编队选择”页面，替代原“矩阵行动”入口跳转逻辑。
* **改进**
  * 调整页面返回与跳转目标，理顺入口→矩阵行动→副本流程衔接。
  * 提升入口要素识别：更新“悬赏委托”与入口区域的定位配置，并优化相关区域配置（含部分旧区域/屏幕移除）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->