### PR TITLE
fix(lost_void): 按层保留脱困状态

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py
@@ -1,4 +1,5 @@
 import time
+from dataclasses import dataclass
 from typing import ClassVar
 
 from cv2.typing import MatLike
@@ -20,6 +21,12 @@ from zzz_od.application.hollow_zero.lost_void.lost_void_challenge_config import 
 from zzz_od.auto_battle import auto_battle_utils
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.operation.zzz_operation import ZOperation
+
+
+@dataclass
+class LostVoidStuckState:
+    stuck_times: int = 0
+    prefer_left_escape: bool = True
 
 
 class MoveTargetWrapper:
@@ -108,6 +115,7 @@ class LostVoidMoveByDet(ZOperation):
         stop_when_disappear: bool = True,
         ignore_entry_list: list[str] | None = None,
         allow_arrival_by_interact_btn: bool = False,
+        stuck_state: LostVoidStuckState | None = None,
     ):
         """
         朝识别目标移动 最终返回目标图标 data=LostVoidRegionType.label
@@ -118,6 +126,7 @@ class LostVoidMoveByDet(ZOperation):
         @param stop_when_disappear:
         @param ignore_entry_list:
         @param allow_arrival_by_interact_btn: 是否允许仅凭交互按钮出现就判定到位
+        @param stuck_state: 当前楼层共享的脱困状态
         """
         ZOperation.__init__(
             self,
@@ -132,6 +141,9 @@ class LostVoidMoveByDet(ZOperation):
         self.stop_when_disappear: bool = stop_when_disappear  # 目标消失时停止移动
         self.ignore_entry_list: list[str] | None = ignore_entry_list
         self.allow_arrival_by_interact_btn: bool = allow_arrival_by_interact_btn
+        self.stuck_state: LostVoidStuckState = (
+            stuck_state if stuck_state is not None else LostVoidStuckState()
+        )
 
         # 需要按方向选的时候 按最大x值选
         # 入口时 从右往左选可以上楼梯
@@ -143,7 +155,6 @@ class LostVoidMoveByDet(ZOperation):
         self.last_visible_target_list: list[MoveTargetWrapper] = []  # 上一次识别到的全部可见目标
         self.last_target_name: str | None = None  # 最后识别到的交互目标名称
         self.same_target_times: float = 0  # 识别到相同目标的次数
-        self.stuck_times: int = 0  # 被困次数
         self.total_turn_times: int = 0  # 总共转向次数
 
         self.last_save_debug_image_time: float = 0  # 上一次保存debug图片的时间
@@ -151,7 +162,6 @@ class LostVoidMoveByDet(ZOperation):
         self.lost_target_during_move_times: int = 0  # 移动过程中丢失目标次数
         self.target_lost_start_time: float = 0  # 本轮移动中开始丢失目标的时间
         self.no_target_handle_times: int = 0  # 连续进入无目标处理的次数
-        self.prefer_left_escape: bool = True  # 脱困时优先向左移动
 
         # 转向校准
         self.last_target_x: float | None = None  # 上一次识别到的目标x轴坐标
@@ -244,7 +254,7 @@ class LostVoidMoveByDet(ZOperation):
                 self.lost_target_during_move_times += 1
                 # https://github.com/OneDragon-Anything/ZenlessZoneZero-OneDragon/issues/867
                 if self.lost_target_during_move_times % 5 == 0:  # 尝试脱困
-                    self.stuck_times += 1
+                    self.stuck_state.stuck_times += 1
                     self.get_out_of_stuck()
             self.last_target_result = None
             return self.round_success(LostVoidMoveByDet.STATUS_NO_FOUND)
@@ -303,7 +313,7 @@ class LostVoidMoveByDet(ZOperation):
             # 移动过程中多次丢失目标 通常是因为识别不准
             # 游戏1.6版本出现了可以因为丢失目标转动镜头而一直无法进入脱困 issues #867
             if self.lost_target_during_move_times % 10 == 0:  # 尝试脱困
-                self.stuck_times += 1
+                self.stuck_state.stuck_times += 1
                 self.get_out_of_stuck()
 
             return self.round_success(LostVoidMoveByDet.STATUS_NO_FOUND)
@@ -586,9 +596,9 @@ class LostVoidMoveByDet(ZOperation):
 
         if self.same_target_times >= stuck_threshold:
             self.ctx.controller.stop_moving_forward()
-            self.stuck_times += 1
+            self.stuck_state.stuck_times += 1
             self._reset_stuck_status()
-            if self.stuck_times > 12:
+            if self.stuck_state.stuck_times > 12:
                 return self.round_fail('无法脱困')
             else:
                 return self.round_success('尝试脱困')
@@ -610,17 +620,17 @@ class LostVoidMoveByDet(ZOperation):
             self.ctx.controller.normal_attack(press=True, press_time=0.2, release=True)
             time.sleep(1)
 
-        escape_phase = (self.stuck_times - 1) % 8
+        escape_phase = (self.stuck_state.stuck_times - 1) % 8
         backward_press_time = min(escape_phase * 0.5, 2)
         side_press_time = min((escape_phase + 1) * 0.2, 2)
         forward_press_time = min(escape_phase * 0.2, 2)
 
         self.ctx.controller.move_s(press=True, press_time=backward_press_time, release=True)
-        if self.prefer_left_escape:
+        if self.stuck_state.prefer_left_escape:
             self.ctx.controller.move_a(press=True, press_time=side_press_time, release=True)
         else:
             self.ctx.controller.move_d(press=True, press_time=side_press_time, release=True)
-        self.prefer_left_escape = not self.prefer_left_escape
+        self.stuck_state.prefer_left_escape = not self.stuck_state.prefer_left_escape
 
         if forward_press_time > 0:
             self.ctx.controller.move_w(press=True, press_time=forward_press_time, release=True)
@@ -716,7 +726,7 @@ class LostVoidMoveByDet(ZOperation):
 
         if self.no_target_handle_times >= 7:
             self.no_target_handle_times = 0
-            self.stuck_times += 1
+            self.stuck_state.stuck_times += 1
             return self.round_success('尝试脱困')
 
         # 保存截图用于优化

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -47,6 +47,7 @@ from zzz_od.application.hollow_zero.lost_void.operation.interact.lost_void_route
 )
 from zzz_od.application.hollow_zero.lost_void.operation.lost_void_move_by_det import (
     LostVoidMoveByDet,
+    LostVoidStuckState,
 )
 from zzz_od.application.hollow_zero.lost_void.operation.update_priority_operation import (
     UpdatePriorityOperation,
@@ -132,6 +133,7 @@ class LostVoidRunLevel(ZOperation):
         self.room_inited_times: int = 0  # 挚交会谈需要初始化两次
         self.had_been_list: list[str] = []  # 已经访问过的类型 1.5更新后 交互后交互类型的图标不会消失 需要自己过滤
         self.interacted_target_key_list: list[str] = []  # 本层已经交互过的具体对象
+        self.stuck_state: LostVoidStuckState = LostVoidStuckState()  # 本层共享的脱困状态
 
     @node_from(from_name='非战斗画面识别', status='未在大世界')  # 有小概率交互入口后 没处理好结束本次RunLevel 重新从等待加载 开始
     @node_from(from_name='非战斗画面识别', status='按钮-挑战-确认')  # 挑战类型的对话框确认后 第一次点击可能无效 跳回来这里点击到最后生效为止
@@ -298,7 +300,8 @@ class LostVoidRunLevel(ZOperation):
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_INTERACT,
                                    stop_when_disappear=False,
-                                   allow_arrival_by_interact_btn=self.boss_pre_battle)
+                                   allow_arrival_by_interact_btn=self.boss_pre_battle,
+                                   stuck_state=self.stuck_state)
             op_result = op.execute()
             if op_result.success:
                 if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
