### PR TITLE
feat(screen): 引入显式区域类型

### DIFF
--- a/docs/develop/one_dragon/modules/screen_area_config.md
+++ b/docs/develop/one_dragon/modules/screen_area_config.md
@@ -1,0 +1,139 @@
+## 目标
+
+`ScreenArea` 使用显式类型描述框架如何处理区域，保存时按类型输出对应字段，不再根据字段是否为空或是否等于当前默认值猜测哪些数据有用。
+
+区域类型固定为：
+
+| 类型 | 含义 | 类型字段 |
+| --- | --- | --- |
+| `none` | 没有框架内置识别方式，可用于点击、拖动、裁剪或自定义处理 | 无 |
+| `text` | 文本区域，可作为固定文本匹配目标或动态 OCR 搜索范围 | `text`、`lcs_percent`、`color_range` |
+| `template` | 模板匹配区域 | `template_sub_dir`、`template_id`、`template_match_threshold` |
+
+公共字段包括：
+
+- `area_name`
+- `area_type`
+- `pc_rect`
+- `id_mark`
+- `goto_list`
+- `gamepad_key`
+
+`color_range` 只表示文本识别前的颜色过滤，不提供独立的颜色区域识别。
+
+## 类型与可匹配能力
+
+区域属于某个类型，不代表它一定能自行匹配。代码使用 `can_match` 单独判断：
+
+- `text`：`text` 非空时可自行匹配。
+- `template`：`template_id` 非空时可自行匹配。
+- `none`：不能自行匹配。
+
+动态文本区域仍然是 `text`，但可以没有固定 `text`。这类区域用于限定 OCR 搜索范围或提供 OCR 颜色过滤，不能作为有效的 `id_mark`，也不会被画面匹配当成命中项。
+
+## YAML 示例
+
+### 无内置识别
+
+```yaml
+- area_name: 按钮-退出
+  area_type: none
+  pc_rect: [1730, 206, 1794, 266]
+```
+
+### 固定文本
+
+```yaml
+- area_name: 标题
+  area_type: text
+  id_mark: true
+  pc_rect: [100, 100, 300, 150]
+  text: 快捷手册
+  lcs_percent: 0.5
+  color_range:
+  - [230, 230, 230]
+  - [255, 255, 255]
+```
+
+### 动态文本范围
+
+```yaml
+- area_name: 列表范围
+  area_type: text
+  pc_rect: [1220, 35, 1770, 110]
+  lcs_percent: 0.5
+```
+
+### 模板
+
+```yaml
+- area_name: 返回
+  area_type: template
+  id_mark: true
+  pc_rect: [20, 20, 80, 80]
+  template_sub_dir: menu
+  template_id: back
+  template_match_threshold: 0.7
+```
+
+## 旧配置读取规则
+
+缺少 `area_type` 时按已有识别字段推断：
+
+1. `text` 非空：`text`。
+2. `template_id` 非空：`template`。
+3. 其它情况：`none`。
+
+旧名称 `click` 和 `ocr` 仅在读取时分别兼容为 `none` 和 `text`，保存时统一写新名称。
+
+没有固定文本的旧区域无法仅靠数据判断它是动态 OCR 范围还是普通裁剪范围。确实需要动态 OCR 参数的区域，应在配置中显式写 `area_type: text`。
+
+## 保存规则
+
+`ScreenArea.to_dict()` 始终写出：
+
+- `area_name`
+- `area_type`
+- `pc_rect`
+
+按需写出公共字段：
+
+- `id_mark`：仅为 `true` 时写出。运行时只把 `can_match` 为 `true` 的标识区域纳入精准匹配。
+- `goto_list`：仅非空时写出。
+- `gamepad_key`：仅非空时写出。
+
+按类型写出识别字段：
+
+- `none`：不写识别字段。
+- `text`：`text` 非空时写出；始终写 `lcs_percent`；`color_range` 非空时写出。
+- `template`：`template_sub_dir`、`template_id` 非空时写出；始终写 `template_match_threshold`。
+
+数值参数即使等于当前默认值也必须保存，例如 `lcs_percent: 0.5` 和 `template_match_threshold: 0.7`。这些值是当前区域的有效配置，不能因为碰巧等于代码默认值就省略，否则配置行为会依赖未来默认值。
+
+保存时会裁剪其它类型的字段。切换类型后，界面内存可以暂时保留旧字段，最终 YAML 只保留当前类型的数据。
+
+## 匹配行为
+
+- `find_area_in_screen`、`find_area_in_screen_binary` 和 `find_area_with_detail` 只处理具备完整匹配条件的 `text`、`template`。
+- `find_and_click_area` 对可匹配的 `text`、`template` 先匹配再点击；配置不完整时不点击。`none` 保持直接点击区域中心的定位语义。
+- `find_screen_matches` 只把 `id_mark` 且 `can_match` 的区域纳入精准匹配条件。
+- `none` 和配置不完整的区域不会被当成匹配成功。
+
+## 画面管理与后端
+
+画面管理表格只展示公共字段，类型参数在独立编辑区显示：
+
+- `text`：目标文本、文本阈值、OCR 颜色范围。
+- `template`：模板目录、模板 ID、模板阈值。
+- `none`：不显示识别参数。
+
+后端和 MCP 的 `upsert_screen_area` 支持 `area_type`。为了兼容旧调用，`area_type=None` 时使用旧配置推断规则。
+
+## 验证重点
+
+- 三种类型和旧名称兼容读取正确。
+- 动态文本区域不参与普通画面匹配和查找点击。
+- 当前类型的默认数值参数仍被写出。
+- `none` 不写文本、模板或颜色过滤参数。
+- 显式 `null` 的文本和模板阈值回退到兼容默认值。
+- 保存再加载不会丢失当前类型的有效字段。

--- a/docs/develop/zzz/backend/mcp.md
+++ b/docs/develop/zzz/backend/mcp.md
@@ -11,7 +11,7 @@
 | `check_game_window` | `backend.check_window()` | `WindowStatus`（结构化 JSON；backend 抛错时返 `{'error': ...}`） |
 | `capture_game_screen` | `backend.capture()` | 截图绝对路径（落盘 `.debug/zzz_od_mcp/screenshot/`） |
 | `analyze_screen(screenshot=None, save_image=False)` | `backend.analyze()` | `AnalyzeScreenResult`（结构化 JSON；实时 + `save_image=True` 多回传 `screenshot_path`；success 时带 `vision_hint` 能力边界提示） |
