### PR TITLE
feat: GitHub 代理改为多线路候选，失败即切，成功线路持久化

### DIFF
--- a/docs/develop/one_dragon/modules/git_service.md
+++ b/docs/develop/one_dragon/modules/git_service.md
@@ -20,6 +20,12 @@
 
 候选源失败或超时后仍继续回退。只有候选源 fetch 成功后才更新 `last_repository_url`；记录的是 YAML 中的原始 URL，不是拼接 GitHub 代理后的临时请求 URL。自动模式的状态属于运行环境配置，具体代码源标题、URL、代理能力和 YAML 顺序仍由项目级 `repository.yml` 提供，框架不硬编码具体托管平台。
 
+## GitHub 代理候选线路
+
+使用 GitHub 代理时（代理类型选择「GitHub 代理」），同一代码源按代理线路展开为多个候选：上次成功线路（`gh_proxy_url`）优先，其后是内置线路（`GH_PROXY_URLS`，按声明顺序，与上次成功线路去重）。每条线路只尝试一次，失败立即切换下一条，全部失败才算该代码源失败。
+
+线路列表为内置固定列表，不依赖解析第三方页面。fetch 成功后，本次成功线路写回 `gh_proxy_url`，下次优先尝试。
+
 ## fetch 线程隔离与作废式超时
 
 Git 网络拉取不直接写正式仓库。每个候选代码源由一个 daemon 线程在独立 bare 仓库中执行 fetch，临时目录位于工作目录的 `.install/git_fetch_tmp/fetch_<进程ID>_*`。已有仓库更新时，临时仓库通过 `objects/info/alternates` 只读复用正式仓库对象；首次克隆使用 `depth=1`。

--- a/src/one_dragon/base/operation/one_dragon_context.py
+++ b/src/one_dragon/base/operation/one_dragon_context.py
@@ -292,10 +292,6 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
 
             self.push_service.init_push_channels()
 
-            # 只有在配置了 ghproxy 代理时才更新代理地址
-            if self.env_config.is_gh_proxy:
-                self.gh_proxy_service.update_proxy_url()
-
             self.init_others()
         except Exception:
             log.error('初始化出错', exc_info=True)

--- a/src/one_dragon/envs/env_config.py
+++ b/src/one_dragon/envs/env_config.py
@@ -15,7 +15,13 @@ DEFAULT_WHEELS_DIR_PATH = os.path.join(DEFAULT_ENV_PATH, 'wheels')  # 默认的w
 DEFAULT_VENV_DIR_PATH = os_utils.get_path_under_work_dir('.venv')  # 默认的虚拟环境文件夹路径
 DEFAULT_VENV_PYTHON_PATH = os.path.join(DEFAULT_VENV_DIR_PATH, 'Scripts', 'python.exe')  # 默认的虚拟环境中python.exe的路径
 
-GH_PROXY_URL = 'https://ghfast.top'  # 免费代理的路径
+GH_PROXY_URL = 'https://ghfast.top'  # 默认的免费代理路径
+GH_PROXY_URLS = [
+    'https://ghfast.top',
+    'https://gh-proxy.com',
+    'https://ghproxy.net',
+    'https://ghp.ci',
+]  # 内置免费代理候选线路，按顺序尝试
 
 
 class ProxyTypeEnum(Enum):
@@ -286,7 +292,7 @@ class EnvConfig(YamlConfig):
     @property
     def gh_proxy_url(self) -> str:
         """
-        免费代理的url
+        免费代理的url（上次成功线路，优先尝试）
         :return:
         """
         return self.get('gh_proxy_url', GH_PROXY_URL)
@@ -294,22 +300,10 @@ class EnvConfig(YamlConfig):
     @gh_proxy_url.setter
     def gh_proxy_url(self, new_value: str) -> None:
         """
-        免费代理的url
+        免费代理的url（上次成功线路，优先尝试）
         :return:
         """
         self.update('gh_proxy_url', new_value)
