### PR TITLE
fix: 修复在勘域运行驱动盘拆解后续卡住

### DIFF
--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1620,28 +1620,14 @@
   screen_name: 画面-通用
   pc_alt: false
   area_list:
-  - area_name: 左上角-街区
+  - area_name: 左上角-区域
     id_mark: false
     pc_rect:
     - 234
     - 26
     - 394
     - 78
-    text: 街区
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list: []
-  - area_name: 左上角-勘域
-    id_mark: false
-    pc_rect:
-    - 234
-    - 26
-    - 394
-    - 78
-    text: 勘域
+    text: 区域
     lcs_percent: 0.5
     template_sub_dir: ''
     template_id: ''

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -8861,21 +8861,6 @@
     color_range: null
     goto_list:
     - 仓库-驱动仓库-驱动盘拆解
-  - area_name: 左上角-街区
-    id_mark: false
-    pc_rect:
-    - 236
-    - 28
-    - 384
-    - 78
-    text: 街区
-    lcs_percent: 0.5
-    template_sub_dir: ''
-    template_id: ''
-    template_match_threshold: 0.7
-    color_range: null
-    goto_list:
-    - 大世界-普通
 - screen_id: storage_wengine
   screen_name: 仓库-音擎仓库
   app_id: drive_disc_dismantle

--- a/assets/game_data/screen_info/_od_merged.yml
+++ b/assets/game_data/screen_info/_od_merged.yml
@@ -1634,6 +1634,20 @@
     template_match_threshold: 0.7
     color_range: null
     goto_list: []
+  - area_name: 左上角-勘域
+    id_mark: false
+    pc_rect:
+    - 234
+    - 26
+    - 394
+    - 78
+    text: 勘域
+    lcs_percent: 0.5
+    template_sub_dir: ''
+    template_id: ''
+    template_match_threshold: 0.7
+    color_range: null
+    goto_list: []
   - area_name: 返回
     id_mark: false
     pc_rect:

--- a/assets/game_data/screen_info/common_screen.yml
+++ b/assets/game_data/screen_info/common_screen.yml
@@ -2,24 +2,13 @@ screen_id: common_screen
 screen_name: 画面-通用
 pc_alt: false
 area_list:
-- area_name: 左上角-街区
+- area_name: 左上角-区域
   pc_rect:
   - 234
   - 26
   - 394
   - 78
-  text: 街区
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-- area_name: 左上角-勘域
-  pc_rect:
-  - 234
-  - 26
-  - 394
-  - 78
-  text: 勘域
+  text: 区域
   lcs_percent: 0.5
   template_sub_dir: ''
   template_id: ''

--- a/assets/game_data/screen_info/common_screen.yml
+++ b/assets/game_data/screen_info/common_screen.yml
@@ -13,6 +13,17 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+- area_name: 左上角-勘域
+  pc_rect:
+  - 234
+  - 26
+  - 394
+  - 78
+  text: 勘域
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
 - area_name: 返回
   id_mark: false
   pc_rect:

--- a/assets/game_data/screen_info/storage_drive_disc.yml
+++ b/assets/game_data/screen_info/storage_drive_disc.yml
@@ -32,18 +32,3 @@ area_list:
   color_range: null
   goto_list:
   - 仓库-驱动仓库-驱动盘拆解
-- area_name: 左上角-街区
-  id_mark: false
-  pc_rect:
-  - 236
-  - 28
-  - 384
-  - 78
-  text: 街区
-  lcs_percent: 0.5
-  template_sub_dir: ''
-  template_id: ''
-  template_match_threshold: 0.7
-  color_range: null
-  goto_list:
-  - 大世界-普通

--- a/src/zzz_od/application/drive_disc_dismantle/drive_disc_dismantle_app.py
+++ b/src/zzz_od/application/drive_disc_dismantle/drive_disc_dismantle_app.py
@@ -1,7 +1,7 @@
 from one_dragon.base.operation.application import application_const
 from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
-from one_dragon.base.operation.operation_notify import node_notify, NotifyTiming
+from one_dragon.base.operation.operation_notify import NotifyTiming, node_notify
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from zzz_od.application.drive_disc_dismantle import drive_disc_dismantle_const
 from zzz_od.application.drive_disc_dismantle.drive_disc_dismantle_config import (
@@ -37,7 +37,7 @@ class DriveDiscDismantleApp(ZApplication):
 
     @operation_node(name='开始前返回', is_start_node=True)
     def back_at_first(self) -> OperationRoundResult:
-        op = BackToNormalWorld(self.ctx)
+        op = BackToNormalWorld(self.ctx, ensure_normal_world=True)  # 仓库-驱动仓库左上角若不是"街区"而是"勘域”则画面不连通
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='开始前返回')
@@ -99,7 +99,7 @@ class DriveDiscDismantleApp(ZApplication):
 
 def __debug():
     ctx = ZContext()
-    ctx.init_by_config()
+    ctx.init()
     app = DriveDiscDismantleApp(ctx)
     app.execute()
 

--- a/src/zzz_od/application/drive_disc_dismantle/drive_disc_dismantle_app.py
+++ b/src/zzz_od/application/drive_disc_dismantle/drive_disc_dismantle_app.py
@@ -37,7 +37,7 @@ class DriveDiscDismantleApp(ZApplication):
 
     @operation_node(name='开始前返回', is_start_node=True)
     def back_at_first(self) -> OperationRoundResult:
