### PR TITLE
fix(notorious_hunt): 修复跳过特训目标之后后续计划可能失败

### DIFF
--- a/src/zzz_od/application/notorious_hunt/notorious_hunt_app.py
+++ b/src/zzz_od/application/notorious_hunt/notorious_hunt_app.py
@@ -85,6 +85,12 @@ class NotoriousHuntApp(ZApplication):
         return self.round_success()
 
     @node_from(from_name='查找下一条计划')
+    @operation_node(name='前往大世界')  # 特训目标查找失败可能把快捷手册列表滑到底部，返回大世界后重置列表位置
+    def back_before_open_compendium(self) -> OperationRoundResult:
+        op = BackToNormalWorld(self.ctx, ensure_normal_world=True)
+        return self.round_by_op_result(op.execute())
+
+    @node_from(from_name='前往大世界')
     @operation_node(name='传送')
     def transport(self) -> OperationRoundResult:
         op = TransportByCompendium(self.ctx,


### PR DESCRIPTION

<img width="1710" height="1140" alt="image" src="https://github.com/user-attachments/assets/421d2bde-51a9-4fe0-8545-0e73c3990460" />


恶名狩猎应用会直接复用当前快捷手册页面进行下一条计划的传送。
如果上一条计划为特训目标且未找到代理人头像，查找过程可能将副本列表滑到底部；
快捷手册会保留该滚动位置，导致下一条计划无法找到位于列表上方的目标副本，
最终耗尽重试次数并执行失败。

在传送节点前增加“前往大世界”节点，使用
BackToNormalWorld(ensure_normal_world=True) 确保每条计划都从普通大世界重新进入快捷手册，
通过游戏自身的页面初始化逻辑重置副本列表位置。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 在打开图鉴前新增返回大世界步骤，确保相关操作在正常世界场景中执行。
  * 优化“前往大世界”流程的结果处理，提升流程衔接稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->