-| `upsert_screen_area(screen_name, area_name, pc_rect, ...)` | `backend.upsert_screen_area()` | `{success, action(inserted/updated), area_count, error}`（写 yml + reload） |
+| `upsert_screen_area(screen_name, area_name, pc_rect, area_type=None, ...)` | `backend.upsert_screen_area()` | `{success, action(inserted/updated), area_count, error}`（支持 `none/text/template`，写 yml + reload） |
 | `delete_screen_area(screen_name, area_name)` | `backend.delete_screen_area()` | `{success, action(deleted), area_count, error}`（写 yml + reload） |
 | `open_game(enter=True, block=True)` | `backend.start_run('mcp', op_factory)`（`enter=False`→`OpenGame`，`enter=True`→`OpenAndEnterGame`） | `block=True`：结果文本；`block=False`：已启动 JSON；并发拒绝时返错误 JSON |
 | `click_game(x, y, press_time=0.1, pc_alt=False)` | `backend.click_game()` | `{success, x, y, in_window, pc_alt}`（坐标不在窗口内 → `in_window=False`；`pc_alt=True` 大世界等锁光标画面点击前需按 Alt 解锁） |

--- a/src/one_dragon/base/screen/screen_area.py
+++ b/src/one_dragon/base/screen/screen_area.py
@@ -1,7 +1,17 @@
+from enum import StrEnum
+
 import numpy as np
 
 from one_dragon.base.geometry.point import Point
 from one_dragon.base.geometry.rectangle import Rect
+
+
+class ScreenAreaType(StrEnum):
+    """画面区域类型。"""
+
+    NONE = 'none'
+    TEXT = 'text'
+    TEMPLATE = 'template'
 
 
 class ScreenArea:
@@ -9,6 +19,7 @@ class ScreenArea:
     def __init__(
         self,
         area_name: str = '',
+        area_type: ScreenAreaType | str | None = None,
         pc_rect: Rect | None = None,
         text: str = '',
         lcs_percent: float = 0.5,
@@ -20,19 +31,42 @@ class ScreenArea:
         goto_list: list[str] | None = None,
         color_range: list[list[int]] | None = None,
         gamepad_key: str | None = None,
-    ):
+    ) -> None:
         self.area_name: str = area_name or ''
         self.pc_rect: Rect = pc_rect if pc_rect is not None else Rect(0, 0, 0, 0)
         self.text: str = text or ''
-        self.lcs_percent: float = lcs_percent
+        self.lcs_percent: float = 0.5 if lcs_percent is None else lcs_percent
         self.template_id: str = template_id or ''
         self.template_sub_dir: str = template_sub_dir or ''
-        self.template_match_threshold: float = template_match_threshold
+        self.template_match_threshold: float = 0.7 if template_match_threshold is None else template_match_threshold
         self.pc_alt: bool = pc_alt  # PC端需要使用ALT后才能点击
         self.id_mark: bool = id_mark  # 是否用于画面的唯一标识
-        self.goto_list: list[str] = [] if goto_list is None else goto_list  # 交互后 可能会跳转的画面名称列表
-        self.color_range: list[list[int]] | None = color_range  # 识别时候的筛选的颜色范围 文本时候有效
+        self.goto_list: list[str] = [] if goto_list is None else goto_list  # 交互后可能会跳转的画面名称列表
+        self.color_range: list[list[int]] | None = color_range  # OCR识别前的颜色过滤范围
         self.gamepad_key: str | None = gamepad_key  # GamepadActionEnum 动作名 如 'menu', 'compendium'
+        self._area_type: ScreenAreaType = self._init_area_type(area_type)
+
+    def _init_area_type(self, area_type: ScreenAreaType | str | None) -> ScreenAreaType:
+        """初始化区域类型，兼容旧名称并推断旧配置。"""
+        if area_type is not None:
+            if area_type == 'click':
+                return ScreenAreaType.NONE
+            if area_type == 'ocr':
+                return ScreenAreaType.TEXT
+            return ScreenAreaType(area_type)
+        if self.text:
+            return ScreenAreaType.TEXT
+        if self.template_id:
+            return ScreenAreaType.TEMPLATE
+        return ScreenAreaType.NONE
+
+    @property
+    def area_type(self) -> ScreenAreaType:
+        return self._area_type
+
+    @area_type.setter
+    def area_type(self, area_type: ScreenAreaType | str) -> None:
+        self._area_type = self._init_area_type(area_type)
 
     @property
     def rect(self) -> Rect:
@@ -76,53 +110,55 @@ class ScreenArea:
 
     @property
     def is_text_area(self) -> bool:
-        """
-        是否文本区域
-        :return:
-        """
-        return len(self.text) > 0
+        """是否文本区域。"""
+        return self.area_type == ScreenAreaType.TEXT
 
     @property
     def is_template_area(self) -> bool:
-        """
-        是否模板区域
-        :return:
-        """
-        return len(self.template_id) > 0
+        """是否模板区域。"""
+        return self.area_type == ScreenAreaType.TEMPLATE
+
+    @property
+    def can_match(self) -> bool:
+        """区域是否具备框架内置匹配所需的完整条件。"""
+        if self.is_text_area:
+            return bool(self.text)
+        if self.is_template_area:
+            return bool(self.template_id)
+        return False
 
     @property
     def color_range_lower(self) -> np.ndarray:
         if self.color_range is None or len(self.color_range) < 1:
             return np.array([0, 0, 0], dtype=np.uint8)
-        else:
-            return np.array(self.color_range[0], dtype=np.uint8)
+        return np.array(self.color_range[0], dtype=np.uint8)
 
     @property
     def color_range_upper(self) -> np.ndarray:
         if self.color_range is None or len(self.color_range) < 2:
             return np.array([255, 255, 255], dtype=np.uint8)
-        else:
-            return np.array(self.color_range[1], dtype=np.uint8)
+        return np.array(self.color_range[1], dtype=np.uint8)
 
     def to_dict(self) -> dict:
