### PR TITLE
fix(lost_void): 修复同层交互状态流转

### DIFF
--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -772,16 +772,28 @@ class LostVoidRunLevel(ZOperation):
         @return:
         """
         completed_interact_target = self.locked_interact_target or self.interact_target
-        if completed_interact_target is not None:
-            target_key = self.get_interact_target_key(completed_interact_target)
-            if target_key not in self.interacted_target_key_list:
-                self.interacted_target_key_list.append(target_key)
-            if (self.locked_interact_target is not None
-                    and self.locked_interact_target.name == LostVoidInteractNPC.MA_LIN.value
-                    and LostVoidRegionType.ENCOUNTER.value.value not in self.had_been_list):
-                self.had_been_list.append(LostVoidRegionType.ENCOUNTER.value.value)
+        in_normal_world = self.ctx.lost_void.in_normal_world(self.last_screenshot)
+        is_challenge_result = False
+        if not in_normal_world:
+            result = self.round_by_find_area(self.last_screenshot, '迷失之地-挑战结果', '标题-挑战结果')
+            is_challenge_result = result.is_success
 
-        if self.ctx.lost_void.in_normal_world(self.last_screenshot):
+        is_next_level = (not in_normal_world
+                         and not is_challenge_result
+                         and self.interact_target is not None
+                         and self.interact_target.is_entry)
+        if in_normal_world or is_challenge_result or is_next_level:
+            if completed_interact_target is not None:
+                target_key = self.get_interact_target_key(completed_interact_target)
+                if target_key not in self.interacted_target_key_list:
+                    self.interacted_target_key_list.append(target_key)
+                if (self.locked_interact_target is not None
+                        and self.locked_interact_target.name == LostVoidInteractNPC.MA_LIN.value
+                        and LostVoidRegionType.ENCOUNTER.value.value not in self.had_been_list):
+                    self.had_been_list.append(LostVoidRegionType.ENCOUNTER.value.value)
+            self.locked_interact_target = None
+
+        if in_normal_world:
             if (completed_interact_target is not None
                     and completed_interact_target.name == LostVoidInteractNPC.AO_FEI_LI_YA.value):
                 self.ctx.lost_void.had_interacted_ophelia_on_current_level = True
@@ -791,8 +803,7 @@ class LostVoidRunLevel(ZOperation):
                 self.move_after_interact()
             return self.round_success(status='大世界', wait=1)
 
-        result = self.round_by_find_area(self.last_screenshot, '迷失之地-挑战结果', '标题-挑战结果')
-        if result.is_success:
+        if is_challenge_result:
             # 这个标题出来之后 按钮还需要一段时间才能出来
             r2 = self.round_by_find_area(self.last_screenshot, '迷失之地-挑战结果', '按钮-确定')
             if r2.is_success:
@@ -802,7 +813,7 @@ class LostVoidRunLevel(ZOperation):
             if r2.is_success:
                 return self.round_success('挑战结果-完成', wait=2)
 
-        if self.interact_target is not None and self.interact_target.is_entry:
+        if is_next_level:
             return self.round_success(
                 LostVoidRunLevel.STATUS_NEXT_LEVEL, data=self.interact_target.icon
             )

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -117,6 +117,7 @@ class LostVoidRunLevel(ZOperation):
         self.nothing_times: int = 0  # 识别不到内容的次数
         self.find_target_fail_count: int = 0  # 寻路失败次数
         self.interact_target: LostVoidInteractTarget | None = None  # 最终识别的交互目标 后续改动应该都是用这个判断
+        self.locked_interact_target: LostVoidInteractTarget | None = None  # OCR锁定的本次交互对象
         self.interact_attempted: bool = False  # 是否尝试过交互
 
         self.last_frame_in_battle: bool = True  # 上一帧画面在战斗
@@ -520,24 +521,31 @@ class LostVoidRunLevel(ZOperation):
         result = self.round_by_find_area(self.last_screenshot, '战斗画面', '按键-交互')
 
         if result.is_success:
-            # 尝试文本识别准备交互的目标 这样会比使用图标更为准确
-            time.sleep(0.5)
-            self.screenshot()  # 重新截图
-            area = self.ctx.screen_loader.get_area('迷失之地-大世界', '区域-交互文本')
-            ocr_result_map = self.ctx.ocr.crop_and_run_ocr(self.last_screenshot, area.rect)
-            current_interact_target = None
-            for ocr_result in ocr_result_map:
-                target = match_interact_target(self.ctx, ocr_result)
-                if target is not None:
-                    current_interact_target = target
-                    break
+            if not self.interact_attempted:
+                self.locked_interact_target = None
 
-            if current_interact_target is not None:
-                target_key = self.get_interact_target_key(current_interact_target)
-                if target_key in self.interacted_target_key_list:
-                    log.info('当前层已交互过 %s，本次不再交互，返回上游继续处理', target_key)
-                    return self.round_fail('重复交互对象')
-                self.interact_target = current_interact_target
+            if self.locked_interact_target is None:
+                # 尝试文本识别准备交互的目标 这样会比使用图标更为准确
+                time.sleep(0.5)
+                self.screenshot()  # 重新截图
+                area = self.ctx.screen_loader.get_area('迷失之地-大世界', '区域-交互文本')
+                ocr_result_map = self.ctx.ocr.crop_and_run_ocr(self.last_screenshot, area.rect)
+                current_interact_target: LostVoidInteractTarget | None = None
+                for ocr_result in ocr_result_map:
+                    target = match_interact_target(self.ctx, ocr_result)
+                    if target is not None:
+                        current_interact_target = target
+                        break
+
+                if current_interact_target is not None:
+                    target_key = self.get_interact_target_key(current_interact_target)
+                    if target_key in self.interacted_target_key_list:
+                        log.info('当前层已交互过 %s，本次不再交互，先离开当前对象', target_key)
+                        self.interact_target = current_interact_target
+                        self.move_after_interact()
+                        return self.round_fail('重复交互对象')
+                    self.interact_target = current_interact_target
+                    self.locked_interact_target = current_interact_target
 
             self.ctx.controller.interact(press=True, press_time=0.2, release=True)
             self.interact_attempted = True # 标记已经尝试过交互
@@ -763,14 +771,19 @@ class LostVoidRunLevel(ZOperation):
         2. 不在大世界的 可能是战斗后结果画面 也可能是交互进入下层
         @return:
         """