@@ -326,7 +329,8 @@ class LostVoidRunLevel(ZOperation):
         if with_distance and not self.boss_pre_battle:
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_DISTANCE,
-                                   stop_when_interact=False)
+                                   stop_when_interact=False,
+                                   stuck_state=self.stuck_state)
             op_result = op.execute()
             if op_result.success:
                 if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:
@@ -351,7 +355,8 @@ class LostVoidRunLevel(ZOperation):
         if with_entry and not self.boss_pre_battle:
             self.nothing_times = 0
             op = LostVoidMoveByDet(self.ctx, self.region_type, LostVoidDetector.CLASS_ENTRY,
-                                   stop_when_disappear=False, ignore_entry_list=self.had_been_list)
+                                   stop_when_disappear=False, ignore_entry_list=self.had_been_list,
+                                   stuck_state=self.stuck_state)
             op_result = op.execute()
             if op_result.success:
                 if op_result.status == LostVoidMoveByDet.STATUS_IN_BATTLE:


### PR DESCRIPTION
## 背景
`LostVoidMoveByDet` 在脱困后返回 `需要重新识别`，同一层内会被 `LostVoidRunLevel` 重新创建，导致脱困计数和策略从头开始。

## 变更
- 新增按层共享的 `LostVoidStuckState`。
- 由 `LostVoidRunLevel` 持有脱困状态，并传递给同层的感叹号、白点和下层入口移动操作。
- 同层重复创建 `LostVoidMoveByDet` 时保留 `stuck_times` 和 `prefer_left_escape`。
- 进入下一层重新创建 `LostVoidRunLevel` 时重置脱困状态。

## 验证
- `uv run ruff check src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_move_by_det.py src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py`
- `python -m py_compile` 通过
- `git diff --check` 通过
- 未进行真实游戏窗口运行验证


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化非战斗场景中的移动脱困机制。
  - 多种移动路径共享脱困次数与方向偏好，使连续移动时的脱困策略更加稳定。
  - 改善目标丢失或无法移动时的自动脱困表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->