### PR TITLE
进一步减少叶瞬光走地的可能

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -9724,7 +9724,7 @@
               "repeat": 10
             - "op_name": "等待秒数"
               "seconds": 1
-            "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+            "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
           - "operations":
             - "op_name": "清除状态"
               "state": "自定义-无视闪光"
@@ -9767,7 +9767,7 @@
           "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
           "sub_handlers":
           - "debug_name": "等待变身就绪"
-            "interrupt_states": "[叶瞬光-明心境]{0,110}"
+            "interrupt_states": "[叶瞬光-明心境]{0,118}"
             "operations":
             - "op_name": "设置状态"
               "seconds": 9
@@ -9776,10 +9776,6 @@
               "seconds": 9
               "state": "自定义-动作不打断"
             - "op_name": "按键-特殊攻击-松开"
-            - "op_name": "按键-普通攻击-松开"
-            - "op_name": "按键-特殊攻击"
-              "post_delay": 0.1
-              "repeat": 3
             - "op_name": "按键-普通攻击"
               "post_delay": 0.1
               "repeat": 40
@@ -9799,6 +9795,9 @@
             - "op_name": "按键-特殊攻击"
               "post_delay": 0.1
               "repeat": 10
+            - "op_name": "按键-普通攻击"
+              "post_delay": 0.1
+              "repeat": 20
             "states": "[叶瞬光-青溟剑势-白]{6,6}"
           - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
             "operations":
@@ -9822,7 +9821,7 @@
               "state": "自定义-动作不打断"
             - "op_name": "按键-特殊攻击"
               "post_delay": 0.1
-              "repeat": 10
+              "repeat": 12
             - "op_name": "按键-普通攻击"
               "post_delay": 0.1
               "repeat": 40
@@ -9851,7 +9850,7 @@
               "post_delay": 0.1
               "repeat": 20
             "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-        - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+        - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
           "operations":
           - "op_name": "设置状态"
             "seconds": 9
@@ -20547,7 +20546,7 @@
             "repeat": 10
           - "op_name": "等待秒数"
             "seconds": 1
-          "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+          "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
         - "operations":
           - "op_name": "清除状态"
             "state": "自定义-无视闪光"
@@ -20590,7 +20589,7 @@
         "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
         "sub_handlers":
         - "debug_name": "等待变身就绪"
-          "interrupt_states": "[叶瞬光-明心境]{0,110}"
+          "interrupt_states": "[叶瞬光-明心境]{0,118}"
           "operations":
           - "op_name": "设置状态"
             "seconds": 9
@@ -20599,10 +20598,6 @@
             "seconds": 9
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击-松开"
-          - "op_name": "按键-普通攻击-松开"
-          - "op_name": "按键-特殊攻击"
-            "post_delay": 0.1
-            "repeat": 3
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 40
@@ -20622,6 +20617,9 @@
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
             "repeat": 10
+          - "op_name": "按键-普通攻击"
+            "post_delay": 0.1
+            "repeat": 20
           "states": "[叶瞬光-青溟剑势-白]{6,6}"
         - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
           "operations":
@@ -20645,7 +20643,7 @@
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
-            "repeat": 10
+            "repeat": 12
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 40
@@ -20674,7 +20672,7 @@
             "post_delay": 0.1
             "repeat": 20
           "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-      - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+      - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
         "operations":
         - "op_name": "设置状态"
           "seconds": 9

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -8745,7 +8745,7 @@
               "repeat": 10
             - "op_name": "等待秒数"
               "seconds": 1
-            "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+            "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
           - "operations":
             - "op_name": "清除状态"
               "state": "自定义-无视闪光"
@@ -8788,7 +8788,7 @@
           "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
           "sub_handlers":
           - "debug_name": "等待变身就绪"
-            "interrupt_states": "[叶瞬光-明心境]{0,110}"
+            "interrupt_states": "[叶瞬光-明心境]{0,118}"
             "operations":
             - "op_name": "设置状态"
               "seconds": 9
@@ -8797,10 +8797,6 @@
               "seconds": 9
               "state": "自定义-动作不打断"
             - "op_name": "按键-特殊攻击-松开"
-            - "op_name": "按键-普通攻击-松开"
-            - "op_name": "按键-特殊攻击"
-              "post_delay": 0.1
-              "repeat": 3
             - "op_name": "按键-普通攻击"
               "post_delay": 0.1
               "repeat": 40
@@ -8820,6 +8816,9 @@
             - "op_name": "按键-特殊攻击"
               "post_delay": 0.1
               "repeat": 10
