### PR TITLE
chore: 调整vscode的debugpy配置顺序

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,20 +2,20 @@
     "version": "0.1.0",
     "configurations": [
         {
-            "name": "当前文件",
+            "name": "主程序",
             "type": "debugpy",
             "request": "launch",
-            "program": "${file}",
+            "program": ".\\src\\zzz_od\\gui\\app.py",
             "console": "integratedTerminal",
             "env": {
                 "PYTHONPATH": ".\\src"
             }
         },
         {
-            "name": "主程序",
+            "name": "当前文件",
             "type": "debugpy",
             "request": "launch",
-            "program": ".\\src\\zzz_od\\gui\\app.py",
+            "program": "${file}",
             "console": "integratedTerminal",
             "env": {
                 "PYTHONPATH": ".\\src"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **其他**
  * 调整调试配置中启动项的排列顺序，主程序配置现显示在当前文件配置之前。
  * 调试参数和运行行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->