### PR TITLE
fix: 固定滚轮事件步长

### DIFF
--- a/src/one_dragon/base/controller/pc_controller_base.py
+++ b/src/one_dragon/base/controller/pc_controller_base.py
@@ -568,8 +568,7 @@ def win_scroll(clicks: int, pos: Point = None):
     """
     if pos is not None:
         pyautogui.moveTo(pos.x, pos.y)
-    d = 2000 if get_mouse_sensitivity() <= 10 else 1000
-    pyautogui.scroll(-d * clicks, pos.x, pos.y)
+    pyautogui.scroll(-120 * clicks, pos.x, pos.y)
 
 
 @lru_cache


### PR DESCRIPTION
## 问题

`win_scroll()` 会将同一个 `clicks` 按系统鼠标灵敏度放大为 1000 或 2000。系统设置不同，自动化滚动距离也不同，导致列表翻页结果不可预测。

## 修改

固定使用 Windows 滚轮事件步长 `120`，使相同的 `clicks` 在不同系统鼠标灵敏度设置下发送一致的滚轮输入。

## 验证

- `python -m py_compile src/one_dragon/base/controller/pc_controller_base.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化滚动操作的滚动距离计算，提升不同环境下滚动行为的一致性。
  * 保持现有滚动方向、位置及调用方式不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->