### PR TITLE
fix(声音闪避): 按 WASAPI id 精确匹配 loopback 设备录音

### DIFF
--- a/src/zzz_od/auto_battle/auto_battle_dodge_context.py
+++ b/src/zzz_od/auto_battle/auto_battle_dodge_context.py
@@ -87,7 +87,16 @@ class AudioRecorder:
         warnings.filterwarnings('ignore', category=SoundcardRuntimeWarning)
 
         try:
-            _mic = sc.get_microphone(id=str(sc.default_speaker().name), include_loopback=True)
+            # 按 WASAPI id 精确匹配默认扬声器的 loopback 设备（录制系统输出声音）。
+            # 不能用名字匹配（soundcard 的 _match_device 会做子串/模糊匹配，可能错落到真实麦克风）
+            default_speaker = sc.default_speaker()
+            _mic = None
+            for mic in sc.all_microphones(include_loopback=True):
+                if mic.isloopback and mic.id == default_speaker.id:
+                    _mic = mic
+                    break
+            if _mic is None:
+                raise RuntimeError(f'未找到默认扬声器 [{default_speaker.name}] 的 loopback 设备')
             _recorder = _mic.recorder(samplerate=self._sample_rate, channels=self._used_channel)
             with _recorder as audio_recorder:
                 while self.running:


### PR DESCRIPTION
## 为什么改

声音闪避识别需要录制游戏声音（系统输出），原实现用 `sc.get_microphone(id=默认扬声器名字, include_loopback=True)` 选录音设备。soundcard 内部 `_match_device` 按名字做子串/模糊匹配，当真实麦克风与默认扬声器名字存在包含/相似关系（如都含厂商名 Realtek 等）时会错落到真实麦克风，导致录到麦克风声音而不是游戏声音。

## 改动要点

- 改用遍历 `all_microphones(include_loopback=True)`，按 WASAPI id 精确匹配默认扬声器对应的 loopback 设备（`mic.isloopback and mic.id == default_speaker.id`）
- 只认 loopback 设备（录制系统输出的虚拟麦克风），不碰真实麦克风
- 找不到 loopback 时明确报错，提示检查音频设备

参考：soundcard 维护者在 issue #146 中建议手动遍历 `all_microphones` 选择设备，规避 `get_microphone` 名字匹配的不稳定。