### PR TITLE
fix: 修复任务计划程序拉起的集成启动器无法打开游戏

### DIFF
--- a/src/zzz_od/operation/enter_game/open_game.py
+++ b/src/zzz_od/operation/enter_game/open_game.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_edge import node_from
@@ -45,12 +46,15 @@ class OpenGame(Operation):
         command = f'{command} & exit"'
         log.info('命令行指令 %s', command)
 
-        # CREATE_BREAKAWAY_FROM_JOB:启动器用进程组管理时,使子进程逃离 jobobject,
-        # 避免 OneDragon-Launcher.exe 退出后游戏被杀死。
-        subprocess.Popen(
-            command,
-            creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB
-        )
+        if not getattr(sys, 'frozen', False):
+            # CREATE_BREAKAWAY_FROM_JOB:启动器用进程组管理时,使子进程逃离 jobobject,
+            # 避免 OneDragon-Launcher.exe 退出后游戏被杀死。
+            subprocess.Popen(
+                command,
+                creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB
+            )
+        else:
+            subprocess.Popen(command)
 
         return self.round_success(wait=5)
 


### PR DESCRIPTION
closes: #2179
源码启动路径的python_launcher里使用了Job对象管理python进程，与任务计划启动的集成启动器有些冲突