### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.11.9,<3.12`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.11.9,<3.12` (using `3.11` where a concrete pin is needed).

- `.github/workflows/update-contributors.yml`
  - `python-version: '3.9'` → `python-version: '3.11'`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.11.9,<3.12`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **维护**
  * 将自动化工作流的 Python 运行环境升级至 3.11。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->