-        if self.interact_target is not None:
-            log.info('交互后处理 上次交互对象为 %s %s', self.interact_target.icon, self.interact_target.name)
-            target_key = self.get_interact_target_key(self.interact_target)
+        completed_interact_target = self.locked_interact_target or self.interact_target
+        if completed_interact_target is not None:
+            target_key = self.get_interact_target_key(completed_interact_target)
             if target_key not in self.interacted_target_key_list:
                 self.interacted_target_key_list.append(target_key)
+            if (self.locked_interact_target is not None
+                    and self.locked_interact_target.name == LostVoidInteractNPC.MA_LIN.value
+                    and LostVoidRegionType.ENCOUNTER.value.value not in self.had_been_list):
+                self.had_been_list.append(LostVoidRegionType.ENCOUNTER.value.value)
 
         if self.ctx.lost_void.in_normal_world(self.last_screenshot):
-            if self.interact_target is not None and self.interact_target.name == LostVoidInteractNPC.AO_FEI_LI_YA.value:
+            if (completed_interact_target is not None
+                    and completed_interact_target.name == LostVoidInteractNPC.AO_FEI_LI_YA.value):
                 self.ctx.lost_void.had_interacted_ophelia_on_current_level = True
             if not (self.boss_pre_battle
                     and self.interact_target is not None

--- a/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
+++ b/src/zzz_od/application/hollow_zero/lost_void/operation/lost_void_run_level.py
@@ -241,6 +241,7 @@ class LostVoidRunLevel(ZOperation):
     @node_from(from_name='战斗中', status='识别需移动交互')  # 战斗后出现距离 或者下层入口
     @node_from(from_name='尝试交互', success=False)  # 没能交互到
     @node_from(from_name='更新优先级')  # 更新优先级后
+    @node_from(from_name='追加代理人类型优先级', status='非战斗区域')
     @operation_node(name='非战斗画面识别', timeout_seconds=180)
     def non_battle_check(self) -> OperationRoundResult:
         # 不在大世界处理


### PR DESCRIPTION
## 背景

`LostVoidRunLevel` 应代表单个游戏层的完整循环。实际运行中，更新代理人类型优先级后会以“非战斗区域”成功结束，但缺少返回非战斗识别的后继边，导致当前层操作被错误结束并重新创建。

玛琳交互会进入路径迭换，路径迭换会改写当前导航目标；交互结束后需要保留 OCR 识别到的对象，才能在同一个 `LostVoidRunLevel` 实例内正确登记已处理内容。

## 变更

- 为“追加代理人类型优先级”返回“非战斗区域”补充到“非战斗画面识别”的后继边，保持同层循环，不再错误重建 `LostVoidRunLevel`。
- 锁定本次 OCR 识别的交互对象；玛琳交互完成后，在当前层的 `had_been_list` 登记“偶遇事件”。
- 同层再次识别到已完成的对象时，先按既有 `move_after_interact()` 逻辑退离，再回到识别流程，不重复交互。

## 验证

- 已实际运行确认玛琳交互完成后仍保持在同一层。
- `git diff --check` 通过。

## 范围

- 不新增或保留测试仓改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 引入“本次 OCR 锁定交互对象”缓存，减少重复 OCR 导致的重复交互与误判。
  * 识别到“已交互重复对象”时，先移动离开目标后以重复交互状态结束本轮；未重复则同步设置交互目标与缓存。
  * 交互后的去重记录更新更精准，并在满足条件时仅追加特定 NPC 标记（含 MA_LIN/ENCOUNTER 相关规则）。

* **流程优化**
  * 优化非战斗区域的节点路由衔接，并在满足条件时返回“下一层”状态，数据使用当前交互目标图标。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->