+            - "op_name": "按键-普通攻击"
+              "post_delay": 0.1
+              "repeat": 20
             "states": "[叶瞬光-青溟剑势-白]{6,6}"
           - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
             "operations":
@@ -8843,7 +8842,7 @@
               "state": "自定义-动作不打断"
             - "op_name": "按键-特殊攻击"
               "post_delay": 0.1
-              "repeat": 10
+              "repeat": 12
             - "op_name": "按键-普通攻击"
               "post_delay": 0.1
               "repeat": 40
@@ -8872,7 +8871,7 @@
               "post_delay": 0.1
               "repeat": 20
             "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-        - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+        - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
           "operations":
           - "op_name": "设置状态"
             "seconds": 9

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -7814,7 +7814,7 @@
           "repeat": 10
         - "op_name": "等待秒数"
           "seconds": 1
-        "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+        "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
       - "operations":
         - "op_name": "清除状态"
           "state": "自定义-无视闪光"
@@ -7857,7 +7857,7 @@
       "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
       "sub_handlers":
       - "debug_name": "等待变身就绪"
-        "interrupt_states": "[叶瞬光-明心境]{0,110}"
+        "interrupt_states": "[叶瞬光-明心境]{0,118}"
         "operations":
         - "op_name": "设置状态"
           "seconds": 9
@@ -7866,10 +7866,6 @@
           "seconds": 9
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击-松开"
-        - "op_name": "按键-普通攻击-松开"
-        - "op_name": "按键-特殊攻击"
-          "post_delay": 0.1
-          "repeat": 3
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 40
@@ -7889,6 +7885,9 @@
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
           "repeat": 10
+        - "op_name": "按键-普通攻击"
+          "post_delay": 0.1
+          "repeat": 20
         "states": "[叶瞬光-青溟剑势-白]{6,6}"
       - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
         "operations":
@@ -7912,7 +7911,7 @@
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
-          "repeat": 10
+          "repeat": 12
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 40
@@ -7941,7 +7940,7 @@
           "post_delay": 0.1
           "repeat": 20
         "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-    - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+    - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
       "operations":
       - "op_name": "设置状态"
         "seconds": 9
@@ -17678,7 +17677,7 @@
           "repeat": 10
         - "op_name": "等待秒数"
           "seconds": 1
-        "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+        "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
       - "operations":
         - "op_name": "清除状态"
           "state": "自定义-无视闪光"
@@ -17721,7 +17720,7 @@
       "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
       "sub_handlers":
       - "debug_name": "等待变身就绪"
-        "interrupt_states": "[叶瞬光-明心境]{0,110}"
+        "interrupt_states": "[叶瞬光-明心境]{0,118}"
         "operations":
         - "op_name": "设置状态"
           "seconds": 9
@@ -17730,10 +17729,6 @@
           "seconds": 9
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击-松开"
-        - "op_name": "按键-普通攻击-松开"
-        - "op_name": "按键-特殊攻击"
-          "post_delay": 0.1
-          "repeat": 3
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 40
@@ -17753,6 +17748,9 @@
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
           "repeat": 10
+        - "op_name": "按键-普通攻击"
+          "post_delay": 0.1
+          "repeat": 20
         "states": "[叶瞬光-青溟剑势-白]{6,6}"
       - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
         "operations":
@@ -17776,7 +17774,7 @@
           "state": "自定义-动作不打断"
         - "op_name": "按键-特殊攻击"
           "post_delay": 0.1
-          "repeat": 10
+          "repeat": 12
         - "op_name": "按键-普通攻击"
           "post_delay": 0.1
           "repeat": 40
@@ -17805,7 +17803,7 @@
           "post_delay": 0.1
           "repeat": 20
         "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-    - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+    - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
       "operations":
       - "op_name": "设置状态"
         "seconds": 9

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -7779,7 +7779,7 @@
             "repeat": 10
           - "op_name": "等待秒数"
             "seconds": 1
-          "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+          "states": "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
         - "operations":
           - "op_name": "清除状态"
             "state": "自定义-无视闪光"
@@ -7822,7 +7822,7 @@
         "states": "[叶瞬光-常态]{0,0} & ![叶瞬光-明心境]{0,0}"
         "sub_handlers":
         - "debug_name": "等待变身就绪"
-          "interrupt_states": "[叶瞬光-明心境]{0,110}"
+          "interrupt_states": "[叶瞬光-明心境]{0,118}"
           "operations":
           - "op_name": "设置状态"
             "seconds": 9
@@ -7831,10 +7831,6 @@
             "seconds": 9
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击-松开"
-          - "op_name": "按键-普通攻击-松开"
-          - "op_name": "按键-特殊攻击"
-            "post_delay": 0.1
-            "repeat": 3
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 40
@@ -7854,6 +7850,9 @@
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
             "repeat": 10