-
-    @property
-    def auto_fetch_gh_proxy_url(self) -> bool:
-        """
-        自动获取免费代理的url
-        :return:
-        """
-        return self.get('auto_fetch_gh_proxy_url', True)
-
-    @auto_fetch_gh_proxy_url.setter
-    def auto_fetch_gh_proxy_url(self, new_value: bool) -> None:
-        self.update('auto_fetch_gh_proxy_url', new_value)
 
     def write_env_bat(self) -> None:
         """

--- a/src/one_dragon/envs/ghproxy_service.py
+++ b/src/one_dragon/envs/ghproxy_service.py
@@ -13,12 +13,16 @@ class GhProxyService:
         self.env_config = env_config
 
     def get_proxy_candidates(self) -> list[str]:
-        """获取代理候选线路：上次成功线路优先，内置线路按顺序在后（去重）。"""
+        """获取代理候选线路：上次成功线路优先，内置线路按顺序在后（去重）。
+
+        去重前统一去掉首尾空白和尾部斜杠，避免同一条线路重复出现。
+        """
         candidates: list[str] = []
-        last_proxy = self.env_config.gh_proxy_url.strip()
+        last_proxy = self.env_config.gh_proxy_url.strip().rstrip('/')
         if last_proxy:
             candidates.append(last_proxy)
         for proxy_url in GH_PROXY_URLS:
-            if proxy_url not in candidates:
+            proxy_url = proxy_url.strip().rstrip('/')
+            if proxy_url and proxy_url not in candidates:
                 candidates.append(proxy_url)
         return candidates

--- a/src/one_dragon/envs/ghproxy_service.py
+++ b/src/one_dragon/envs/ghproxy_service.py
@@ -1,69 +1,24 @@
-import re
-
-import requests
-
-from one_dragon.envs.env_config import EnvConfig
-from one_dragon.utils.log_utils import log
+from one_dragon.envs.env_config import GH_PROXY_URLS, EnvConfig
 
 
 class GhProxyService:
+    """GitHub 免费代理线路服务。
+
+    内置多条候选线路（见 env_config.GH_PROXY_URLS），不依赖解析第三方页面。
+    使用方每次按候选顺序尝试一条，失败切换下一条，全部失败才算失败；
+    成功线路由使用方写回 env_config.gh_proxy_url，下次优先尝试。
+    """
 
     def __init__(self, env_config: EnvConfig):
         self.env_config = env_config
 
-    def update_proxy_url(self) -> bool:
-        """
-        更新免费代理的url
-        :return:
-        """
-        url = 'https://ghproxy.link/js/src_views_home_HomeView_vue.js'  # 打开 https://ghproxy.link/ 后找到的js文件
-        headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            'Referer': 'https://ghproxy.link/'
-        }
-        try:
-            response = requests.get(url, headers=headers, timeout=10)
-            response.raise_for_status()
-            js_content = response.text
-        except Exception:
-            log.error('自动获取免费代理地址失败', exc_info=True)
-            return False
-
-        url_prefix = '<a href=\\\\\\"'
-        url_prefix_idx = js_content.find(url_prefix)
-        if url_prefix_idx == -1:
-            log.error('自动获取免费代理地址失败')
-            return False
-
-        url_suffix = '\\\\\\" target='
-        url_suffix_idx = js_content.find(url_suffix)
-        if url_suffix_idx == -1:
-            log.error('自动获取免费代理地址失败')
-            return False
-
-        another_url_prefix_idx = js_content.find(url_prefix, url_suffix_idx)  # 理论上这个文件里只有一个 <a href> 标签 有多个时候忽略 等待后续再处理
-        if another_url_prefix_idx != -1:
-            log.error('自动获取免费代理地址失败 有多个 <a href> 标签')
-            return False
-
-        proxy_url = js_content[url_prefix_idx + len(url_prefix):url_suffix_idx]
-        # 判断 proxy_url 是一个 https 开头的域名 不包含任何路径 例如 https://ghfast.top
-        pattern = r'^https://[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-
-        # 使用正则表达式匹配
-        if not re.match(pattern, proxy_url):
-            log.error('自动获取免费代理地址失败 提取域名不合法 %s', proxy_url)
-            return False
-
-        log.info('自动获取免费代理地址成功 %s', proxy_url)
-        self.env_config.gh_proxy_url = proxy_url
-        return True
-
-
-def __debug():
-    service = GhProxyService(None)
-    service.update_proxy_url()
-
-
-if __name__ == '__main__':
-    __debug()
+    def get_proxy_candidates(self) -> list[str]:
+        """获取代理候选线路：上次成功线路优先，内置线路按顺序在后（去重）。"""
+        candidates: list[str] = []
+        last_proxy = self.env_config.gh_proxy_url.strip()
+        if last_proxy:
+            candidates.append(last_proxy)
+        for proxy_url in GH_PROXY_URLS:
+            if proxy_url not in candidates:
+                candidates.append(proxy_url)
+        return candidates

--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -886,7 +886,8 @@ class GitService:
                 if used_proxy_url is not None:
                     try:
                         self.env_config.gh_proxy_url = used_proxy_url
-                    except Exception:
+                    except OSError:
+                        # 配置写盘失败只记日志，不影响本次拉取结果
                         log.warning('记录上次成功代理线路失败', exc_info=True)
 
         used_repository_name = self._get_repository_item(used_repository).ui_text if used_repository else ''

--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -549,6 +549,19 @@ class GitService:
             return repository_url[:-len(suffix)]
         return None
 
+    def _record_success_gh_proxy(self, repository: RepositoryItem, repository_url: str) -> None:
+        """记录本次成功的代理线路，下次优先尝试；未使用代理时无操作。"""
+        if not self.env_config.is_gh_proxy or not repository.use_proxy:
+            return
+        used_proxy_url = self._extract_gh_proxy(repository_url, repository)
+        if used_proxy_url is None:
+            return
+        try:
+            self.env_config.gh_proxy_url = used_proxy_url
+        except OSError:
+            # 配置写盘失败只记日志，不影响本次操作结果
+            log.warning('记录上次成功代理线路失败', exc_info=True)
+
     def _get_git_repository(self) -> str:
         """获取当前选择模式下首个候选代码源地址。"""
         candidates = self._get_repository_candidates()
@@ -881,14 +894,7 @@ class GitService:
             except Exception:
                 log.warning('记录上次成功代码源失败', exc_info=True)
             # 使用代理时记录本次成功的线路，下次优先尝试
-            if self.env_config.is_gh_proxy and used_repository.use_proxy:
-                used_proxy_url = self._extract_gh_proxy(used_url, used_repository)
-                if used_proxy_url is not None:
-                    try:
-                        self.env_config.gh_proxy_url = used_proxy_url
-                    except OSError:
-                        # 配置写盘失败只记日志，不影响本次拉取结果
-                        log.warning('记录上次成功代理线路失败', exc_info=True)
+            self._record_success_gh_proxy(used_repository, used_url)
 
         used_repository_name = self._get_repository_item(used_repository).ui_text if used_repository else ''
         log.info(f'远程代码拉取成功，实际代码源: {used_repository_name}')
@@ -1476,6 +1482,7 @@ class GitService:
                     with self._temporary_fetch_timeout():
                         heads = remote.list_heads(callbacks=callbacks, proxy=self._get_proxy_address())
                     log.info(f'标签查询使用代码源: {repository_name}')
+                    self._record_success_gh_proxy(repository, repository_url)
                     break
                 except Exception:
                     log.warning(f'代码源 {repository_name} 获取标签失败，尝试下一个代码源', exc_info=True)

--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -31,6 +31,7 @@ from pygit2.enums import CheckoutStrategy, ConfigLevel, ResetMode, SortMode
 
 from one_dragon.base.config.config_item import ConfigItem
 from one_dragon.envs.env_config import EnvConfig
+from one_dragon.envs.ghproxy_service import GhProxyService
 from one_dragon.envs.project_config import ProjectConfig
 from one_dragon.envs.repo_config import RepoConfig, RepositoryItem
 from one_dragon.utils import os_utils
@@ -434,6 +435,7 @@ class GitService:
         self.project_config: ProjectConfig = project_config
         self.env_config: EnvConfig = env_config
         self.repo_config: RepoConfig = repo_config
+        self.gh_proxy_service: GhProxyService = GhProxyService(env_config)
 
         if repo_dir:
             if not Path(repo_dir).is_absolute():
@@ -514,7 +516,11 @@ class GitService:
         return repository_url
 
     def _get_repository_candidates(self) -> list[tuple[RepositoryItem, str]]:
-        """按用户选择、上次成功源和 YAML 声明顺序生成候选列表。"""
+        """按用户选择、上次成功源和 YAML 声明顺序生成候选列表。
+
+        使用 GitHub 代理时，同一代码源按代理线路展开（上次成功线路优先，
+        内置线路按顺序在后，每条只出现一次），失败一条换下一条。
+        """
         repository_url = self.env_config.repository_url
         preferred_repository = self._find_repository(repository_url)
         if preferred_repository is None and repository_url != RepoConfig.AUTO_REPOSITORY_VALUE:
@@ -526,10 +532,22 @@ class GitService:
         for repository in [preferred_repository, *self.repo_config.repositories]:
             if repository is None or any(candidate[0] is repository for candidate in candidates):
                 continue
-            repository_url = self._get_repository_url(repository)
-            if repository_url:
-                candidates.append((repository, repository_url))
+            if repository.use_proxy and self.env_config.is_gh_proxy:
+                for proxy_url in self.gh_proxy_service.get_proxy_candidates():
+                    candidates.append((repository, f'{proxy_url.rstrip("/")}/{repository.url}'))
+            else:
+                repository_url = self._get_repository_url(repository)
+                if repository_url:
+                    candidates.append((repository, repository_url))
         return candidates
+
+    @staticmethod
+    def _extract_gh_proxy(repository_url: str, repository: RepositoryItem) -> str | None:
+        """从拼接 URL 反推本次使用的代理地址；未使用代理时返回 None。"""
+        suffix = f'/{repository.url}'
+        if repository_url.endswith(suffix):
+            return repository_url[:-len(suffix)]
+        return None
 
     def _get_git_repository(self) -> str:
         """获取当前选择模式下首个候选代码源地址。"""
@@ -820,6 +838,7 @@ class GitService:
         log.info(gt('拉取远程代码...'))
         success = False
         used_repository: RepositoryItem | None = None
+        used_url: str = ''
         has_missing_object_failure = False
 
         try:
@@ -838,6 +857,7 @@ class GitService:
                     )
                     success = True
                     used_repository = repository
+                    used_url = repository_url
                     break
                 except Exception as error:
                     has_missing_object_failure |= self._is_missing_object_error(error)
@@ -860,6 +880,14 @@ class GitService:
                 self.env_config.last_repository_url = used_repository.url
             except Exception:
                 log.warning('记录上次成功代码源失败', exc_info=True)
+            # 使用代理时记录本次成功的线路，下次优先尝试
+            if self.env_config.is_gh_proxy and used_repository.use_proxy:
+                used_proxy_url = self._extract_gh_proxy(used_url, used_repository)
+                if used_proxy_url is not None:
+                    try:
+                        self.env_config.gh_proxy_url = used_proxy_url
+                    except Exception:
+                        log.warning('记录上次成功代理线路失败', exc_info=True)
 
         used_repository_name = self._get_repository_item(used_repository).ui_text if used_repository else ''
         log.info(f'远程代码拉取成功，实际代码源: {used_repository_name}')

--- a/src/one_dragon_qt/view/setting/setting_env_interface.py
+++ b/src/one_dragon_qt/view/setting/setting_env_interface.py
@@ -153,7 +153,7 @@ class SettingEnvInterface(VerticalScrollInterface):
 
         self.gh_proxy_url_opt = TextSettingCard(
             icon=FluentIcon.GLOBE, title='免费代理',
-            content='优先使用此线路，失败后自动切换内置线路（ghfast.top / gh-proxy.com / ghproxy.net / ghp.ci）'
+            content='优先使用已保存线路，失败后自动切换内置线路'
         )
         web_group.addSettingCard(self.gh_proxy_url_opt)
 

--- a/src/one_dragon_qt/view/setting/setting_env_interface.py
+++ b/src/one_dragon_qt/view/setting/setting_env_interface.py
@@ -3,7 +3,6 @@ from PySide6.QtGui import Qt
 from PySide6.QtWidgets import QWidget
 from qfluentwidgets import (
     FluentIcon,
-    HyperlinkButton,
     InfoBar,
     InfoBarPosition,
     PushButton,
@@ -153,23 +152,10 @@ class SettingEnvInterface(VerticalScrollInterface):
         web_group.addSettingCard(self.personal_proxy_input)
 
         self.gh_proxy_url_opt = TextSettingCard(
-            icon=FluentIcon.GLOBE, title='免费代理'
+            icon=FluentIcon.GLOBE, title='免费代理',
+            content='优先使用此线路，失败后自动切换内置线路（ghfast.top / gh-proxy.com / ghproxy.net / ghp.ci）'
         )
         web_group.addSettingCard(self.gh_proxy_url_opt)
-
-        self.auto_fetch_gh_proxy_url_opt = SwitchSettingCard(
-            icon=FluentIcon.SYNC, title='自动获取免费代理地址', content='获取失败时 可前往 https://ghproxy.link/ 查看自行更新'
-        )
-        self.fetch_gh_proxy_url_btn = PushButton(gt('获取'), self)
-        self.fetch_gh_proxy_url_btn.clicked.connect(self.on_fetch_gh_proxy_url_clicked)
-        self.auto_fetch_gh_proxy_url_opt.hBoxLayout.addWidget(self.fetch_gh_proxy_url_btn, 0, Qt.AlignmentFlag.AlignRight)
-        self.auto_fetch_gh_proxy_url_opt.hBoxLayout.addSpacing(16)
-
-        self.goto_gh_proxy_link_btn = HyperlinkButton('https://ghproxy.link', gt('前往'), self)
-        self.auto_fetch_gh_proxy_url_opt.hBoxLayout.addWidget(self.goto_gh_proxy_link_btn, 0, Qt.AlignmentFlag.AlignRight)
-        self.auto_fetch_gh_proxy_url_opt.hBoxLayout.addSpacing(16)
-
-        web_group.addSettingCard(self.auto_fetch_gh_proxy_url_opt)
 
         return web_group
 
@@ -224,7 +210,6 @@ class SettingEnvInterface(VerticalScrollInterface):
         self.proxy_type_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('proxy_type'))
         self.personal_proxy_input.init_with_adapter(self.ctx.env_config.get_prop_adapter('personal_proxy'))
         self.gh_proxy_url_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('gh_proxy_url'))
-        self.auto_fetch_gh_proxy_url_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('auto_fetch_gh_proxy_url'))
         self.update_proxy_ui()
 
     def _on_proxy_type_changed(self, index: int, value: str) -> None:
@@ -237,10 +222,6 @@ class SettingEnvInterface(VerticalScrollInterface):
         :return:
         """
         self.ctx.env_config.init_system_proxy()
