### PR TITLE
fix(auto_battle): 后台模式结算误触再来一次(普攻兜底决策层 gate)

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -11794,7 +11794,7 @@
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 10
-          "states": ""
+          "states": "[按键可用-普通攻击]"
     - "debug_name": "失衡被琉音延长了"
       "operations":
       - "op_name": "设置状态"
@@ -22377,7 +22377,7 @@
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 10
-        "states": ""
+        "states": "[按键可用-普通攻击]"
   "interval": 0.02
   "priority": 9
   "triggers": []

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -10815,7 +10815,7 @@
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 10
-          "states": ""
+          "states": "[按键可用-普通攻击]"
     - "operations":
       - "data": []
         "op_name": "按键-切换角色-上一个"

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -9882,7 +9882,7 @@
       - "op_name": "按键-普通攻击"
         "post_delay": 0.1
         "repeat": 10
-      "states": ""
+      "states": "[按键可用-普通攻击]"
   "interval": 1
   "triggers":
   - "前台-击破"
@@ -19536,7 +19536,7 @@
       - "op_name": "按键-普通攻击"
         "post_delay": 0.1
         "repeat": 10
-      "states": ""
+      "states": "[按键可用-普通攻击]"
   "interval": 1
   "triggers":
   - "前台-支援"

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -9848,7 +9848,7 @@
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 10
-        "states": ""
+        "states": "[按键可用-普通攻击]"
   - "operations":
     - "data":
       - "99"

--- a/config/auto_battle_state_handler/速切模板-通用.sample.yml
+++ b/config/auto_battle_state_handler/速切模板-通用.sample.yml
@@ -38,6 +38,6 @@ handlers:
             post_delay: 0.5
             repeat: 2
 
-      - states: ""
+      - states: "[按键可用-普通攻击]"
         operations:
           - operation_template: "通用-切人普通攻击"

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -554,6 +554,11 @@ class AutoBattleContext:
         if in_battle:
             self.state_record_service.update_state(
                 StateRecord(BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value, screenshot_time))
+        else:
+            # 离开战斗(普攻按钮消失):立即清状态,不依赖默认时间窗口在战后自然失效,
+            # 避免战后残留的"按键可用"让 速切模板-通用 兜底继续发普攻(#2157)
+            self.state_record_service.update_state(
+                StateRecord(BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value, is_clear=True))
 
         future_list: list[Future] = []
 

