### PR TITLE
fix(auto_battle): stabilize Remielle long-press inputs

### DIFF
--- a/config/auto_battle/全配队通用.merged.yml
+++ b/config/auto_battle/全配队通用.merged.yml
@@ -10719,7 +10719,35 @@
             "seconds": 0.5
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 5
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-松开"
           "states": "[蕾米埃尔-虚曜]{3,3}"
         - "debug_name": "等待快速支援出现"
           "operations":
@@ -10746,7 +10774,35 @@
             "seconds": 0.5
           - "op_name": "按键-特殊攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 5
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-松开"
           "states": "[蕾米埃尔-浮晖]{100,100}"
         - "debug_name": "其他情况：普通攻击"
           "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"
@@ -21511,7 +21567,35 @@
           "seconds": 0.5
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 5
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-松开"
         "states": "[蕾米埃尔-虚曜]{3,3}"
       - "debug_name": "等待快速支援出现"
         "operations":
@@ -21538,7 +21622,35 @@
           "seconds": 0.5
         - "op_name": "按键-特殊攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 5
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-松开"
         "states": "[蕾米埃尔-浮晖]{100,100}"
       - "debug_name": "其他情况：普通攻击"
         "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"

--- a/config/auto_battle/击破站场-强攻速切.merged.yml
+++ b/config/auto_battle/击破站场-强攻速切.merged.yml
@@ -9740,7 +9740,35 @@
             "seconds": 0.5
           - "op_name": "按键-普通攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 5
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-普通攻击-松开"
           "states": "[蕾米埃尔-虚曜]{3,3}"
         - "debug_name": "等待快速支援出现"
           "operations":
@@ -9767,7 +9795,35 @@
             "seconds": 0.5
           - "op_name": "按键-特殊攻击-按下"
           - "op_name": "等待秒数"
-            "seconds": 5
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-按下"
+          - "op_name": "等待秒数"
+            "seconds": 0.5
+          - "op_name": "按键-特殊攻击-松开"
           "states": "[蕾米埃尔-浮晖]{100,100}"
         - "debug_name": "其他情况：普通攻击"
           "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"

--- a/config/auto_battle/强攻站场-击破支援速切.merged.yml
+++ b/config/auto_battle/强攻站场-击破支援速切.merged.yml
@@ -8809,7 +8809,35 @@
         "seconds": 0.5
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 5
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-松开"
       "states": "[蕾米埃尔-虚曜]{3,3}"
     - "debug_name": "等待快速支援出现"
       "operations":
@@ -8836,7 +8864,35 @@
         "seconds": 0.5
       - "op_name": "按键-特殊攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 5
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-松开"
       "states": "[蕾米埃尔-浮晖]{100,100}"
     - "debug_name": "其他情况：普通攻击"
       "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"
@@ -18642,7 +18698,35 @@
         "seconds": 0.5
       - "op_name": "按键-普通攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 5
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-普通攻击-松开"
       "states": "[蕾米埃尔-虚曜]{3,3}"
     - "debug_name": "等待快速支援出现"
       "operations":
@@ -18669,7 +18753,35 @@
         "seconds": 0.5
       - "op_name": "按键-特殊攻击-按下"
       - "op_name": "等待秒数"
-        "seconds": 5
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-按下"
+      - "op_name": "等待秒数"
+        "seconds": 0.5
+      - "op_name": "按键-特殊攻击-松开"
       "states": "[蕾米埃尔-浮晖]{100,100}"
     - "debug_name": "其他情况：普通攻击"
       "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"

--- a/config/auto_battle/自动守护.merged.yml
+++ b/config/auto_battle/自动守护.merged.yml
@@ -8774,7 +8774,35 @@
           "seconds": 0.5
         - "op_name": "按键-普通攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 5
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-普通攻击-松开"
         "states": "[蕾米埃尔-虚曜]{3,3}"
       - "debug_name": "等待快速支援出现"
         "operations":
@@ -8801,7 +8829,35 @@
           "seconds": 0.5
         - "op_name": "按键-特殊攻击-按下"
         - "op_name": "等待秒数"
-          "seconds": 5
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-按下"
+        - "op_name": "等待秒数"
+          "seconds": 0.5
+        - "op_name": "按键-特殊攻击-松开"
         "states": "[蕾米埃尔-浮晖]{100,100}"
       - "debug_name": "其他情况：普通攻击"
         "interrupt_states": "[蕾米埃尔-虚曜]{3,3} | [蕾米埃尔-浮晖]{100,100} | [按键可用-快速支援]"

--- a/config/auto_battle_operation/蕾米埃尔-长按强化特殊技.sample.yml
+++ b/config/auto_battle_operation/蕾米埃尔-长按强化特殊技.sample.yml
@@ -10,4 +10,32 @@ operations:
     seconds: 0.5
   - op_name: "按键-特殊攻击-按下"
   - op_name: "等待秒数"
-    seconds: 5
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-特殊攻击-松开"

--- a/config/auto_battle_operation/蕾米埃尔-长按普攻.sample.yml
+++ b/config/auto_battle_operation/蕾米埃尔-长按普攻.sample.yml
@@ -10,4 +10,32 @@ operations:
     seconds: 0.5
   - op_name: "按键-普通攻击-按下"
   - op_name: "等待秒数"
-    seconds: 5
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-按下"
+  - op_name: "等待秒数"
+    seconds: 0.5
+  - op_name: "按键-普通攻击-松开"


### PR DESCRIPTION
## 问题
蕾米埃尔切入后，长按动作只发送少量「按下」事件，随后长时间等待且没有明确松键，自动战斗可能停在按键保持状态。

## 变更
- 只修改蕾米埃尔长按普攻与长按强化特殊技两个角色动作模板
- 长按期间每 0.5 秒续发一次「按下」，避免并发输入使长按提前失效
- 动作结束时明确发送「松开」
- 保留原有 10 秒「自定义-动作不打断 / 自定义-无视闪光」保护，不修改任何状态模板、配队逻辑或 merged 配置

## 测试
- 定向测试与全量 sample 加载检查：3 passed
- ruff：通过
- 测试仓 PR：OneDragon-Anything/zzz-od-test#47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化蕾米埃尔的特殊技操作：改为每隔 0.5 秒重复触发，共执行 10 次后松开按键。
  - 优化蕾米埃尔的普通攻击操作：改为连续执行按下与间隔操作，完成后自动松开按键。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->