### PR TITLE
fix: 修复后台模式误触再来一次

### DIFF
--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -157,6 +157,7 @@ class AutoBattleContext:
             # 清空之前检测到的状态
 
             with self._normal_attack_lock:
+                self._normal_attack_locked(release=True)
                 self._normal_attack_missing_since = None
                 self._normal_attack_blocked = True
 
@@ -209,6 +210,7 @@ class AutoBattleContext:
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
 
         with self._normal_attack_lock:
+            self._normal_attack_locked(release=True)
             self._normal_attack_missing_since = None
             self._normal_attack_blocked = True
 

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -74,6 +74,12 @@ class AutoBattleContext:
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
 
+        # 普攻输出保护（哪怕游戏内开启"日常战斗结束动画加速"，普攻消失后也有长达4s才出现"再来一次"）
+        self._normal_attack_block_delay: float = 3.5
+        self._normal_attack_missing_since: float | None = None
+        self._normal_attack_blocked: bool = True
+        self._normal_attack_lock: threading.Lock = threading.Lock()
+
         # 识别结果
         self.last_check_in_battle: bool = False  # 是否在战斗画面
         self.last_check_end_result: str | None = None  # 最后一次识别的结束结果
@@ -150,6 +156,10 @@ class AutoBattleContext:
         if self.auto_op is not None:
             # 清空之前检测到的状态
 
+            with self._normal_attack_lock:
+                self._normal_attack_missing_since = None
+                self._normal_attack_blocked = True
+
             self.auto_op.start_running_async()
             self.start_context_async()
             self.clear_all_states()
@@ -197,6 +207,10 @@ class AutoBattleContext:
         self._last_check_end_time: float = 0
         self._last_check_distance_time: float = 0
         self._last_chain_front_correction_time: float = 0  # 上一次连携前台角色修正的时间
+
+        with self._normal_attack_lock:
+            self._normal_attack_missing_since = None
+            self._normal_attack_blocked = True
 
         # 识别结果
         self.last_check_end_result: str | None = None  # 识别战斗结束的结果
@@ -315,7 +329,15 @@ class AutoBattleContext:
         self.state_record_service.update_state(StateRecord(e, finish_time))
         self._emit_overlay_action(e)
 
-    def normal_attack(self, press: bool = False, press_time: float | None = None, release: bool = False):
+    def normal_attack(self, press: bool = False, press_time: float | None = None, release: bool = False) -> None:
+        with self._normal_attack_lock:
+            self._normal_attack_locked(press=press, press_time=press_time, release=release)
+
+    def _normal_attack_locked(self, press: bool = False, press_time: float | None = None, release: bool = False) -> None:
+        """在持有普攻锁时执行普攻输入。"""
+        if self._normal_attack_blocked and not release:
+            return
+
         if press:
             e = BattleStateEnum.BTN_SWITCH_NORMAL_ATTACK.value + '-按下'
         elif release:
@@ -550,6 +572,7 @@ class AutoBattleContext:
         :return: 当前是否在战斗画面
         """
         in_battle = self.is_normal_attack_btn_available(screen)
+        self._update_normal_attack_block(in_battle, screenshot_time)
         self.last_check_in_battle = in_battle
 
         future_list: list[Future] = []
@@ -606,6 +629,25 @@ class AutoBattleContext:
                 future.result()
 
         return in_battle
+
+    def _update_normal_attack_block(self, in_battle: bool, screenshot_time: float) -> None:
+        """
+        根据普攻按钮识别结果保护普攻输出，避免战斗结束后残留按键误触结算页。
+        """
+        with self._normal_attack_lock:
+            if in_battle:
+                should_log_resume = self._normal_attack_blocked and self._normal_attack_missing_since is not None
+                self._normal_attack_missing_since = None
+                self._normal_attack_blocked = False
+                if should_log_resume:
+                    log.info('重新识别到普攻按钮，恢复普攻输出')
+            elif not self._normal_attack_blocked:
+                if self._normal_attack_missing_since is None:
+                    self._normal_attack_missing_since = screenshot_time
+                elif screenshot_time - self._normal_attack_missing_since >= self._normal_attack_block_delay:
+                    self._normal_attack_blocked = True
+                    self._normal_attack_locked(release=True)
+                    log.info(f'连续 {self._normal_attack_block_delay:g} 秒未识别到普攻按钮，停止普攻输出')
 
     def check_chain_attack(self, screen: MatLike, screenshot_time: float) -> None:
         """


### PR DESCRIPTION
* [x] 测试/已拉取到本地自用

close #2157 
relate #2372 

## 问题和修复

- 后台手柄模式刷本时，战斗结束进入结算页面后，自动战斗可能仍在继续发送普通攻击键。由于 Xbox 手柄的普通攻击和结算页面的“再来一次”都使用 X 键，残留的普攻输入可能直接触发“再来一次”，导致副本被重复挑战，影响体力计划正常结束或进入下一项计划
  - 增加普攻输出保护：连续 3.5 秒未识别到普通攻击按钮后，阻断后续普攻输出
  - 主动释放可能仍处于按下状态的普攻键
  - 重新识别到普通攻击按钮后恢复普攻输出
  - 在战斗初始化和重新开始自动战斗时重置保护状态

## 日志（修复后）
复合中断条件满足，执行中断
当前场景 主循环 当前条件 [自定义-黄光切人, 0, 1] ← [前台-橘福福] ← 
当前场景 主循环 当前条件 ← [前台-橘福福] ← 
OCR结果 [] 耗时 0.03
OCR结果 [] 耗时 0.04
**连续 3.5 秒未识别到普攻按钮，停止普攻输出**
OCR结果 [] 耗时 0.03
OCR结果 [] 耗时 0.03
OCR结果 ['完成'] 耗时 0.04
松开所有按键
指令[ 区域巡防 机师与叛甲 ] 节点 自动战斗 -> 战斗结束 返回状态 成功
指令[ 战斗后选择 ] 节点 检测游戏窗口 返回状态 成功
OCR结果 ['再来一次'] 耗时 0.04
指令[ 战斗后选择 ] 节点 检测游戏窗口 -> 判断再来一次 返回状态 战斗结果-再来一次
OCR结果 ['恢复电量'] 耗时 0.04
OCR结果 ['电量恢复02分22秒全部恢复20时32分', '取消', 'V', '确认'] 耗时 0.12
指令[ 战斗后选择 ] 节点 判断再来一次 -> 恢复电量 返回状态 战斗结果-完成
OCR结果 ['完成'] 耗时 0.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新内容

* **问题修复**
  * 增强自动战斗“普攻输出保护”：当普攻按钮在短时间内无法识别时，自动阻止误触，避免重复普攻结算。

* **功能改进**
  * 战斗状态刷新后自动维护保护：按钮恢复可用会解除阻止；非战斗超时达到阈值后进入阻止，并触发一次释放补偿以保持输出连续性。

* **维护**
  * 切换战斗时同步重置保护计时与开关状态，防止跨战斗残留影响表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->