### PR TITLE
feat: 应用运行界面新增应用商城与本地插件目录入口

### DIFF
--- a/src/zzz_od/gui/view/standalone/zzz_standalone_app_run_interface.py
+++ b/src/zzz_od/gui/view/standalone/zzz_standalone_app_run_interface.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import QWidget
-from qfluentwidgets import FluentIcon
+from pathlib import Path
 
+from PySide6.QtWidgets import QWidget
+from qfluentwidgets import FluentIcon, HyperlinkCard
+
+from one_dragon.utils.os_utils import get_work_dir
 from one_dragon_qt.view.standalone_app_run_interface import StandaloneRunInterface
+from one_dragon_qt.widgets.column import Column
 from one_dragon_qt.widgets.setting_card.help_card import HelpCard
 from zzz_od.context.zzz_context import ZContext
 
@@ -22,8 +26,25 @@ class ZStandaloneAppRunInterface(StandaloneRunInterface):
         )
 
     def get_widget_at_top(self) -> QWidget:
-        return HelpCard(
+        column = Column(spacing=4)
+        column.add_widget(HelpCard(
             url='https://one-dragon.com/zzz/zh/feat/feat_standalone_app.html',
             title='应用运行说明',
             content='从应用列表中选择单个功能模块独立运行，无需跑完整的一条龙流程',
+        ))
+        column.add_widget(HelpCard(
+            url='https://onedragon-anyone.github.io/plugin-registry/',
+            text='前往应用商城',
+            title='应用商城',
+            content='插件由第三方提供, 请注意安全风险, 仅供学习交流使用',
+        ))
+
+        # 本地插件目录
+        plugin_dir = Path(get_work_dir()) / 'plugins'
+        folder_card = HyperlinkCard(
+            plugin_dir.as_uri(), '打开目录', FluentIcon.FOLDER,
+            '本地插件目录', '下载后解压到 plugins 目录',
         )
+        folder_card.setFixedHeight(50)
+        column.add_widget(folder_card)
+        return column


### PR DESCRIPTION
## 改动

应用运行界面顶部新增两张入口卡片（与原有「应用运行说明」同样式）：

- **应用商城**：跳转第三方插件注册站 https://onedragon-anyone.github.io/plugin-registry/ ，卡片小字附免责声明「第三方网站 应用与本项目无关 请自行甄别」
- **本地插件目录**：一键打开工作目录下的 `plugins` 目录（通过 `get_work_dir()` 定位，源码 / 打包运行均适用）

仅 GUI 改动，涉及 `zzz_standalone_app_run_interface.py` 单文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 独立运行界面新增应用商城入口。
  * 新增本地插件目录快捷访问入口。
  * 优化界面布局，将说明内容与功能入口集中展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->