### PR TITLE
fix: 兼容旧版启动器读取 repository.yml

### DIFF
--- a/config/repository.yml
+++ b/config/repository.yml
@@ -33,6 +33,18 @@ env_source:
     gitee:
       label: Gitee
       value: "https://gitee.com/OneDragon-Anything/OneDragon-Env/releases/download"
+cpython_source:
+  default: cnb
+  options:
+    github:
+      label: GitHub
+      value: "https://github.com/astral-sh/python-build-standalone/releases/download"
+    cnb:
+      label: CNB
+      value: "https://cnb.cool/astral-sh/python-build-standalone/-/releases/download"
+    gitee:
+      label: Gitee
+      value: "https://gitee.com/OneDragon-Anything/python-build-standalone/releases/download"
 pip_source:
   default: alibaba
   options:
@@ -46,6 +58,11 @@ pip_source:
       label: 阿里云
       value: "https://mirrors.aliyun.com/pypi/simple"
 resource_download:
+  default: github
+  options:
+    github:
+      label: GitHub
+      value: "https://example.com/resource"
   sources:
     github:
       label: GitHub
@@ -104,31 +121,31 @@ regions:
     label: 中国 - CNB
     repository: cnb
     values:
-      env_source: cnb
-      pip_source: alibaba
+      env_source: "https://cnb.cool/OneDragon-Anything/OneDragon-Env/-/releases/download"
+      pip_source: "https://mirrors.aliyun.com/pypi/simple"
       proxy_type: "None"
       resource_source: cnb
   china_gitee:
     label: 中国 - Gitee
     repository: gitee
     values:
-      env_source: gitee
-      pip_source: alibaba
+      env_source: "https://gitee.com/OneDragon-Anything/OneDragon-Env/releases/download"
+      pip_source: "https://mirrors.aliyun.com/pypi/simple"
       proxy_type: "None"
       resource_source: gitee
   china_ghproxy:
     label: 中国 - GitHub 代理
     repository: github
     values:
-      env_source: github
-      pip_source: alibaba
+      env_source: "https://github.com/OneDragon-Anything/OneDragon-Env/releases/download"
+      pip_source: "https://mirrors.aliyun.com/pypi/simple"
       proxy_type: ghproxy
       resource_source: github
   oversea:
     label: 海外
     repository: github
     values:
-      env_source: github
-      pip_source: pypi
+      env_source: "https://github.com/OneDragon-Anything/OneDragon-Env/releases/download"
+      pip_source: "https://pypi.org/simple"
       proxy_type: "None"
       resource_source: github

--- a/src/one_dragon/envs/repo_config.py
+++ b/src/one_dragon/envs/repo_config.py
@@ -270,7 +270,10 @@ class RepoConfig(YamlConfig):
         return tuple(regions)
 
     def _resolve_region_value(self, key: str, value: str) -> str:
-        """地区预设的下载源字段引用 options 选项名 解析为对应 URL。"""
+        """地区预设的下载源字段：完整 URL 原样保留，选项名解析为对应 URL。"""
+        if value.startswith('http://') or value.startswith('https://'):
+            # 旧格式：直接写完整 URL，保持向后兼容
+            return value
         options = self.sources.get(key)
         if options is None:
             # 非下载源字段（如 proxy_type）保持原样


### PR DESCRIPTION
## 为什么改

pr-2638 把 regions.values 从完整 URL 改为选项名引用（`env_source: cnb`），并移除了 cpython_source 段。但已发布的旧版启动器（编译好的 exe）读取 repository.yml 的逻辑是：

1. **regions.values 直接当 URL 写入 env_config**（source_config_interface 的 `_on_region_changed` 逐键 update），选项名会让旧版启动器下载失败；
2. **顶层未知段当下载源解析**（`_load_source_defaults` 要求每个段必须有 `default` 且 default 在 options 中），新增的 `resource_download` 段没有 default，旧版启动器直接崩溃：`ValueError: 下载源 resource_download 必须配置 default`。

yml 是运行时配置，旧版启动器也要能读，否则升级代码后旧 exe 无法启动。

## 改动要点

- **config/repository.yml**
  - regions.values 恢复完整 URL（cnb 用带 `/-/` 的规范路径，实测可下载）
  - 恢复 cpython_source 段（旧版 env_config / UI 下拉框依赖）
  - resource_download 段补 `default: github` + 占位 options，旧代码可把它当普通下载源跳过
- **src/one_dragon/envs/repo_config.py**
  - `_resolve_region_value` 兼容完整 URL：http/https 开头原样返回，选项名才解析为 URL

## 验证

- 旧版代码（origin/main 逻辑）读新 yml：崩溃 `resource_download 必须配置 default`
- 旧版代码读本 PR yml：OK，sources/regions 全部正常加载
- 新版代码（pr-2638 + 本补丁）读本 PR yml：OK，model_resources 正常

## 关联

配套 #2638