### PR TITLE
fix: 更新双倍活动识别 3.0

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1824,9 +1824,9 @@
     id_mark: false
     pc_rect:
     - 1000
-    - 316
+    - 346
     - 1400
-    - 356
+    - 386
     text: 每日怪物卡双倍掉落次数
     lcs_percent: 0.5
     template_sub_dir: ''
@@ -1838,9 +1838,9 @@
     id_mark: false
     pc_rect:
     - 1270
-    - 316
+    - 346
     - 1380
-    - 356
+    - 386
     text: ''
     lcs_percent: 0.5
     template_sub_dir: ''

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1792,20 +1792,6 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
-  - area_name: 目标列表-作战
-    id_mark: false
-    pc_rect:
-    - 1254
-    - 552
-    - 1312
-    - 894
-    text: ''
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
   - area_name: 目标列表-训练-恶名狩猎
     id_mark: false
     pc_rect:
@@ -2373,20 +2359,6 @@
     goto_list:
     - 菜单
     - 大世界-普通
-  - area_name: 按钮-奖励
-    id_mark: false
-    pc_rect:
-    - 1334
-    - 214
-    - 1566
-    - 266
-    text: 奖励
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
 - screen_id: coupon
   screen_name: 家政券
   pc_alt: false

--- a/assets/game_data/screen_info/compendium.yml
+++ b/assets/game_data/screen_info/compendium.yml
@@ -156,20 +156,6 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
-- area_name: 目标列表-作战
-  id_mark: false
-  pc_rect:
-  - 1254
-  - 552
-  - 1312
-  - 894
-  text: ''
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
 - area_name: 目标列表-训练-恶名狩猎
   id_mark: false
   pc_rect:

--- a/assets/game_data/screen_info/compendium.yml
+++ b/assets/game_data/screen_info/compendium.yml
@@ -188,9 +188,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 1000
-  - 316
+  - 346
   - 1400
-  - 356
+  - 386
   text: 每日怪物卡双倍掉落次数
   lcs_percent: 0.5
   template_sub_dir: ''
@@ -202,9 +202,9 @@ area_list:
   id_mark: false
   pc_rect:
   - 1270
-  - 316
+  - 346
   - 1380
-  - 356
+  - 386
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/compendium_training.yml
+++ b/assets/game_data/screen_info/compendium_training.yml
@@ -99,17 +99,3 @@ area_list:
   goto_list:
   - 菜单
   - 大世界-普通
-- area_name: 按钮-奖励
-  id_mark: false
-  pc_rect:
-  - 1334
-  - 214
-  - 1566
-  - 266
-  text: 奖励
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []


### PR DESCRIPTION
OCR结果 [':每日怪物卡双倍掉落次数5/5'] 耗时 0.09
OCR结果 [[('数5/5', 0.9983081817626953)]] 耗时 0.01
指令[ 体力刷本 ] 节点 识别电量 -> 查看双倍活动 返回状态 成功

 close #2545 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能调整**
  * 更新图鉴页面的目标列表区域，支持显示“训练-恶名狩猎”。
  * 优化怪物卡双倍掉落次数相关区域的位置识别。
  * 移除训练页面中不再使用的“奖励”按钮区域。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->