-        """转为可序列化字典，跳过与默认值一致的字段以精简 YAML。"""
+        """按区域类型输出配置，只裁剪缺失字段和其它类型的字段。"""
         order_dict: dict = {}
         order_dict['area_name'] = self.area_name
-        order_dict['pc_rect'] = [self.pc_rect.x1, self.pc_rect.y1, self.pc_rect.x2, self.pc_rect.y2]
+        order_dict['area_type'] = self.area_type.value
         if self.id_mark:
             order_dict['id_mark'] = self.id_mark
-        if self.text:
-            order_dict['text'] = self.text
-        if self.lcs_percent != 0.5:
+        order_dict['pc_rect'] = [self.pc_rect.x1, self.pc_rect.y1, self.pc_rect.x2, self.pc_rect.y2]
+        if self.is_text_area:
+            if self.text:
+                order_dict['text'] = self.text
             order_dict['lcs_percent'] = self.lcs_percent
-        if self.template_sub_dir:
-            order_dict['template_sub_dir'] = self.template_sub_dir
-        if self.template_id:
-            order_dict['template_id'] = self.template_id
-        if self.template_match_threshold != 0.7:
+            if self.color_range:
+                order_dict['color_range'] = self.color_range
+        elif self.is_template_area:
+            if self.template_sub_dir:
+                order_dict['template_sub_dir'] = self.template_sub_dir
+            if self.template_id:
+                order_dict['template_id'] = self.template_id
             order_dict['template_match_threshold'] = self.template_match_threshold
-        if self.color_range:
-            order_dict['color_range'] = self.color_range
         if self.goto_list:
             order_dict['goto_list'] = self.goto_list
         if self.gamepad_key:

