### PR TITLE
ci: pr按照tag自动squash到test分支

### DIFF
--- a/.github/workflows/update-test-branch.yml
+++ b/.github/workflows/update-test-branch.yml
@@ -90,6 +90,10 @@ jobs:
         conflicted=()
         skipped=()
 
+        normalize_line() {
+          printf '%s' "$1" | tr '\r\n' '  '
+        }
+
         for pr in $PRS; do
           # PR 号写错 / 已删除时 gh 会非 0 退出,兜住它,让这个 PR 跳过而不是中断整个 job
           state="$(gh pr view "$pr" --json state --jq .state 2>/dev/null || true)"
@@ -99,6 +103,7 @@ jobs:
           fi
 
           title="$(gh pr view "$pr" --json title --jq .title)"
+          title="$(normalize_line "$title")"
 
           if ! git fetch origin "refs/pull/$pr/head:refs/remotes/pr/$pr" --force; then
             skipped+=("$pr|拉取 PR 分支失败")
@@ -122,15 +127,18 @@ jobs:
           # 保留原作者(committer 仍是 bot,因为 squash 动作是 CI 做的)
           # 单作者 PR 直接用其提交里的真实署名;多作者 PR 归给 PR 发起人,其余进 Co-authored-by
           # --reverse:按提交先后排,兜底时取到的是 PR 第一个提交的作者
-          mapfile -t authors < <(git log --reverse --format='%aN <%aE>' "origin/main..refs/remotes/pr/$pr" | awk 'NF && !seen[$0]++')
+          mapfile -t authors < <(git log --reverse --format='%aN <%aE>' "origin/main..refs/remotes/pr/$pr" | while IFS= read -r a; do normalize_line "$a"; printf '\n'; done | awk 'NF && !seen[$0]++')
           if [ "${#authors[@]}" -eq 1 ]; then
             author="${authors[0]}"
           else
             login="$(gh pr view "$pr" --json author --jq .author.login)"
+            login="$(normalize_line "$login")"
             # GitHub 自己 squash 时用的就是 <id>+<login>@users.noreply.github.com,能正确计入贡献
             user_info="$(gh api "users/$login" --jq '[.id, (.name // .login)] | @tsv' 2>/dev/null || true)"
             uid="$(printf '%s' "$user_info" | cut -f1)"
             uname="$(printf '%s' "$user_info" | cut -f2)"
+            uid="$(normalize_line "$uid")"
+            uname="$(normalize_line "$uname")"
             if [ -n "$uid" ]; then
               author="$uname <$uid+$login@users.noreply.github.com>"
             else

--- a/.github/workflows/update-test-branch.yml
+++ b/.github/workflows/update-test-branch.yml
@@ -1,13 +1,35 @@
+# 重建 test 分支 = 最新 main + 若干 PR 的 squash 提交(强制推送)
+#
+# PR 来源(二选一):
+#   1. 定时 / 不填参数:所有带 `test-branch` 标签的 open PR,按 PR 号升序
+#   2. 手动触发填 prs:按填写顺序,临时覆盖标签(不改动标签本身)
+#
+# 有冲突的 PR 直接跳过(打上 `test-conflict` 标签),不影响后续 PR;
+# 每次都从 origin/main 重新开始,所以 test 分支上不会残留历史垃圾。
 name: Update Test Branch
 
 on:
   schedule:
     - cron: '0 20 * * *'
   workflow_dispatch:
+    inputs:
+      prs:
+        description: '临时 PR 列表(如 2571,2567,2527),按填写顺序合入;留空则用 test-branch 标签'
+        required: false
+        default: ''
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  INCLUDE_LABEL: test-branch
+  CONFLICT_LABEL: test-conflict
 
 jobs:
   update-test-branch:
@@ -25,33 +47,165 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Attempt to Fast-Forward Merge
-      id: merge-attempt
-      continue-on-error: true
+    - name: Ensure Labels Exist
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git checkout test
-        git pull origin main --ff-only
-        git push origin test
+        gh label create "$INCLUDE_LABEL" --color 0E8A16 --description "合入 test 分支" --force
+        gh label create "$CONFLICT_LABEL" --color D93F0B --description "合入 test 分支时冲突,需 rebase" --force
 
-    - name: Find Comment
-      if: steps.merge-attempt.outcome == 'failure'
-      uses: peter-evans/find-comment@v3
-      id: fc
-      with:
-        issue-number: ${{ vars.SYNC_STATUS_ISSUE_NUMBER }}
-        comment-author: 'github-actions[bot]'
-        body-includes: 检测到合并冲突
+    - name: Resolve PR List
+      id: resolve
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INPUT_PRS: ${{ inputs.prs }}
+      run: |
+        set -euo pipefail
+        # grep 无匹配 / gh 失败都会让整条管道以非 0 退出,这里不能让它中断 job
+        if [ -n "$(printf '%s' "${INPUT_PRS:-}" | tr -d '[:space:]')" ]; then
+          prs="$(printf '%s' "$INPUT_PRS" | grep -oE '[0-9]+' | awk '!seen[$0]++' | tr '\n' ' ' || true)"
+          src="手动输入(按填写顺序)"
+        else
+          prs="$(gh pr list --state open --label "$INCLUDE_LABEL" --limit 100 --json number --jq '.[].number' | sort -n | tr '\n' ' ')"
+          src="标签 \`$INCLUDE_LABEL\`(按 PR 号升序)"
+        fi
+        echo "prs=$prs" >> "$GITHUB_OUTPUT"
+        echo "src=$src" >> "$GITHUB_OUTPUT"
+        echo "PR 来源: $src"
+        echo "PR 列表: ${prs:-(空)}"
 
