### PR TITLE
fix(hollow_zero): 更新事件清除侵蚀症状识别与ocrv6的兼容性

### DIFF
--- a/src/zzz_od/hollow_zero/event/remove_corruption.py
+++ b/src/zzz_od/hollow_zero/event/remove_corruption.py
@@ -22,4 +22,5 @@ class RemoveCorruption(ZOperation):
         area = self.ctx.screen_loader.get_area('零号空洞-事件', '底部-清除列表')
         return self.round_by_ocr_and_click(self.last_screenshot, '清除', area=area,
                                            color_range=[(240, 240, 240), (255, 255, 255)],
+                                           crop_first=False,
                                            success_wait=1, retry_wait=1)


### PR DESCRIPTION

close #2544 

ppocrv6 引入后，清除侵蚀症状流程使用 crop_first=True 先裁剪底部清除列表，再进行 OCR。该区域过窄时 ppocrv6 可能返回空结果（v6识别框大小要求高于v5），导致可用的清除按钮无法点击

关闭 crop_first，改为整张截图 OCR 后按区域筛选结果（不想把框按原位置加大一圈了），同时保留 RGB 240..255 的白色过滤，排除灰色禁用按钮。该调用不区分模型版本，兼容 ppocrv5 和 ppocrv6

修改前后均已用 issue #2544、#2498 附件分别验证 ppocrv5 和 ppocrv6，修改前只有v6识别不出来，修改后都能识别出来

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化清除腐化选项的识别与点击流程，提升相关操作的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->