### PR TITLE
fix(git): 忽略内部 fetch remote 残留，避免阻止仓库重建

### DIFF
--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -1148,7 +1148,13 @@ class GitService:
             except Exception:
                 log.warning('旧 Git 仓库无法打开，跳过 remote 检查并直接备份重建')
             else:
-                extra_remotes = sorted(set(opened_repo.remotes.names()) - {'origin'})
+                # one-dragon-fetch-* 是导入临时仓库时创建的内部 remote，
+                # 正常用完即删；仅进程被强杀等场景可能残留空配置，不算用户额外 remote。
+                extra_remotes = sorted(
+                    name
+                    for name in opened_repo.remotes.names()
+                    if name != 'origin' and not name.startswith('one-dragon-fetch-')
+                )
                 if extra_remotes:
                     log.error(f'检测到 origin 以外的远程仓库，暂不自动重建本地 Git 仓库: {extra_remotes}')
                     return GitSyncStatus.LOCAL_UPDATE_FAILED, failure_message


### PR DESCRIPTION
## 为什么改

`_import_fetch_result` 导入临时仓库时创建的 `one-dragon-fetch-*` 内部 remote 正常用完即删，但进程被强杀（断电、结束进程）等场景可能残留。`_rebuild_repository` 的额外 remote 保护检查不区分名称，会把这种残留当成用户手动添加的 remote，导致仓库损坏时自动重建被永久阻止。空 section 残留（url 键已删）不会被枚举，无影响；本修复堵住带 url 的残留场景。

## 改动要点

- 修复：`_rebuild_repository` 额外 remote 检查过滤 `one-dragon-fetch-` 前缀的内部 remote，仅用户手动添加的 remote 阻止重建
- 测试：新增 `test_rebuild_repository_ignores_internal_fetch_remote`，覆盖内部 fetch remote 残留不阻止重建

## 关联

配套测试仓 PR：OneDragon-Anything/zzz-od-test#59