-    - name: Post a Comment on Failure
-      if: steps.merge-attempt.outcome == 'failure'
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ vars.SYNC_STATUS_ISSUE_NUMBER }}
-        body: |
-          > :warning: **检测到合并冲突**
+    - name: Rebuild Test Branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PRS: ${{ steps.resolve.outputs.prs }}
+        SRC: ${{ steps.resolve.outputs.src }}
+      run: |
+        set -euo pipefail
 
-          @${{ vars.ASSIGNEE_USERNAME }}
-          `test` 分支和 `main` 分支有冲突，无法自动更新。
-        edit-mode: replace
+        git fetch origin main
+        git checkout -B test origin/main
+        base_sha="$(git rev-parse --short HEAD)"
+
+        applied=()
+        conflicted=()
+        skipped=()
+
+        for pr in $PRS; do
+          # PR 号写错 / 已删除时 gh 会非 0 退出,兜住它,让这个 PR 跳过而不是中断整个 job
+          state="$(gh pr view "$pr" --json state --jq .state 2>/dev/null || true)"
+          if [ "$state" != "OPEN" ]; then
+            skipped+=("$pr|${state:-查不到该 PR}")
+            continue
+          fi
+
+          title="$(gh pr view "$pr" --json title --jq .title)"
+
+          if ! git fetch origin "refs/pull/$pr/head:refs/remotes/pr/$pr" --force; then
+            skipped+=("$pr|拉取 PR 分支失败")
+            continue
+          fi
+          head_sha="$(git rev-parse --short "refs/remotes/pr/$pr")"
+
+          if ! git merge --squash "refs/remotes/pr/$pr"; then
+            # --squash 冲突时没有 MERGE_HEAD,只能靠 reset 清场
+            git reset --hard HEAD
+            git clean -fd
+            conflicted+=("$pr|$title")
+            continue
+          fi
+
+          if git diff --cached --quiet; then
+            skipped+=("$pr|无变更(已在 main 中)")
+            continue
+          fi
+
+          # 保留原作者(committer 仍是 bot,因为 squash 动作是 CI 做的)
+          # 单作者 PR 直接用其提交里的真实署名;多作者 PR 归给 PR 发起人,其余进 Co-authored-by
+          # --reverse:按提交先后排,兜底时取到的是 PR 第一个提交的作者
+          mapfile -t authors < <(git log --reverse --format='%aN <%aE>' "origin/main..refs/remotes/pr/$pr" | awk 'NF && !seen[$0]++')
+          if [ "${#authors[@]}" -eq 1 ]; then
+            author="${authors[0]}"
+          else
+            login="$(gh pr view "$pr" --json author --jq .author.login)"
+            # GitHub 自己 squash 时用的就是 <id>+<login>@users.noreply.github.com,能正确计入贡献
+            user_info="$(gh api "users/$login" --jq '[.id, (.name // .login)] | @tsv' 2>/dev/null || true)"
+            uid="$(printf '%s' "$user_info" | cut -f1)"
+            uname="$(printf '%s' "$user_info" | cut -f2)"
+            if [ -n "$uid" ]; then
+              author="$uname <$uid+$login@users.noreply.github.com>"
+            else
+              author="${authors[0]:-github-actions[bot] <github-actions[bot]@users.noreply.github.com>}"
+            fi
+          fi
+
+          {
+            printf '%s (#%s)\n\nSquashed from #%s (%s) by update-test-branch workflow.\n' \
+              "$title" "$pr" "$pr" "$head_sha"
+            if [ "${#authors[@]}" -gt 1 ]; then
+              printf '\n'
+              for a in "${authors[@]}"; do
+                printf 'Co-authored-by: %s\n' "$a"
+              done
+            fi
+          } | git commit -q -F - --author="$author"
+          applied+=("$pr|$author|$title")
+        done
+
+        if ! git push --force origin test; then
+          {
+            echo "## test 分支重建失败"
+            echo
+            echo "PR 已按顺序处理完,但 \`git push --force origin test\` 被拒绝,\`test\` 分支**未更新**。"
+            echo "请检查 \`test\` 分支的保护规则是否禁止强制推送。"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+        test_sha="$(git rev-parse --short HEAD)"
+
+        # 冲突的打标签提醒作者,成功合入的清掉旧的冲突标签
+        for item in "${conflicted[@]:-}"; do
+          [ -n "$item" ] || continue
+          gh pr edit "${item%%|*}" --add-label "$CONFLICT_LABEL" || true
+        done
+        for item in "${applied[@]:-}"; do
+          [ -n "$item" ] || continue
+          gh pr edit "${item%%|*}" --remove-label "$CONFLICT_LABEL" 2>/dev/null || true
+        done
+
+        {
+          echo "## test 分支重建结果"
+          echo
+          echo "- 基线:\`main\` @ \`$base_sha\` → \`test\` @ \`$test_sha\`"
+          echo "- PR 来源:$SRC"
+          echo
+          echo "### 已合入(${#applied[@]})"
+          echo
+          if [ "${#applied[@]}" -eq 0 ]; then
+            echo "无,\`test\` 与 \`main\` 一致。"
+          else
+            for item in "${applied[@]}"; do
+              rest="${item#*|}"
+              author_name="${rest%%|*}"
+              # 只显示作者名,不把邮箱写进公开的摘要页
+              echo "- #${item%%|*} ${rest#*|} — ${author_name%% <*}"
+            done
+          fi
+          if [ "${#conflicted[@]}" -gt 0 ]; then
+            echo
+            echo "### 冲突跳过(${#conflicted[@]})"
+            echo
+            echo "> 已打上 \`$CONFLICT_LABEL\` 标签,需作者 rebase 到最新 \`main\` 后重跑。"
+            echo
+            for item in "${conflicted[@]}"; do
+              echo "- #${item%%|*} ${item#*|}"
+            done
+          fi
+          if [ "${#skipped[@]}" -gt 0 ]; then
+            echo
+            echo "### 其他跳过(${#skipped[@]})"
+            echo
+            for item in "${skipped[@]}"; do
+              echo "- #${item%%|*}:${item#*|}"
+            done
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/develop/development_workflow.md
+++ b/docs/develop/development_workflow.md
@@ -43,7 +43,7 @@
 2. 主仓开 PR,**描述里带上测试仓 PR 链接**(reviewer 可跳转看测试改动);主仓与测试仓用**同分支名**(CI 按分支名 clone 测试仓)。
 3. assign **DoctorReid / ShadowLemoon**,按 `zzz-od-dev-pr-finishing` skill 走 review(逐条回复 / 修正、清 unresolved thread、处理 CodeRabbit);**关联 PR 一起收尾、合并顺序(测试仓先)见该 skill §6**。
 
-> **想让 PR 合并前先进 `test` 分支给人试用**:给 PR 打 `test-branch` 标签即可。CI 每天(也可手动触发)基于最新 `main` 把带该标签的 open PR 按 PR 号升序 squash 重建 `test` 并强制推送;有冲突的 PR 自动跳过并打上 `test-conflict` 标签,rebase 到最新 `main` 后下次会自动重试。squash 出来的提交**保留原作者**(committer 是 bot)。手动触发时可填 PR 列表临时覆盖标签(按填写顺序合入)。见 [update-test-branch.yml](../../.github/workflows/update-test-branch.yml)。
+> **想让 PR 合并前进入 `test` 分支给人试用**:为 PR 添加 `test-branch` 标签,或手动触发 [Update Test Branch](../../.github/workflows/update-test-branch.yml) 并填写 PR 列表。
 
 ### 5. 配套产出(按需)
 

--- a/docs/develop/development_workflow.md
+++ b/docs/develop/development_workflow.md
@@ -43,6 +43,8 @@
 2. 主仓开 PR,**描述里带上测试仓 PR 链接**(reviewer 可跳转看测试改动);主仓与测试仓用**同分支名**(CI 按分支名 clone 测试仓)。
 3. assign **DoctorReid / ShadowLemoon**,按 `zzz-od-dev-pr-finishing` skill 走 review(逐条回复 / 修正、清 unresolved thread、处理 CodeRabbit);**关联 PR 一起收尾、合并顺序(测试仓先)见该 skill §6**。
 
+> **想让 PR 合并前先进 `test` 分支给人试用**:给 PR 打 `test-branch` 标签即可。CI 每天(也可手动触发)基于最新 `main` 把带该标签的 open PR 按 PR 号升序 squash 重建 `test` 并强制推送;有冲突的 PR 自动跳过并打上 `test-conflict` 标签,rebase 到最新 `main` 后下次会自动重试。squash 出来的提交**保留原作者**(committer 是 bot)。手动触发时可填 PR 列表临时覆盖标签(按填写顺序合入)。见 [update-test-branch.yml](../../.github/workflows/update-test-branch.yml)。
+
 ### 5. 配套产出(按需)
 
 | 产出 | 何时做 | 在哪 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 手动触发支持填写可选 PR 列表；未填写时自动基于 `test-branch` 标签获取待处理 PR。
  * 通过 `gh pr view` 校验 PR 是否为 OPEN；对不可处理项（不存在/非 OPEN/合并冲突）执行跳过并记录原因。
  * 冲突 PR 会新增 `test-conflict` 标签；已合入 PR 会移除旧冲突标记。
  * 合并成功会在 `test` 分支生成带作者/共同作者信息的 squash 提交，并在工作流摘要输出基线与结果信息。

* **文档**
  * 补充在“提 PR”流程中，说明如何使用 `test-branch` 标签或手动触发工作流并填写 PR 列表在 `test` 分支试用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->