### PR TITLE
fix: 更新迷失之地战斗失败画面

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -4998,9 +4998,9 @@
   - area_name: 按钮-撤退
     id_mark: true
     pc_rect:
-    - 530
+    - 700
     - 850
-    - 746
+    - 930
     - 912
     text: 撤退
     lcs_percent: 0.5
@@ -5012,25 +5012,11 @@
   - area_name: 按钮-重播
     id_mark: true
     pc_rect:
-    - 878
+    - 1050
     - 850
-    - 1086
+    - 1270
     - 912
     text: 重播
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 按钮-分析
-    id_mark: true
-    pc_rect:
-    - 1226
-    - 848
-    - 1428
-    - 916
-    text: 分析
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''

--- a/assets/game_data/screen_info/lost_void_battle_fail.yml
+++ b/assets/game_data/screen_info/lost_void_battle_fail.yml
@@ -6,9 +6,9 @@ area_list:
 - area_name: 按钮-撤退
   id_mark: true
   pc_rect:
-  - 530
+  - 700
   - 850
-  - 746
+  - 930
   - 912
   text: 撤退
   lcs_percent: 0.5
@@ -20,25 +20,11 @@ area_list:
 - area_name: 按钮-重播
   id_mark: true
   pc_rect:
-  - 878
+  - 1050
   - 850
-  - 1086
+  - 1270
   - 912
   text: 重播
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list: []
-- area_name: 按钮-分析
-  id_mark: true
-  pc_rect:
-  - 1226
-  - 848
-  - 1428
-  - 916
-  text: 分析
   lcs_percent: 0.5
   template_sub_dir: ''
   template_id: ''


### PR DESCRIPTION
close #2249 

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/519f28a8-4dee-4efa-8d68-8f9648e6af98" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 调整“迷失之地-战斗失败”界面中“撤退”和“重播”按钮的点击区域，使操作识别更准确。
  * 移除已不再显示的“分析”按钮区域定义。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->