-        op = BackToNormalWorld(self.ctx, ensure_normal_world=True)  # 仓库-驱动仓库左上角若不是"街区"而是"勘域”则画面不连通
+        op = BackToNormalWorld(self.ctx)
         return self.round_by_op_result(op.execute())
 
     @node_from(from_name='开始前返回')

--- a/src/zzz_od/operation/back_to_normal_world.py
+++ b/src/zzz_od/operation/back_to_normal_world.py
@@ -68,10 +68,11 @@ class BackToNormalWorld(ZOperation):
         if mini_map.play_mask_found:
             return self.round_success(status='发现地图')
 
-        # 大部分画面都有街区可以直接返回
-        result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', '左上角-街区')
-        if result.is_success:
-            return self.round_retry(result.status, wait=1)
+        # 大部分画面都有街区或勘域可以直接返回
+        for area_name in ['左上角-街区', '左上角-勘域']:
+            result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', area_name)
+            if result.is_success:
+                return self.round_retry(result.status, wait=1)
 
 
         # 战斗菜单-退出战斗（完全通用，包括但不限于危局强袭战！）
@@ -91,7 +92,7 @@ class BackToNormalWorld(ZOperation):
             return self.round_success('脱离卡死', wait=1)
 
         # 通用返回按钮（识别点击型）
-        # 需要在"完成"前面，某些插件场景可能会识别到'返回'和"完成"同时存在
+        # 需要在"完成"前面，否则在丽都城募app（若购买了大月卡）会误点击“已完成购买” issue #2005
         result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', '返回')
         if result.is_success:
             return self.round_retry(result.status, wait=1)
@@ -102,8 +103,6 @@ class BackToNormalWorld(ZOperation):
             return self.round_retry(result.status, wait=1)
 
         # 通用完成按钮
-        # 某些插件场景"合成"可能会被误匹配为"完成"
-        # 需要在'返回'后面，购买大月卡后返回大世界一直点击“已完成购买” issue #2005
         result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', '完成')
         if result.is_success:
             return self.round_retry(result.status, wait=1)

--- a/src/zzz_od/operation/back_to_normal_world.py
+++ b/src/zzz_od/operation/back_to_normal_world.py
@@ -68,11 +68,10 @@ class BackToNormalWorld(ZOperation):
         if mini_map.play_mask_found:
             return self.round_success(status='发现地图')
 
-        # 大部分画面都有街区或勘域可以直接返回
-        for area_name in ['左上角-街区', '左上角-勘域']:
-            result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', area_name)
-            if result.is_success:
-                return self.round_retry(result.status, wait=1)
+        # 大部分画面都有街区或勘域可以直接返回，“区域”通过 0.5 LCS 匹配“街区”的“区”或“勘域”的“域”
+        result = self.round_by_find_and_click_area(self.last_screenshot, '画面-通用', '左上角-区域')
+        if result.is_success:
+            return self.round_retry(result.status, wait=1)
 
 
         # 战斗菜单-退出战斗（完全通用，包括但不限于危局强袭战！）

--- a/src/zzz_od/operation/compendium/combat_simulation.py
+++ b/src/zzz_od/operation/compendium/combat_simulation.py
@@ -317,7 +317,7 @@ class CombatSimulation(ZOperation):
     @operation_node(name='战斗超时')
     def battle_timeout(self) -> OperationRoundResult:
         self.ctx.auto_battle_context.stop_auto_battle()
-        op = ExitInBattle(self.ctx, '画面-通用', '左上角-街区')
+        op = ExitInBattle(self.ctx, '画面-通用', '左上角-区域')
         result = self.round_by_op_result(op.execute())
         if result.is_success:
             return self.round_fail(status=CombatSimulation.STATUS_FIGHT_TIMEOUT)


### PR DESCRIPTION


继 #2520 为新用户预设了一个默认的app排序后，我主动将我的一条龙app排序改成了预设的那个样子，随后驱动盘拆解竟出现了问题

查看日志：
<img width="1257" height="425" alt="25f7f430ebf164030e137ce4cd1ab921" src="https://github.com/user-attachments/assets/b4d221a4-8c4f-4d1f-8cab-347a9941597f" />

问题分析：
运行完锄大地后当前画面被带到了大世界-勘域，随后运行了驱动盘拆解，进行到最后阶段时因为仓库-驱动仓库左上角不是"街区"而是"勘域”，所以导致 storage_drive_disc.yml 的画面不连通进而导致无限卡住（，最后程序被千机链kill了）

<img width="744" height="232" alt="image" src="https://github.com/user-attachments/assets/5196734d-f5da-44c5-bc28-cf8f6f5f9a93" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/964e0582-f8f1-4f0e-a759-d724060eeeb9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化调试场景上下文初始化方式，提升相关流程稳定性。
  * 更新“大世界”兜底返回识别：将“左上角-街区”替换为“左上角-区域”，并相应修正超时/返回路径的区域判断。
* **Configuration Updates**
  * 调整屏幕区域配置：在公共屏幕新增“左上角-区域”，并在存储驱动相关屏幕移除“左上角-街区”，同时修正屏幕区域衔接逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->