### PR TITLE
fix(hollow): 修复寻路目标格在脚下时 next_to_move 为 None 崩溃

### DIFF
--- a/src/zzz_od/hollow_zero/hollow_runner.py
+++ b/src/zzz_od/hollow_zero/hollow_runner.py
@@ -202,14 +202,17 @@ class HollowRunner(ZOperation):
         # if target_node.entry.entry_name == '不宜久留':  # 测试代码 在特殊情况停下
         #     return self.round_fail('不宜久留')
         next_to_move = target_node.next_node_to_move
+        if next_to_move is None:
+            # 目标节点可能已在脚下 或寻路未算出第一步
+            log.info(f"前往目标: [{target_node.entry.entry_name}] 当前移动: [无]")
+            self._save_debug_image(screen)
+            return self.round_retry('自动寻路失败')
         log.info(f"前往目标: [{target_node.entry.entry_name}] 当前移动: [{next_to_move.entry.entry_name}]")
 
         # 999 是寻路兜底策略的特殊标识 是在识别识别的情况下使用的
-        pathfinding_success = next_to_move is not None and next_to_move.path_step_cnt != 999
+        pathfinding_success = next_to_move.path_step_cnt != 999
         if not pathfinding_success:
             self._save_debug_image(screen)
-            if next_to_move is None:
-                return self.round_retry('自动寻路失败')
 
         # 寻路失败的话 间隔1秒才尝试一次兜底策略的移动
         if not pathfinding_success and screen_time - self._last_move_time < 1:


### PR DESCRIPTION
## 为什么改

空洞寻路中「目标格已被踩到脚下」时 `next_to_move` 为 None，日志打印在 None 检查之前，每轮循环触发 `AttributeError: 'NoneType' object has no attribute 'entry'`，最后空洞操作器报「异常」暂停。任何挑战配置都可能触发（例如目标是安全区，走到脚下后 `last_target_node` 仍指向它）。

## 改动要点

- 修复：把 `next_to_move` 的 None 检查提到日志打印之前，None 时保存调试截图并走原有的 `round_retry('自动寻路失败')` 重试路径，不再崩溃
- 变更：`pathfinding_success` 判断中移除已冗余的 `is not None`（由前置检查保证非空）

## 关联

- 测试仓 PR: OneDragon-Anything/zzz-od-test#51