### PR TITLE
fix(auto_battle): optimize Remielle long press timing

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -10711,48 +10711,15 @@
             "state_list":
             - "自定义-动作不打断"
             - "自定义-无视闪光"
+          - "op_name": "按键-特殊攻击-松开"
+          - "op_name": "等待秒数"
+            "seconds": 0.02
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
             "seconds": 0.5
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
+            "seconds": 5
           "states": "[蕾米埃尔-虚曜]{3,3}"
         - "debug_name": "等待快速支援出现"
           "operations":
@@ -10773,7 +10740,10 @@
             - "自定义-无视闪光"
           - "op_name": "按键-普通攻击-松开"
           - "op_name": "等待秒数"
-            "seconds": 0.2
+            "seconds": 0.02
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
           - "op_name": "按键-特殊攻击-按下"
           - "op_name": "等待秒数"
             "seconds": 5
@@ -21533,48 +21503,15 @@
           "state_list":
           - "自定义-动作不打断"
           - "自定义-无视闪光"
+        - "op_name": "按键-特殊攻击-松开"
+        - "op_name": "等待秒数"
+          "seconds": 0.02
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
           "seconds": 0.5
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
+          "seconds": 5
         "states": "[蕾米埃尔-虚曜]{3,3}"
       - "debug_name": "等待快速支援出现"
         "operations":
@@ -21595,7 +21532,10 @@
           - "自定义-无视闪光"
         - "op_name": "按键-普通攻击-松开"
         - "op_name": "等待秒数"
-          "seconds": 0.2
+          "seconds": 0.02
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
         - "op_name": "按键-特殊攻击-按下"
         - "op_name": "等待秒数"
           "seconds": 5

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -9732,48 +9732,15 @@
             "state_list":
             - "自定义-动作不打断"
             - "自定义-无视闪光"
+          - "op_name": "按键-特殊攻击-松开"
+          - "op_name": "等待秒数"
+            "seconds": 0.02
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
             "seconds": 0.5
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
-          - "op_name": "按键-普通攻击-按下"
-          - "op_name": "等待秒数"
-            "seconds": 0.5
+            "seconds": 5
           "states": "[蕾米埃尔-虚曜]{3,3}"
         - "debug_name": "等待快速支援出现"
           "operations":
@@ -9794,7 +9761,10 @@
             - "自定义-无视闪光"
           - "op_name": "按键-普通攻击-松开"
           - "op_name": "等待秒数"
-            "seconds": 0.2
+            "seconds": 0.02
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
           - "op_name": "按键-特殊攻击-按下"
           - "op_name": "等待秒数"
             "seconds": 5

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -8801,48 +8801,15 @@
         "state_list":
         - "自定义-动作不打断"
         - "自定义-无视闪光"
+      - "op_name": "按键-特殊攻击-松开"
+      - "op_name": "等待秒数"
+        "seconds": 0.02
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
         "seconds": 0.5
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
+        "seconds": 5
       "states": "[蕾米埃尔-虚曜]{3,3}"
     - "debug_name": "等待快速支援出现"
       "operations":
@@ -8863,7 +8830,10 @@
         - "自定义-无视闪光"
       - "op_name": "按键-普通攻击-松开"
       - "op_name": "等待秒数"
-        "seconds": 0.2
+        "seconds": 0.02
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
       - "op_name": "按键-特殊攻击-按下"
       - "op_name": "等待秒数"
         "seconds": 5
@@ -18664,48 +18634,15 @@
         "state_list":
         - "自定义-动作不打断"
         - "自定义-无视闪光"
+      - "op_name": "按键-特殊攻击-松开"
+      - "op_name": "等待秒数"
+        "seconds": 0.02
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
         "seconds": 0.5
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
-      - "op_name": "按键-普通攻击-按下"
-      - "op_name": "等待秒数"
-        "seconds": 0.5
+        "seconds": 5
       "states": "[蕾米埃尔-虚曜]{3,3}"
     - "debug_name": "等待快速支援出现"
       "operations":
@@ -18726,7 +18663,10 @@
         - "自定义-无视闪光"
       - "op_name": "按键-普通攻击-松开"
       - "op_name": "等待秒数"
-        "seconds": 0.2
+        "seconds": 0.02
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
       - "op_name": "按键-特殊攻击-按下"
       - "op_name": "等待秒数"
         "seconds": 5

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -8766,48 +8766,15 @@
           "state_list":
           - "自定义-动作不打断"
           - "自定义-无视闪光"
+        - "op_name": "按键-特殊攻击-松开"
+        - "op_name": "等待秒数"
+          "seconds": 0.02
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
           "seconds": 0.5
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
-        - "op_name": "按键-普通攻击-按下"
-        - "op_name": "等待秒数"
-          "seconds": 0.5
+          "seconds": 5
         "states": "[蕾米埃尔-虚曜]{3,3}"
       - "debug_name": "等待快速支援出现"
         "operations":
@@ -8828,7 +8795,10 @@
           - "自定义-无视闪光"
         - "op_name": "按键-普通攻击-松开"
         - "op_name": "等待秒数"
-          "seconds": 0.2
+          "seconds": 0.02
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
         - "op_name": "按键-特殊攻击-按下"
         - "op_name": "等待秒数"
           "seconds": 5

--- a/config/auto_battle_operation/蕾米埃尔-长按强化特殊技.sample.yml
+++ b/config/auto_battle_operation/蕾米埃尔-长按强化特殊技.sample.yml
@@ -4,7 +4,10 @@ operations:
     seconds: 10
   - op_name: "按键-普通攻击-松开"
   - op_name: "等待秒数"
-    seconds: 0.2
+    seconds: 0.02
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
   - op_name: "按键-特殊攻击-按下"
   - op_name: "等待秒数"
     seconds: 5

--- a/config/auto_battle_operation/蕾米埃尔-长按普攻.sample.yml
+++ b/config/auto_battle_operation/蕾米埃尔-长按普攻.sample.yml
@@ -2,45 +2,12 @@ operations:
   - op_name: "设置状态"
     state_list: ["自定义-动作不打断", "自定义-无视闪光"]
     seconds: 10
+  - op_name: "按键-特殊攻击-松开"
+  - op_name: "等待秒数"
+    seconds: 0.02
   - op_name: "按键-普通攻击-按下"
   - op_name: "等待秒数"
     seconds: 0.5
   - op_name: "按键-普通攻击-按下"
   - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
-  - op_name: "按键-普通攻击-按下"
-  - op_name: "等待秒数"
-    seconds: 0.5
+    seconds: 5


### PR DESCRIPTION
## 改动
- 长按普攻前松开特殊攻击，等待 0.02 秒。
- 长按强化特殊技前松开普通攻击，等待 0.02 秒。
- 重新生成 4 个 auto_battle merged 配置。

## 验证
- 6 个 YAML 文件解析通过。
- git diff --check 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化蕾米埃尔自动战斗中的长按普攻与长按强化特殊技连招时序。
  * 调整技能衔接与等待时间，使操作流程更紧凑，并改善后续动作触发节奏。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->