--- a/src/one_dragon/base/screen/screen_info.py
+++ b/src/one_dragon/base/screen/screen_info.py
@@ -25,6 +25,7 @@ class ScreenInfo:
             pc_rect = data_area.get('pc_rect')
             area = ScreenArea(
                 area_name=data_area.get('area_name', ''),
+                area_type=data_area.get('area_type'),
                 pc_rect=Rect(pc_rect[0], pc_rect[1], pc_rect[2], pc_rect[3]),
                 text=data_area.get('text', ''),
                 lcs_percent=(

--- a/src/one_dragon/base/screen/screen_match.py
+++ b/src/one_dragon/base/screen/screen_match.py
@@ -26,12 +26,7 @@ if TYPE_CHECKING:
 
 
 class AreaType(str, Enum):
-    """画面区域类型(str Enum,序列化为 'text'/'template')。
-
-    Attributes:
-        TEXT: 文本区域(OCR 识别)。
-        TEMPLATE: 模板区域(模板匹配)。
-    """
+    """已命中的画面区域类型。"""
 
     TEXT = 'text'
     TEMPLATE = 'template'
@@ -49,7 +44,7 @@ class AreaMatchDetail:
         width: 命中宽度。
         height: 命中高度。
         text: 文本区域实际命中文本(模板区域为 None)。
-        confidence: 置信度(文本=ocr score,模板=匹配度)。
+        confidence: 置信度(文本=OCR 得分，模板=匹配度)。
     """
 
     area_name: str
@@ -95,8 +90,10 @@ def find_area_with_detail(
         crop_first: 是否先裁剪再 OCR,默认 False(全图缓存复用)。
 
     Returns:
-        命中详情;纯定位区域或未命中返 None。
+        命中详情;纯定位区域、配置不完整或未命中返 None。
     """
+    if not area.can_match:
+        return None
     if area.is_text_area:
         ocr_result_list: list[OcrMatchResult] = ctx.ocr_service.get_ocr_result_list(
             image=screen,
@@ -223,7 +220,7 @@ def find_screen_matches(
             if detail is not None:
                 hit_details.append(detail)
                 hit_names.add(area.area_name)
-        id_mark_names = {a.area_name for a in screen_info.area_list if a.id_mark}
+        id_mark_names = {a.area_name for a in screen_info.area_list if a.id_mark and a.can_match}
         is_precise = len(id_mark_names) > 0 and id_mark_names.issubset(hit_names)
         if is_precise:
             return [ScreenMatch(screen_name=name, is_precise=True, areas=hit_details)]

--- a/src/one_dragon/base/screen/screen_utils.py
+++ b/src/one_dragon/base/screen/screen_utils.py
@@ -467,7 +467,7 @@ def is_target_screen(
     existed_id_mark: bool = False
     fit_id_mark: bool = True
     for screen_area in screen_info.area_list:
-        if not screen_area.id_mark:
+        if not screen_area.id_mark or not screen_area.can_match:
             continue
         existed_id_mark = True
 

--- a/src/one_dragon/base/screen/screen_utils.py
+++ b/src/one_dragon/base/screen/screen_utils.py
@@ -100,6 +100,8 @@ def find_area_in_screen_binary(
     """
     if area is None:
         return FindAreaResultEnum.AREA_NO_CONFIG
+    if not area.can_match:
+        return FindAreaResultEnum.FALSE
 
     # 对屏幕进行二值化处理
     binary_screen = cv2_utils.to_binary(screen, threshold=binary_threshold)
@@ -155,6 +157,8 @@ def find_area_in_screen(
     """
     if area is None:
         return FindAreaResultEnum.AREA_NO_CONFIG
+    if not area.can_match:
+        return FindAreaResultEnum.FALSE
 
     find: bool = False
     if area.is_text_area:
@@ -175,7 +179,6 @@ def find_area_in_screen(
         mrl = ctx.tm.crop_and_match_template(screen, rect, area.template_sub_dir, area.template_id,
                                              threshold=area.template_match_threshold)
         find = mrl.max is not None
-
     return FindAreaResultEnum.TRUE if find else FindAreaResultEnum.FALSE
 
 
@@ -251,6 +254,8 @@ def find_and_click_area(
     area: ScreenArea = ctx.screen_loader.get_area(screen_name, area_name)
     if area is None:
         return OcrClickResultEnum.AREA_NO_CONFIG
+    if (area.is_text_area or area.is_template_area) and not area.can_match:
+        return OcrClickResultEnum.OCR_CLICK_NOT_FOUND
     if area.is_text_area:
         ocr_result_list = ctx.ocr_service.get_ocr_result_list(
             image=screen,

--- a/src/one_dragon/base/screen/设计文档.md
+++ b/src/one_dragon/base/screen/设计文档.md
@@ -149,12 +149,15 @@ def is_target_screen(ctx: OneDragonContext, screen: MatLike,
     """判断当前截图是否为目标画面"""
     screen_info = ctx.screen_loader.get_screen(screen_name)
     
-    # 检查所有标识区域
+    # 只检查具备内置匹配条件的标识区域
+    existed_id_mark = False
     for area in screen_info.area_list:
-        if area.id_mark:  # 画面唯一标识区域
-            if not find_area_in_screen(ctx, screen, area):
-                return False
-    return True
+        if not area.id_mark or not area.can_match:
+            continue
+        existed_id_mark = True
+        if not find_area_in_screen(ctx, screen, area):
+            return False
+    return existed_id_mark
 ```
 
 #### 3.3.2 最佳画面匹配

--- a/src/one_dragon/base/screen/设计文档.md
+++ b/src/one_dragon/base/screen/设计文档.md
@@ -83,12 +83,17 @@ sequenceDiagram
 
 #### 3.1.2 ScreenArea（画面区域）
 - **area_name**: 区域名称
+- **area_type**: 区域类型，支持 `none`、`text`、`template`
 - **pc_rect**: 区域坐标矩形
-- **text**: 文本识别内容（文本区域）
-- **template_id**: 模板标识（模板区域）
-- **id_mark**: 是否为画面唯一标识区域
+- **text**: 固定目标文本；`text` 类型可留空作为动态 OCR 范围
+- **lcs_percent**: 文本匹配阈值，仅 `text` 类型生效
+- **color_range**: OCR 前的颜色过滤范围，仅 `text` 类型生效
+- **template_id**: 模板标识，仅 `template` 类型生效
+- **template_match_threshold**: 模板匹配阈值，仅 `template` 类型生效
+- **id_mark**: 是否为画面唯一标识区域，仅可自行匹配的区域有效
 - **goto_list**: 点击后可能跳转的画面列表
-- **color_range**: 颜色筛选范围
+
+区域类型和匹配能力分开判断：动态文本区域属于 `text`，但没有固定目标文本时 `can_match` 为 `false`，不会参与画面匹配。
 
 ### 3.2 识别技术
 
@@ -245,6 +250,8 @@ def find_and_click_area(ctx: OneDragonContext, screen: MatLike,
     """在画面中找到指定区域并点击"""
     area = ctx.screen_loader.get_area(screen_name, area_name)
     
+    if (area.is_text_area or area.is_template_area) and not area.can_match:
+        return OcrClickResultEnum.OCR_CLICK_NOT_FOUND
     if area.is_text_area:
         # OCR识别并点击
         return ocr_click_logic(ctx, screen, area)
@@ -252,7 +259,7 @@ def find_and_click_area(ctx: OneDragonContext, screen: MatLike,
         # 模板匹配并点击
         return template_click_logic(ctx, screen, area)
     else:
-        # 直接点击区域中心
+        # none 类型直接点击区域中心
         return direct_click_logic(ctx, area)
 ```
 
@@ -397,7 +404,7 @@ def check_level_text(self) -> OperationRoundResult:
 4. **跳转关系**：准确配置goto_list，确保路径规划正确
 
 ### 9.2 识别优化建议
-1. **颜色筛选**：对于特定颜色的文本，使用color_range提高识别精度
+1. **颜色筛选**：文本识别使用 `color_range` 提高精度
 2. **模板质量**：使用高质量的模板图像，避免背景干扰
 3. **区域大小**：合理设置识别区域大小，避免过大或过小
 4. **多重验证**：对关键画面使用多个标识区域提高可靠性

--- a/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
+++ b/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
@@ -30,7 +30,7 @@ from qfluentwidgets import (
 from one_dragon.base.config.config_item import ConfigItem
 from one_dragon.base.geometry.rectangle import Rect
 from one_dragon.base.operation.one_dragon_context import OneDragonContext
-from one_dragon.base.screen.screen_area import ScreenArea
+from one_dragon.base.screen.screen_area import ScreenArea, ScreenAreaType
 from one_dragon.base.screen.screen_info import ScreenInfo
 from one_dragon.base.screen.template_info import (
     TemplateInfo,
@@ -43,6 +43,7 @@ from one_dragon.utils.i18_utils import gt
 from one_dragon.utils.log_utils import log
 from one_dragon_qt.mixins.history_mixin import HistoryMixin
 from one_dragon_qt.utils.layout_utils import Margins
+from one_dragon_qt.widgets.combo_box import ComboBox
 from one_dragon_qt.widgets.cv2_image import Cv2Image
 from one_dragon_qt.widgets.editable_combo_box import EditableComboBox
 from one_dragon_qt.widgets.fast_scroll_area import FastScrollArea
@@ -91,20 +92,47 @@ def _parse_color_range(text: str) -> list[list[int]] | None:
     raise ValueError(f'需要 [[r,g,b],[r,g,b]]，实际: {val}')
 
 
+AREA_TYPE_LABEL_MAP: dict[ScreenAreaType, str] = {
+    ScreenAreaType.NONE: '无内置识别',
+    ScreenAreaType.TEXT: '文本',
+    ScreenAreaType.TEMPLATE: '模板',
+}
+AREA_TYPE_ITEMS: list[ConfigItem] = [
+    ConfigItem(label, area_type)
+    for area_type, label in AREA_TYPE_LABEL_MAP.items()
+]
+
+
+def _parse_area_type(text: str) -> ScreenAreaType:
+    """解析区域类型。"""
+    stripped = text.strip()
+    for area_type, label in AREA_TYPE_LABEL_MAP.items():
+        if stripped in (area_type.value, label):
+            return area_type
+    raise ValueError(f'未知区域类型: {text}')
+
+
+def _format_area_type(area_type: ScreenAreaType | str) -> str:
+    """格式化区域类型。"""
+    try:
+        return AREA_TYPE_LABEL_MAP[ScreenAreaType(area_type)]
+    except (TypeError, ValueError):
+        return str(area_type)
+
+
+def _format_color_range(color_range: list[list[int]] | None) -> str:
+    """格式化颜色范围。"""
+    return '' if color_range is None else str(color_range)
+
+
 class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
     AREA_COLUMNS: list[ColumnMeta] = [
         ColumnMeta('操作', width=40),
         ColumnMeta('标识', width=40),
+        ColumnMeta('类型', 'area_type', _parse_area_type, 110, _format_area_type),
         ColumnMeta('区域名称', 'area_name', lambda x: x),
-        ColumnMeta('位置', 'pc_rect', _parse_rect, 200),
-        ColumnMeta('OCR文本', 'text', lambda x: x),
-        ColumnMeta('OCR阈值', 'lcs_percent', lambda x: float(x) if x else 0.5, 70),
-        ColumnMeta('模板目录', 'template_sub_dir', lambda x: x),
-        ColumnMeta('模板ID', 'template_id', lambda x: x),
-        ColumnMeta('模板阈值', 'template_match_threshold', lambda x: float(x) if x else 0.7, 70),
-        ColumnMeta('颜色范围', 'color_range', _parse_color_range,
-                   formatter=lambda v: '' if v is None else str(v)),
+        ColumnMeta('位置', 'pc_rect', _parse_rect, 170),
         ColumnMeta('前往画面', 'goto_list', lambda x: [i.strip() for i in x.split(',') if i.strip()],
                    formatter=lambda v: ','.join(v) if v else ''),
         ColumnMeta('手柄键', 'gamepad_key', lambda x: x.strip() or None, 120,
@@ -112,6 +140,19 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
     ]
 
     AREA_FIELD_2_COLUMN: dict[str, int] = {col.display_name: idx for idx, col in enumerate(AREA_COLUMNS)}
+    AREA_PARAM_PARSERS: dict[str, Callable[[str], Any]] = {
+        'area_type': _parse_area_type,
+        'area_name': lambda x: x,
+        'pc_rect': _parse_rect,
+        'text': lambda x: x,
+        'lcs_percent': lambda x: float(x) if x else 0.5,
+        'template_sub_dir': lambda x: x,
+        'template_id': lambda x: x,
+        'template_match_threshold': lambda x: float(x) if x else 0.7,
+        'color_range': _parse_color_range,
+        'goto_list': lambda x: [i.strip() for i in x.split(',') if i.strip()],
+        'gamepad_key': lambda x: x.strip() or None,
+    }
 
     def __init__(self, ctx: OneDragonContext, parent=None):
         VerticalScrollInterface.__init__(
@@ -127,6 +168,9 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
         self.chosen_screen: ScreenInfo | None = None
         self.last_screen_dir: str | None = None  # 上一次选择的图片路径
+        self.area_param_rows: dict[str, QWidget] = {}
+        self.area_param_inputs: dict[str, LineEdit] = {}
+        self._updating_area_param: bool = False
 
         self._whole_update = ScreenInfoWorker()
         self._whole_update.signal.connect(self._update_display_by_screen)
@@ -282,12 +326,46 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         self.area_table.horizontalHeader().sectionResized.connect(self._on_table_column_resized)
 
         # table的行被选中时 触发
-        self.area_table_row_selected: int = -1  # 选中的行
+        self.area_table_row_selected: int | None = -1  # 选中的行
         self.area_table.cellClicked.connect(self.on_area_table_cell_clicked)
 
         # 将表格放入滚动区域
         scroll_area.setWidget(self.area_table)
         layout.addWidget(scroll_area)
+        layout.addWidget(self._init_area_param_widget())
+
+        return widget
+
+    def _init_area_param_widget(self) -> QWidget:
+        """创建区域类型参数控件。"""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(12, 0, 12, 12)
+        layout.setSpacing(6)
+
+        title_label = BodyLabel(text=gt('区域参数'))
+        layout.addWidget(title_label)
+
+        param_meta_list = [
+            ('text', '目标文本'),
+            ('lcs_percent', '文本阈值'),
+            ('color_range', 'OCR颜色范围'),
+            ('template_sub_dir', '模板目录'),
+            ('template_id', '模板ID'),
+            ('template_match_threshold', '模板阈值'),
+        ]
+
+        for attr_name, label_text in param_meta_list:
+            row = Row(spacing=8, margins=Margins(0, 0, 0, 0))
+            label = BodyLabel(text=gt(label_text))
+            label.setFixedWidth(88)
+            editor = LineEdit()
+            editor.editingFinished.connect(lambda attr=attr_name: self._on_area_param_changed(attr))
+            row.add_widget(label)
+            row.add_widget(editor, stretch=1)
+            layout.addWidget(row)
+            self.area_param_rows[attr_name] = row
+            self.area_param_inputs[attr_name] = editor
 
         return widget
 
@@ -446,6 +524,13 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
             for col_idx, col in enumerate(self.AREA_COLUMNS):
                 if col.attr_name is None:
                     continue
+                if col.attr_name == 'area_type':
+                    area_type_combo = ComboBox()
+                    area_type_combo.set_items(AREA_TYPE_ITEMS, area_item.area_type)
+                    area_type_combo.setProperty('row_idx', idx)
+                    area_type_combo.currentIndexChanged.connect(self._on_area_type_changed)
+                    self.area_table.setCellWidget(idx, col_idx, area_type_combo)
+                    continue
                 val = getattr(area_item, col.attr_name)
                 text = col.formatter(val) if col.formatter else str(val)
                 self.area_table.setItem(idx, col_idx, QTableWidgetItem(text))
@@ -456,9 +541,11 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         add_btn.clicked.connect(self._on_area_add_clicked)
         self.area_table.setCellWidget(area_cnt, 0, add_btn)
         for col_idx in range(1, len(self.AREA_COLUMNS)):
+            self.area_table.removeCellWidget(area_cnt, col_idx)
             self.area_table.setItem(area_cnt, col_idx, QTableWidgetItem(''))
 
         self.area_table.blockSignals(False)
+        self._update_area_param_display()
 
     def _update_image_display(self):
         """更新图片显示。"""
@@ -642,6 +729,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
                                 min(self.ctx.project_config.screen_standard_height, p2.y + 10))
         area.template_sub_dir = sub_dir
         area.template_id = template_id
+        area.area_type = ScreenAreaType.TEMPLATE
 
         self.chosen_screen.area_list.append(area)
         self._area_table_update.signal.emit()
@@ -672,6 +760,117 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         self.chosen_screen.area_list.append(ScreenArea())
         self._area_table_update.signal.emit()
 
+    def _get_selected_area(self) -> ScreenArea | None:
+        """获取当前选中的区域。"""
+        if self.chosen_screen is None:
+            return None
+        if self.area_table_row_selected is None:
+            return None
+        if self.area_table_row_selected < 0 or self.area_table_row_selected >= len(self.chosen_screen.area_list):
+            return None
+        return self.chosen_screen.area_list[self.area_table_row_selected]
+
+    def _on_area_type_changed(self, _index: int) -> None:
+        """区域类型变化。"""
+        if self.chosen_screen is None:
+            return
+        combo: ComboBox = self.sender()
+        if combo is None:
+            return
+
+        row_idx = combo.property('row_idx')
+        if row_idx is None or row_idx < 0 or row_idx >= len(self.chosen_screen.area_list):
+            return
+
+        area_item = self.chosen_screen.area_list[row_idx]
+        new_value = combo.currentData()
+        if new_value is None or new_value == area_item.area_type:
+            return
+
+        old_value = area_item.area_type
+        area_item.area_type = new_value
+        self.area_table_row_selected = row_idx
+
+        table_change = {
+            'type': 'table_edit',
+            'row_index': row_idx,
+            'change_type': 'area_type',
+            'old_value': old_value,
+            'new_value': new_value,
+        }
+        self._add_history_record(table_change)
+        self._update_area_param_display()
+
+    def _update_area_param_display(self) -> None:
+        """根据选中区域类型更新参数编辑区。"""
+        if not self.area_param_inputs:
+            return
+
+        area_item = self._get_selected_area()
+        visible_map = {
+            'text': area_item is not None and area_item.is_text_area,
+            'lcs_percent': area_item is not None and area_item.is_text_area,
+            'color_range': area_item is not None and area_item.is_text_area,
+            'template_sub_dir': area_item is not None and area_item.is_template_area,
+            'template_id': area_item is not None and area_item.is_template_area,
+            'template_match_threshold': area_item is not None and area_item.is_template_area,
+        }
+
+        self._updating_area_param = True
+        for attr_name, row in self.area_param_rows.items():
+            row.setVisible(visible_map.get(attr_name, False))
+            editor = self.area_param_inputs[attr_name]
+            if area_item is None:
+                editor.setText('')
+                continue
+            value = getattr(area_item, attr_name)
+            if attr_name == 'color_range':
+                text = _format_color_range(value)
+            else:
+                text = '' if value is None else str(value)
+            editor.setText(text)
+        self._updating_area_param = False
+
+    def _on_area_param_changed(self, attr_name: str) -> None:
+        """区域参数变化。"""
+        if self._updating_area_param:
+            return
+
+        area_item = self._get_selected_area()
+        if area_item is None:
+            return
+
+        editor = self.area_param_inputs[attr_name]
+        text = editor.text().strip()
+        parser = self._get_attr_parser(attr_name)
+        old_value = getattr(area_item, attr_name)
+
+        try:
+            new_value = parser(text) if parser is not None else text
+        except Exception as e:
+            log.error('解析失败', exc_info=True)
+            self.show_info_bar(
+                '解析失败',
+                f'{attr_name}: {e}',
+                icon=InfoBarIcon.ERROR,
+                duration=5000,
+            )
+            self._update_area_param_display()
+            return
+
+        if new_value == old_value:
+            return
+
+        setattr(area_item, attr_name, new_value)
+        table_change = {
+            'type': 'table_edit',
+            'row_index': self.area_table_row_selected,
+            'change_type': attr_name,
+            'old_value': old_value,
+            'new_value': text,
+        }
+        self._add_history_record(table_change)
+
     def _on_row_delete_clicked(self):
         """删除一行。"""
         if self.chosen_screen is None:
@@ -684,14 +883,21 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
             self.area_table.removeRow(row_idx)
             self._image_update.signal.emit()
 
+    def _get_attr_parser(self, attr_name: str) -> Callable[[str], Any] | None:
+        """获取字段解析器。"""
+        return self.AREA_PARAM_PARSERS.get(attr_name)
+
     def _on_area_table_cell_changed(self, row: int, column: int) -> None:
         """表格内容改变。"""
         if self.chosen_screen is None:
             return
         if row < 0 or row >= len(self.chosen_screen.area_list):
             return
+        item = self.area_table.item(row, column)
+        if item is None:
+            return
         area_item = self.chosen_screen.area_list[row]
-        text = self.area_table.item(row, column).text().strip()
+        text = item.text().strip()
 
         # 直接从 AREA_COLUMNS 获取属性名和解析器
         if column >= len(self.AREA_COLUMNS):
@@ -700,14 +906,14 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         if col_meta.attr_name is None:
             return
         attr_name = col_meta.attr_name
-        handler = col_meta.parser
+        handler = self._get_attr_parser(attr_name)
 
         # 记录修改前的状态
         old_value = getattr(area_item, attr_name)
 
         # 应用新值
         try:
-            new_value = handler(text)
+            new_value = handler(text) if handler is not None else text
             setattr(area_item, attr_name, new_value)
             if attr_name == 'pc_rect':
                 self._image_update.signal.emit()
@@ -790,6 +996,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         else:
             self.area_table_row_selected = row
         self._update_image_display()
+        self._update_area_param_display()
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """
@@ -842,6 +1049,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
             # 更新表格显示
             self._update_area_table_display()
+            self._update_area_param_display()
 
         else:
             # 处理拖框操作的撤回
@@ -863,6 +1071,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
             # 更新图像显示
             self._image_update.signal.emit()
+            self._update_area_param_display()
 
     def _apply_redo(self, change_record: dict[str, Any]) -> None:
         """
@@ -884,7 +1093,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
             area_item = self.chosen_screen.area_list[row_index]
 
             # 将文本恢复为正确类型
-            parser = next((col.parser for col in self.AREA_COLUMNS if col.attr_name == change_type), None)
+            parser = self._get_attr_parser(change_type)
             parsed = parser(new_value) if parser else new_value
             setattr(area_item, change_type, parsed)
 
@@ -893,6 +1102,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
             # 更新表格显示
             self._area_table_update.signal.emit()
+            self._update_area_param_display()
 
         else:
             # 处理拖框操作的恢复
@@ -914,6 +1124,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
             # 更新图像显示
             self._image_update.signal.emit()
+            self._update_area_param_display()
 
     def _on_merge_clicked(self) -> None:
         self.ctx.screen_loader.reload(from_separated_files=True)

--- a/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
+++ b/src/one_dragon_qt/view/devtools/devtools_screen_manage_interface.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtGui import QKeyEvent
@@ -127,7 +127,7 @@ def _format_color_range(color_range: list[list[int]] | None) -> str:
 
 class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
 
-    AREA_COLUMNS: list[ColumnMeta] = [
+    AREA_COLUMNS: ClassVar[list[ColumnMeta]] = [
         ColumnMeta('操作', width=40),
         ColumnMeta('标识', width=40),
         ColumnMeta('类型', 'area_type', _parse_area_type, 110, _format_area_type),
@@ -139,8 +139,10 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
                    formatter=lambda v: '' if v is None else str(v)),
     ]
 
-    AREA_FIELD_2_COLUMN: dict[str, int] = {col.display_name: idx for idx, col in enumerate(AREA_COLUMNS)}
-    AREA_PARAM_PARSERS: dict[str, Callable[[str], Any]] = {
+    AREA_FIELD_2_COLUMN: ClassVar[dict[str, int]] = {
+        col.display_name: idx for idx, col in enumerate(AREA_COLUMNS)
+    }
+    AREA_PARAM_PARSERS: ClassVar[dict[str, Callable[[str], Any]]] = {
         'area_type': _parse_area_type,
         'area_name': lambda x: x,
         'pc_rect': _parse_rect,
@@ -527,7 +529,6 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
                 if col.attr_name == 'area_type':
                     area_type_combo = ComboBox()
                     area_type_combo.set_items(AREA_TYPE_ITEMS, area_item.area_type)
-                    area_type_combo.setProperty('row_idx', idx)
                     area_type_combo.currentIndexChanged.connect(self._on_area_type_changed)
                     self.area_table.setCellWidget(idx, col_idx, area_type_combo)
                     continue
@@ -778,8 +779,8 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
         if combo is None:
             return
 
-        row_idx = combo.property('row_idx')
-        if row_idx is None or row_idx < 0 or row_idx >= len(self.chosen_screen.area_list):
+        row_idx = self.area_table.indexAt(combo.pos()).row()
+        if row_idx < 0 or row_idx >= len(self.chosen_screen.area_list):
             return
 
         area_item = self.chosen_screen.area_list[row_idx]
@@ -796,7 +797,7 @@ class DevtoolsScreenManageInterface(VerticalScrollInterface, HistoryMixin):
             'row_index': row_idx,
             'change_type': 'area_type',
             'old_value': old_value,
-            'new_value': new_value,
+            'new_value': new_value.value,
         }
         self._add_history_record(table_change)
         self._update_area_param_display()

--- a/src/zzz_od/backend/backend_context.py
+++ b/src/zzz_od/backend/backend_context.py
@@ -31,7 +31,7 @@ from one_dragon.base.operation.application.application_run_context import (
     RunFinishReason,
 )
 from one_dragon.base.operation.operation_base import OperationResult
-from one_dragon.base.screen.screen_area import ScreenArea
+from one_dragon.base.screen.screen_area import ScreenArea, ScreenAreaType
 from one_dragon.base.screen.screen_match import find_screen_matches
 from one_dragon.utils import cv2_utils, debug_utils, os_utils
 from one_dragon.utils.log_utils import mask_text
@@ -581,6 +581,7 @@ class ZzzBackendContext:
         goto_list: list[str] | None = None,
         id_mark: bool = False,
         gamepad_key: str | None = None,
+        area_type: ScreenAreaType | str | None = None,
     ) -> dict:
         """按 area_name 在指定 screen 插入或更新一个 area(写 yml + reload)。操作类。
 
@@ -591,14 +592,15 @@ class ZzzBackendContext:
             screen_name: 目标画面名(中文,对齐 get_screen / analyze 返回)。
             area_name: 区域名(同 screen 内唯一,作匹配键)。
             pc_rect: ``[x1, y1, x2, y2]``,1920×1080 内、x2>x1、y2>y1。
-            text: 文本区域的 OCR 文本(空则非文本区)。
+            text: 文本区域的固定目标文本；动态文本区域可留空。
             lcs_percent: 文本匹配阈值。
             template_sub_dir / template_id: 模板引用;template_id 非空时模板必须存在,否则阻断。
             template_match_threshold: 模板匹配阈值。
-            color_range: 文本颜色筛选 ``[[lower], [upper]]`` 或 None。
+            color_range: 文本识别前的颜色过滤范围。
             goto_list: 交互后可能跳转的画面名列表。
-            id_mark: 是否画面唯一标识。
+            id_mark: 是否画面唯一标识；区域必须可自行匹配。
             gamepad_key: 手柄动作名。
+            area_type: 区域类型；支持 none、text、template，None 表示兼容旧配置推断。
 
         Returns:
             ``{success, screen_name, area_name, action(inserted/updated), area_count, error}``。
@@ -609,18 +611,30 @@ class ZzzBackendContext:
             rect_msg = _validate_pc_rect(pc_rect)
             if rect_msg is not None:
                 return _area_result(False, screen_name, area_name, None, error=rect_msg)
-            if template_id and self._ctx.template_loader.load_template(template_sub_dir, template_id) is None:
-                return _area_result(False, screen_name, area_name, None,
-                                    error=f'模板不存在: {template_sub_dir}/{template_id}')
             area = ScreenArea(
                 area_name=area_name,
+                area_type=area_type,
                 pc_rect=Rect(int(pc_rect[0]), int(pc_rect[1]), int(pc_rect[2]), int(pc_rect[3])),
-                text=text, lcs_percent=lcs_percent,
-                template_id=template_id, template_sub_dir=template_sub_dir,
+                text=text,
+                lcs_percent=lcs_percent,
+                template_id=template_id,
+                template_sub_dir=template_sub_dir,
                 template_match_threshold=template_match_threshold,
-                color_range=color_range, goto_list=goto_list or [],
-                id_mark=id_mark, gamepad_key=gamepad_key,
+                color_range=color_range,
+                goto_list=goto_list or [],
+                id_mark=id_mark,
+                gamepad_key=gamepad_key,
             )
+            if (area.is_template_area and area.template_id
+                    and self._ctx.template_loader.load_template(
+                        area.template_sub_dir,
+                        area.template_id,
+                    ) is None):
+                return _area_result(False, screen_name, area_name, None,
+                                    error=f'模板不存在: {area.template_sub_dir}/{area.template_id}')
+            if id_mark and not area.can_match:
+                return _area_result(False, screen_name, area_name, None,
+                                    error='id_mark 只能用于可自行匹配的文本或模板区域')
             screen_info = self._ctx.screen_loader.get_screen(screen_name)  # 未找到 raise
             action = screen_info.upsert_area(area)
             self._ctx.screen_loader.save_screen(screen_info)

--- a/src/zzz_od/backend/mcp/app.py
+++ b/src/zzz_od/backend/mcp/app.py
@@ -18,7 +18,7 @@ tool 写法（annotations / Field / 返回 / docstring）遵循
 
 import asyncio
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -26,6 +26,14 @@ from pydantic import Field
 
 from one_dragon.utils.log_utils import log
 from zzz_od.backend.backend_context import ZzzBackendContext, _save_screenshot
+from zzz_od.backend.mcp.config_app import (
+    make_add_config_item,
+    make_delete_config_item,
+    make_describe_config,
+    make_get_config,
+    make_list_app_configs,
+    make_set_config,
+)
 from zzz_od.backend.mcp.prompts import (
     register_prompt_tools,
     register_prompts,
@@ -39,14 +47,6 @@ from zzz_od.backend.mcp.service_app import (
     make_run_one_dragon,
     make_run_operation,
     make_run_standalone_app,
-)
-from zzz_od.backend.mcp.config_app import (
-    make_add_config_item,
-    make_delete_config_item,
-    make_describe_config,
-    make_get_config,
-    make_list_app_configs,
-    make_set_config,
 )
 from zzz_od.backend.schemas import AnalyzeScreenResult, RunStatusResult, WindowStatus
 
@@ -207,16 +207,28 @@ def create_mcp_server(backend: ZzzBackendContext, name: str = "zzz_od") -> FastM
 
     @mcp.tool(annotations=ToolAnnotations(title="增改画面区域"))  # 操作类:改 screen_info(写 yml + reload)
     def upsert_screen_area(
-        screen_name: str, area_name: str,
+        screen_name: str,
+        area_name: str,
         pc_rect: Annotated[list[int], Field(description="area 矩形 [x1,y1,x2,y2],1080p 游戏坐标;模板 bbox 建议每边 +10px")],
-        text: str = '', lcs_percent: float = 0.5,
-        template_sub_dir: str = '', template_id: str = '', template_match_threshold: float = 0.7,
-        color_range: list[list[int]] | None = None, goto_list: list[str] | None = None,
-        id_mark: bool = False, gamepad_key: str | None = None,
+        area_type: Annotated[
+            Literal['none', 'text', 'template'] | None,
+            Field(description="区域类型；None 表示按旧字段安全推断"),
+        ] = None,
+        text: str = '',
+        lcs_percent: float = 0.5,
+        color_range: list[list[int]] | None = None,
+        template_sub_dir: str = '',
+        template_id: str = '',
+        template_match_threshold: float = 0.7,
+        goto_list: list[str] | None = None,
+        id_mark: bool = False,
+        gamepad_key: str | None = None,
     ) -> dict:
         """按 area_name 在指定 screen 插入或更新一个 area(写 yml + reload)。操作类,改 screen_info。
 
-        area_name 存在则整体更新,不存在则追加。校验:screen 存在、area_name 非空、pc_rect 合法、
+        area_name 存在则整体更新,不存在则追加。area_type 支持 none、text、template；
+        text 可不填写固定目标，用作动态 OCR 范围，color_range 仅用于文本识别前的颜色过滤。
+        校验:screen 存在、area_name 非空、pc_rect 合法、
         模板引用存在(template_id 非空时)。写回 yml 并 reload,下次 analyze_screen 即生效。无需游戏在线。
 
         Returns:
@@ -224,9 +236,19 @@ def create_mcp_server(backend: ZzzBackendContext, name: str = "zzz_od") -> FastM
         """
         try:
             return backend.upsert_screen_area(
-                screen_name, area_name, pc_rect, text, lcs_percent,
-                template_sub_dir, template_id, template_match_threshold,
-                color_range, goto_list, id_mark, gamepad_key,
+                screen_name=screen_name,
+                area_name=area_name,
+                pc_rect=pc_rect,
+                text=text,
+                lcs_percent=lcs_percent,
+                template_sub_dir=template_sub_dir,
+                template_id=template_id,
+                template_match_threshold=template_match_threshold,
+                color_range=color_range,
+                goto_list=goto_list,
+                id_mark=id_mark,
+                gamepad_key=gamepad_key,
+                area_type=area_type,
             )
         except Exception as e:  # noqa: BLE001 工具层统一兜底
             return {'success': False, 'screen_name': screen_name, 'area_name': area_name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“无、文本、模板”三种屏幕区域类型，支持更灵活的识别与点击配置。
  * 屏幕管理界面支持类型切换、参数编辑、校验、错误提示及撤销/重做。
  * 支持动态文本、OCR 颜色筛选及模板匹配参数配置。
  * MCP 配置工具新增区域类型参数，并支持保存与重新加载。

* **兼容性**
  * 兼容旧版配置和历史类型名称，并支持自动推断区域类型。

* **文档**
  * 补充区域类型、匹配规则、配置示例及使用说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->