--- a/src/zzz_od/auto_battle/auto_battle_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_context.py
@@ -551,6 +551,9 @@ class AutoBattleContext:
         """
         in_battle = self.is_normal_attack_btn_available(screen)
         self.last_check_in_battle = in_battle
+        if in_battle:
+            self.state_record_service.update_state(
+                StateRecord(BattleStateEnum.STATUS_NORMAL_ATTACK_READY.value, screenshot_time))
 
         future_list: list[Future] = []
 

--- a/src/zzz_od/auto_battle/auto_battle_state.py
+++ b/src/zzz_od/auto_battle/auto_battle_state.py
@@ -24,3 +24,4 @@ class BattleStateEnum(Enum):
     STATUS_CHAIN_READY = '按键可用-连携技'
     STATUS_QUICK_ASSIST_READY = '按键可用-快速支援'
     STATUS_SWITCH_BACKUP_READY = '按键可用-切换后援'
+    STATUS_NORMAL_ATTACK_READY = '按键可用-普通攻击'


### PR DESCRIPTION
## 问题与修复

close #2157。后台手柄模式,普攻(X)与结算页"再来一次"共用 X 键。战斗结束后自动战斗仍在发普攻,残留普攻在结算页误触"再来一次",导致副本被重复挑战。

**修复思路(决策层,而非输出层)**:不在输出层用计时器拦(见 #2557),而是在"决定发普攻"那一步判断有没有攻击按钮 —— 给普攻兜底加 `[按键可用-普通攻击]` gate(按钮在才发)。

## 改动

1. **新增状态 `按键可用-普通攻击`**(commit 1):`BattleStateEnum.STATUS_NORMAL_ATTACK_READY` + `AutoBattleContext.check_battle_state` 在 `is_normal_attack_btn_available(screen)` 为真(战中)时写入。把"普攻按钮当前是否可用"暴露给策略层(之前只有内部 `last_check_in_battle` bool,策略读不到)。
2. **gate `速切模板-通用` 的普攻兜底**(commit 2,本 PR 核心):

```yaml
# config/auto_battle_state_handler/速切模板-通用.sample.yml line 41
- states: "[按键可用-普通攻击]"     # 原: states: ""(恒真 → 战后也会发普攻)
  operations:
    - operation_template: "通用-切人普通攻击"
```

rebuild 了引用该模板的 4 个 merged(全配队通用 / 击破站场-强攻速切 / 强攻站场-击破支援速切 / 自动守护)。

## 为什么只改 `速切模板-通用` 这一处(排查过程)

### bug 机制
战中 auto_op 按"识别到角色"等状态走速切/轮换模板发普攻。**战斗结束后**识别停止,`[前台-<角色>]` 等状态在时间窗口(默认 1s)内仍 stale 为真、过期后失配 → **落到 `速切模板-通用`**(速切模板-全角色 dispatcher 最后一项,未识别角色的兜底)→ 其**无条件** `states:""` 末端(`通用-切人普通攻击` = 普攻)战后持续发普攻 = bug。

### 排查脚本(思路:别手工读 yml,代码遍历)
写了个脚本递归加载 `全配队通用`(复刻 loader 的模板展开,递归时带"模板路径 + 祖先 states"),收集所有普攻叶子,按"战内信号"剪枝,剩下的就是没被守住、需要 gate 的兜底。

**剪枝规则**(祖先 `states` 含【正向,非 `!` 否定】的这些 → 视为"在战斗画面=按钮在"→ 安全):
- `[前台-/后台-/后台-1-/后台-2-<角色或类型>]`(3 人队,任意位置识别到角色;类型=击破/强攻/支援/防护/异常/命破;不含 `前台-能量`)
- `[按键可用-快速支援]` / `[按键可用-切换后援]` / `[按键可用-普通攻击]`(只在战斗画面出现的按钮可用状态)
- `[<角色>-…]`(角色专属状态,如 `[苍角-能量]`、`[卢西娅-特殊技可用]`、`[琉音-客诉]`)
- `[自定义-黄光切人]`(黄光是"即将被攻击"的战内提示,该状态只在战中才设)

### 收敛过程
| 剪枝集 | 未剪枝候选 |
|---|---|
| 普攻叶子总数 | 981 |
| +前台/后台 角色类型 + 快速支援/切换后援 | 37 |
| +后台-1/后台-2 角色类型 | 29 |
| +`[<角色>-` 前缀(角色专属状态) | 6 |
| +`自定义-黄光切人` | **4** |

4 个候选全部指向**同一个 handler**(经 handler 156/182 两条路径 × 该 handler 内 2 个普攻 op)= `速切模板-通用` line 41。**全配队通用 981 个普攻叶子里,只有这一处没被任何战内信号守住。** 改完 gate 后再跑脚本(把 `按键可用-普通攻击` 也入剪枝)→ 候选 = 0。

脚本本身用 3 个独立子 agent 验过:递归保真度(981=981,与真实 loader 一致)、剪枝正则(23 case 全过,实际配置无误剪/漏剪)。

### 排查脚本全文(放这里供 review,不入库)
```python
# find_normal_attack_fallback.py —— 找未被战内信号守住的普攻兜底
# 用法: uv run --env-file .env python .temp/find_normal_attack_fallback.py [配置名]
import re
from one_dragon.base.conditional_operation.loader import ConditionalOperatorLoader

_AGENT_TYPES = ['击破', '强攻', '支援', '防护', '异常', '命破']
_POSITIONS = ['前台-', '后台-', '后台-1-', '后台-2-']
_BUTTON_PRUNE = ['按键可用-快速支援', '按键可用-切换后援', '按键可用-普通攻击', '自定义-黄光切人']

def _agent_names():
    from zzz_od.game_data.agent import AgentEnum
    return [a.value.agent_name for a in AgentEnum]

def _load(sub_dir, name):
    return ConditionalOperatorLoader.load_yaml_config(sub_dir, name, read_from_merged=False)

def _is_pruned(ancestor_states, exact, prefix):
    for s in ancestor_states:
        if not s:
            continue
        for m in exact:
            if re.search(rf'(?<!!)\[{re.escape(m)}(?=[\],])', s):
                return True
        for m in prefix:
            if re.search(rf'(?<!!)\[{re.escape(m)}', s):
                return True
    return False

def _walk_handler(h, anc, hpath, res, exact, prefix):
    tname = h.get('state_template')
    if tname:
        for hh in _load(['auto_battle_state_handler'], tname).get('handlers', []):
            _walk_handler(hh, anc, hpath + [tname], res, exact, prefix)
        return
    states = h.get('states', '')
    subs, ops = h.get('sub_handlers', []), h.get('operations', [])
    if subs:
        for sub in subs:
            _walk_handler(sub, anc + [states], hpath, res, exact, prefix)
    elif ops:
        for op in ops:
            _walk_op(op, anc + [states], hpath, states, res, exact, prefix)

def _walk_op(op, anc, hpath, parent_states, res, exact, prefix):
    ot = op.get('operation_template')
    if ot:
        for o in _load(['auto_battle_operation'], ot).get('operations', []):
            _walk_op(o, anc, hpath, parent_states, res, exact, prefix)
    else:
        name = op.get('op_name', '')
        if '普通攻击' in name and not name.endswith('松开'):
            res.append({'op': name, 'source': hpath[-1], 'parent_states': parent_states,
                        'ancestor_states': list(anc), 'pruned': _is_pruned(anc, exact, prefix)})

def find_ungated(entry='全配队通用'):
    names = _agent_names()
    exact = [p + n for p in _POSITIONS for n in names] + [p + t for p in _POSITIONS for t in _AGENT_TYPES] + _BUTTON_PRUNE
    prefix = [f'{n}-' for n in names]
    res = []
    for scene in _load(['auto_battle'], entry).get('scenes', []):
        for h in scene.get('handlers', []):
            _walk_handler(h, [], [entry], res, exact, prefix)
    return [r for r in res if not r['pruned']]

if __name__ == '__main__':
    import sys
    cands = find_ungated(sys.argv[1] if len(sys.argv) > 1 else '全配队通用')
    print(f'未 gated 普攻兜底候选 = {len(cands)}')
    for r in cands:
        print(r['source'], '|', repr(r['parent_states']))
```

## 覆盖面
`速切模板-通用` 是共享模板,1 处改动覆盖 `全配队通用` + `强攻站场-击破支援速切` + `自动守护`(击破站场-强攻速切 经 速切模板-强攻站场 间接受益)。角色模板自己的普攻末端都包在 `[前台-<角色>]` 里(战后随前台 stale 失配而停),无需改。`专属配队-*`(手写、不走速切模板)不在覆盖内。

## 测试
- `test_all_sample_valid`:改完 sample 仍能正常加载。
- 状态写入单测 `test_normal_attack_ready_state.py`(在测试仓 `zzz-od-test` 同名分支)。

## 与 #2557 的关系
#2557 在输出层(`auto_battle_context.normal_attack`)用 3.5s 计时器拦截;本 PR 在决策层(普攻兜底 gate)根治。两者可互补(本 PR 已堵住唯一无条件兜底;#2557 可作框架级兜底保留或撤下,后续评估)。

## 后续维护(给自动战斗配置开发者)

**重要**:`速切模板-通用` 等配置文件会随版本演进,**"兜底在哪个文件"会变**。本 PR 修的是当前的无条件普攻兜底,但以后新增/重构兜底时要注意:

1. **兜底末端别"无脑攻击"**:任何普攻兜底(`states: ""` → 发普攻那种)都应 gate 在一个"在战斗画面才为真"的状态上(如 `[按键可用-普通攻击]`、`[前台-<角色>]`),避免战斗结束后残留普攻触发结算页按钮(#2157)。
2. **改完配置可复跑上面的排查脚本验证**:它递归加载配置,按战内信号剪枝,报出所有"未被守住"的普攻兜底。期望输出 `未 gated 普攻兜底候选 = 0`;若 >0,说明有新的兜底需要补 gate。
3. 剪枝集(代表"在战斗画面"的状态)若以后有新增(新按钮/新战内信号),记得同步进脚本。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“普通攻击按键可用”状态识别，并在战斗中自动记录该状态。
* **优化**
  * 多种自动战斗配置调整触发条件：普通攻击相关分支现仅在“普通攻击按键可用”时生效。
  * 更新速切模板：新增基于“普通攻击按键可用”的操作匹配。
* **Bug Fix**
  * 战斗结束后会清除“普通攻击按键可用”状态，避免残留状态导致后续误触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->