### PR TITLE
feat(env): 新增 GitCode 镜像源

### DIFF
--- a/config/repository.yml
+++ b/config/repository.yml
@@ -13,6 +13,10 @@ repositories:
       label: Gitee
       url: "https://gitee.com/OneDragon-Anything/ZenlessZoneZero-OneDragon.git"
       use_proxy: false
+    gitcode:
+      label: GitCode
+      url: "https://gitcode.com/gh_mirrors/ze/ZenlessZoneZero-OneDragon.git"
+      use_proxy: false
 env_source:
   default: cnb
   options:


### PR DESCRIPTION
在 repositories 中补充 GitCode 镜像仓库，作为 Git 更新的备选源，无需代理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

**新功能**
- 新增 GitCode 代码仓库镜像选项，用户现在可以从 GitCode 镜像源克隆和管理代码仓库。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->