+          - "op_name": "按键-普通攻击"
+            "post_delay": 0.1
+            "repeat": 20
           "states": "[叶瞬光-青溟剑势-白]{6,6}"
         - "interrupt_states": "[叶瞬光-青溟剑势-白]{3,3}"
           "operations":
@@ -7877,7 +7876,7 @@
             "state": "自定义-动作不打断"
           - "op_name": "按键-特殊攻击"
             "post_delay": 0.1
-            "repeat": 10
+            "repeat": 12
           - "op_name": "按键-普通攻击"
             "post_delay": 0.1
             "repeat": 40
@@ -7906,7 +7905,7 @@
             "post_delay": 0.1
             "repeat": 20
           "states": "[叶瞬光-青溟剑势-白]{2,2} | [叶瞬光-青溟剑势-白]{5,5}"
-      - "interrupt_states": "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+      - "interrupt_states": "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
         "operations":
         - "op_name": "设置状态"
           "seconds": 9

--- a/config/auto_battle_state_handler/速切模板-叶瞬光.sample.yml
+++ b/config/auto_battle_state_handler/速切模板-叶瞬光.sample.yml
@@ -82,7 +82,7 @@ handlers:
                 seconds: 10
               - operation_template: "叶瞬光-变身"
 
-          - states: "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,3}"
+          - states: "[叶瞬光-终结技可用] & [叶瞬光-青溟剑势-红]{0,5}"
             operations:
               - operation_template: "叶瞬光-终结技-起"
 
@@ -116,7 +116,7 @@ handlers:
         debug_name: "明心境-期间输出"
         sub_handlers:
           - states: "[叶瞬光-明心境]{110,120}"
-            interrupt_states: "[叶瞬光-明心境]{0,110}"
+            interrupt_states: "[叶瞬光-明心境]{0,118}"
             debug_name: "等待变身就绪"
             operations:
               - op_name: "设置状态"
@@ -126,10 +126,6 @@ handlers:
                 state: "自定义-动作不打断"
                 seconds: 9
               - op_name: "按键-特殊攻击-松开"
-              - op_name: "按键-普通攻击-松开"
-              - op_name: "按键-特殊攻击"
-                post_delay: 0.1
-                repeat: 3
               - op_name: "按键-普通攻击"
                 post_delay: 0.1
                 repeat: 40
@@ -150,6 +146,9 @@ handlers:
               - op_name: "按键-特殊攻击"
                 post_delay: 0.1
                 repeat: 10
+              - op_name: "按键-普通攻击"
+                post_delay: 0.1
+                repeat: 20
 
           - states: "[叶瞬光-青溟剑势-白]{4,4}"
             interrupt_states: "[叶瞬光-青溟剑势-白]{3,3}"
@@ -175,7 +174,7 @@ handlers:
                 seconds: 9
               - op_name: "按键-特殊攻击"
                 post_delay: 0.1
-                repeat: 10
+                repeat: 12
               - op_name: "按键-普通攻击"
                 post_delay: 0.1
                 repeat: 40
@@ -207,7 +206,7 @@ handlers:
                 repeat: 20
 
       - states: "([叶瞬光-青溟剑势-白]{0,0} | [叶瞬光-明心境]{0,20}) & ![叶瞬光-青溟剑势-白]{6,6}"
-        interrupt_states: "([叶瞬光-常态]{1,1} & [叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
+        interrupt_states: "([叶瞬光-明心境]{0,0}) | [叶瞬光-明心境]{90,130}"
         operations:
           - op_name: "设置状态"
             state: "自定义-无视闪光"


### PR DESCRIPTION
## 变更

- 调整叶瞬光明心境期间的终结技阈值、变身等待与白剑势输入时序。
- 明心境高值时提前中断乱砍，减少错误回到走地输出的可能。
- 通过 `new-config.ps1` 重新生成受影响的自动战斗合并配置。

## 验证

- `powershell -ExecutionPolicy Bypass -File skills/new-config/new-config.ps1`
- `git diff --check`

## 未覆盖

- 未进行游戏内实战验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 扩大叶瞬光相关触发与中断判定窗口（例如终结技与青溟剑势阶段的触发时长、明心境“等待变身就绪”的上限），提升自动战斗衔接稳定性。
  * 调整明心境/青溟剑势输出节奏：移除部分松开类输入步骤，并更新普通攻击/特殊攻击的重复次数与按键执行顺序（含 repeat: 40 / 20 / 12 等）。
  * 同步更新多份自动战斗配置与速切模板，统一中断条件逻辑（减少对常态条件的依赖）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->