### PR TITLE
fix: 修复录像店营业页面未加载完成时误点击

### DIFF
--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -96,7 +96,6 @@ class RandomPlayApp(ZApplication):
         return self.round_success()
 
     @node_from(from_name='移动交互')
-    @node_from(from_name='识别营业状态', success=False)
     @operation_node(name='等待经营画面加载', node_max_retry_times=10)
     def wait_run(self) -> OperationRoundResult:
         # 每日首次。点完关闭按钮后回到本节点重判，防止昨日账本残影或未关闭

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -128,6 +128,7 @@ class RandomPlayApp(ZApplication):
         return self.round_retry(status='等待营业状态', wait=1)
 
     @node_from(from_name='识别营业状态', status=STATUS_ALREADY_RUNNING)
+    @node_from(from_name='点击宣传员入口', success=False)
     @operation_node(name='关闭经营页面')
     def close_business_page(self) -> OperationRoundResult:
         return self.round_by_find_and_click_area(self.last_screenshot, '影像店营业', '返回',

--- a/src/zzz_od/application/random_play/random_play_app.py
+++ b/src/zzz_od/application/random_play/random_play_app.py
@@ -96,6 +96,7 @@ class RandomPlayApp(ZApplication):
         return self.round_success()
 
     @node_from(from_name='移动交互')
+    @node_from(from_name='识别营业状态', success=False)
     @operation_node(name='等待经营画面加载', node_max_retry_times=10)
     def wait_run(self) -> OperationRoundResult:
         # 每日首次。点完关闭按钮后回到本节点重判，防止昨日账本残影或未关闭
@@ -106,7 +107,7 @@ class RandomPlayApp(ZApplication):
         # 识别到"经营状况"就点击一下以保证在该分支。二次运行时，有极低概率"无人咨询"变成"咨询中"并被默认跳转
         result = self.round_by_find_and_click_area(self.last_screenshot, '影像店营业', '经营状况')
         if result.is_success:
-            return self.round_success()
+            return self.round_success(wait=1)
         # 澄辉坪-录像店营业点交互后的专属对话框。前面都没识别到说明被对话框挡住了，点击 "查看经营状况" 推进
         area = self.ctx.screen_loader.get_area('影像店营业', '右侧选项区域')
         result = self.round_by_ocr_and_click(self.last_screenshot, '查看经营状况', area=area)
@@ -121,8 +122,11 @@ class RandomPlayApp(ZApplication):
         result = self.round_by_find_area(self.last_screenshot, '影像店营业', '正在营业')
         if result.is_success:
             return self.round_success(RandomPlayApp.STATUS_ALREADY_RUNNING)
-        else:
+        result = self.round_by_find_area(self.last_screenshot, '影像店营业', '开始营业')
+        if result.is_success:
             return self.round_success()
+
+        return self.round_retry(status='等待营业状态', wait=1)
 
     @node_from(from_name='识别营业状态', status=STATUS_ALREADY_RUNNING)
     @operation_node(name='关闭经营页面')


### PR DESCRIPTION

close #2420 

识别到“正在营业”时结束流程，识别到“开始营业”时继续选择宣传员（则两个模板lcs分别为0.75）
未识别到明确状态时等待重试，重试失败后回退到经营页面加载节点


<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/cef63cf3-a64d-41a6-91b1-e1a2fb15f56f" />

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/78e16403-353b-4d31-b0f8-c13b6e409a26" />

首次运行：
OCR结果 ['经营状况'] 耗时 0.04
指令[ 录像店营业 ] 节点 移动交互 -> 等待经营画面加载 返回状态 成功
OCR结果 ['开始营业'] 耗时 0.03
指令[ 录像店营业 ] 节点 等待经营画面加载 -> 识别营业状态 返回状态 成功
指令[ 录像店营业 ] 节点 识别营业状态 -> 点击宣传员入口 返回状态 宣传员入口
...

二次运行：
OCR结果 ['经营状况'] 耗时 0.05
指令[ 录像店营业 ] 节点 移动交互 -> 等待经营画面加载 返回状态 成功
OCR结果 ['正在营业'] 耗时 0.04
指令[ 录像店营业 ] 节点 等待经营画面加载 -> 识别营业状态 返回状态 正在营业
指令[ 录像店营业 ] 节点 识别营业状态 -> 关闭经营页面 返回状态 返回
指令[ 返回大世界 ] 节点 检测游戏窗口 返回状态 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 功能改进
- 优化随机经营流程中“经营状况/正在营业/开始营业”的衔接逻辑，减少因识别不全导致的卡顿。
- 点击“经营状况”成功后，改为带等待标记继续后续处理，提高稳定性。
- 未命中“正在营业”时会改为继续尝试“开始营业”；两者都未识别到则进入带状态的等待重试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->