### PR TITLE
fix: 避免未识别地图区域时默认左滑

### DIFF
--- a/src/zzz_od/operation/map_transport.py
+++ b/src/zzz_od/operation/map_transport.py
@@ -46,6 +46,9 @@ class MapTransport(ZOperation):
             elif current_idx > max_current_area_idx:
                 max_current_area_idx = current_idx
 
+        if max_current_area_idx < 0:
+            return self.round_retry('未识别到地图区域', wait=0.5)
+
         start_point = Point(self.ctx.controller.standard_width // 2, self.ctx.controller.standard_height // 2)
         if max_current_area_idx > target_area_idx:
             end_point = start_point + Point(500, 0)


### PR DESCRIPTION
该问题来源于几个月前的群聊，大家很积极测试，然后没有后续了

前因：地图区域选择的旧逻辑中，只要没有识别到任何区域，就会固定向左拖动

触发：体力刷本从“大世界-勘域”传送到普通大世界时，地图刚打开的首张截图尚未加载出区域信息，因此触发了固定左拖

后果：OCR 处理完成、执行拖动时地图已经显示，导致地图卡片额外向左滑动一次。后续后果因设备而异，有的设备根本没拖动

修复：未识别到地图区域时只等待重试，识别到区域后才判断滑动方向

日志表明（修复后）：
指令[ 体力刷本 ] 节点 检测游戏窗口 返回状态 成功
指令[ 体力刷本 ] 节点 检测游戏窗口 -> 开始体力计划 返回状态 成功
指令[ 返回大世界 ] 节点 检测游戏窗口 返回状态 成功
指令[ 返回大世界 ] 节点 检测游戏窗口 -> 画面识别 返回状态 传送到录像店
指令[ 返回大世界 ] 节点 画面识别 -> 打开地图 返回状态 地图
指令[ 地图传送 录像店 房间 ] 节点 检测游戏窗口 返回状态 成功
**指令[ 地图传送 录像店 房间 ] 节点 检测游戏窗口 -> 选择区域 返回状态 未识别到地图区域**
指令[ 地图传送 录像店 房间 ] 节点 检测游戏窗口 -> 选择区域 返回状态 成功
指令[ 地图传送 录像店 房间 ] 节点 选择区域 -> 选择传送点 返回状态 成功
指令[ 地图传送 录像店 房间 ] 节点 选择传送点 -> 点击传送 返回状态 确认
指令[ 地图传送 录像店 房间 ] 执行成功 返回状态 确认


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化地图区域识别失败时的处理流程。
  * 未识别到任何地图区域时，将直接提示并进行重试，避免执行无效的拖拽操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->