-
-    def on_fetch_gh_proxy_url_clicked(self) -> None:
-        self.ctx.gh_proxy_service.update_proxy_url()
-        self.gh_proxy_url_opt.init_with_adapter(self.ctx.env_config.get_prop_adapter('gh_proxy_url'))
 
     def _show_info_bar(self, title: str, content: str, duration: int = 20000):
         """显示信息条"""
@@ -300,15 +281,12 @@ class SettingEnvInterface(VerticalScrollInterface):
         if self.ctx.env_config.proxy_type == ProxyTypeEnum.GHPROXY.value.value:
             self.personal_proxy_input.hide()
             self.gh_proxy_url_opt.show()
-            self.auto_fetch_gh_proxy_url_opt.show()
         elif self.ctx.env_config.proxy_type == ProxyTypeEnum.PERSONAL.value.value:
             self.personal_proxy_input.show()
             self.gh_proxy_url_opt.hide()
-            self.auto_fetch_gh_proxy_url_opt.hide()
         elif self.ctx.env_config.proxy_type == ProxyTypeEnum.NONE.value.value:
             self.personal_proxy_input.hide()
             self.gh_proxy_url_opt.hide()
-            self.auto_fetch_gh_proxy_url_opt.hide()
 
 
 class SpeedTestRunnerBase(QThread):


### PR DESCRIPTION
- env_config：新增内置 GH_PROXY_URLS 候选列表，删除 auto_fetch_gh_proxy_url
- ghproxy_service：删除第三方页面 HTML 解析，改为 get_proxy_candidates
- git_service：代理代码源按线路展开（上次成功线路优先），_extract_gh_proxy 反推并写回成功线路
- 设置界面：删除「获取免费代理」按钮与自动获取开关