### PR TITLE
fix(资源更新): 修复启动器更新弹窗卡死与重复弹出

### DIFF
--- a/src/one_dragon/envs/update_service.py
+++ b/src/one_dragon/envs/update_service.py
@@ -37,6 +37,8 @@ class UpdateService:
         self.project_config: ProjectConfig = project_config
         self.env_config: EnvConfig = env_config
         self.git_service: GitService = git_service
+        # 版本信息缓存：检查线程查询后填入，UI 构造下载项只读缓存，避免主线程网络请求
+        self._launcher_version_cache: dict[str, tuple[str, str, str]] = {}
 
     @staticmethod
     def get_launcher_exe_name(launcher_type: LauncherType) -> str:
@@ -54,7 +56,10 @@ class UpdateService:
         return RUNTIME_LAUNCHER_ZIP_SUFFIX if launcher_type == 'runtime' else LAUNCHER_ZIP_SUFFIX
 
     def get_launcher_version_info(self, launcher_type: LauncherType) -> tuple[str, str, str]:
-        """获取当前启动器版本、最新稳定版和最新测试版。"""
+        """获取当前启动器版本、最新稳定版和最新测试版（带缓存，重复调用不重新请求网络）。"""
+        cached = self._launcher_version_cache.get(launcher_type)
+        if cached is not None:
+            return cached
         exe_path = Path(os_utils.get_work_dir()) / self.get_launcher_exe_name(launcher_type)
         current_version = app_utils.get_exe_version(str(exe_path)) if exe_path.exists() else ''
         try:
@@ -62,7 +67,9 @@ class UpdateService:
         except Exception:
             log.error('获取最新启动器版本失败', exc_info=True)
             latest_stable, latest_beta = '', ''
-        return current_version, latest_stable, latest_beta
+        result = (current_version, latest_stable, latest_beta)
+        self._launcher_version_cache[launcher_type] = result
+        return result
 
     def is_launcher_update_available(self) -> bool:
         """检查当前启动器通道是否存在可用更新。"""

--- a/src/one_dragon_qt/services/resource_update_coordinator.py
+++ b/src/one_dragon_qt/services/resource_update_coordinator.py
@@ -89,6 +89,7 @@ class ResourceUpdateCoordinator(QObject):
         self._suppressed_update_keys: set[str] = set()
         self._update_dialog_scheduled: bool = False
         self._update_dialog_open: bool = False
+        self._ocr_waiting: bool = False
         self._last_check_time: float = 0
         self._check_interval: float = 300
         self._checks_started: bool = False
@@ -120,7 +121,9 @@ class ResourceUpdateCoordinator(QObject):
         self._check_runners[resource_check.check_id] = runner
 
     def check_updates(self, force: bool = False) -> None:
-        """按冷却时间并行启动各资源提供器的检查。"""
+        """每次启动只检查一次；启动检查完成后，后续非强制调用不再检查。"""
+        if self._checks_started and not force:
+            return
         current_time = time.time()
         if not force and current_time - self._last_check_time <= self._check_interval:
             return
@@ -168,6 +171,7 @@ class ResourceUpdateCoordinator(QObject):
             or not self._checks_started
             or not all(self._checks_complete.values())
             or not (has_pending_update or self._pending_ocr_request is not None)
+            or self._ocr_waiting
             or self._update_dialog_scheduled
             or self._update_dialog_open
         ):
@@ -185,6 +189,7 @@ class ResourceUpdateCoordinator(QObject):
         specs = self._build_pending_specs(included_ocr_request)
         if not specs:
             self._update_dialog_open = False
+            self._reset_pending_updates()
             return
 
         self._suppressed_update_keys.update(
@@ -214,7 +219,7 @@ class ResourceUpdateCoordinator(QObject):
                         False,
                     )
                 self._update_dialog_open = False
-                self._schedule_update_dialog()
+                self._reset_pending_updates()
                 return
             selected_specs = dialog.selected_specs()
             remember_choice = dialog.remember_choice
@@ -225,6 +230,7 @@ class ResourceUpdateCoordinator(QObject):
             remember_choice,
         )
         self._update_dialog_open = False
+        self._reset_pending_updates()
         self._schedule_update_dialog()
 
     def _build_pending_specs(
@@ -314,6 +320,7 @@ class ResourceUpdateCoordinator(QObject):
             ResourceDownloadTaskState.FAILED,
             ResourceDownloadTaskState.CANCELLED,
         )
+        self._ocr_waiting = True
         if task.state in terminal_states:
             self._respond_ocr_request(
                 request,
@@ -347,6 +354,11 @@ class ResourceUpdateCoordinator(QObject):
         self.queue.task_updated.connect(_on_task_updated)
         self.queue.task_removed.connect(_on_task_removed)
 
+    def _reset_pending_updates(self) -> None:
+        """弹窗已展示并处理完毕后清除本轮待更新标记，避免立即重复弹窗。"""
+        for check_id in self._pending_updates:
+            self._pending_updates[check_id] = False
+
     def _respond_ocr_request(
         self,
         request: ContextDownloadRequestEvent,
@@ -356,6 +368,7 @@ class ResourceUpdateCoordinator(QObject):
         """结束指定 OCR 下载确认请求，不影响后来到达的新请求。"""
         if self._pending_ocr_request is request:
             self._pending_ocr_request = None
+        self._ocr_waiting = False
         request.respond(confirmed=confirmed, remember=remember)
 
     def _build_launcher_specs(self) -> list[ResourceDownloadSpec]:


### PR DESCRIPTION
## 为什么改

启动器启动时若 GitHub 网络慢，弹窗构造在主线程同步请求启动器版本信息（pygit2 list_heads），UI 卡死无响应；且弹窗处理完毕后待更新标记未清理，导致同一会话内反复弹窗。

## 改动要点

- 修复：UpdateService 增加启动器版本信息缓存，检查线程查询后写入，UI 构造下载项只读缓存，主线程不再发起网络请求
- 修复：资源更新检查每次启动只执行一次，弹窗处理完毕后清除待更新标记，不再重复弹窗
- 修复：OCR 下载等待期间抑制弹窗，避免任务已在队列时二次弹出

## 关联

承接 #2714（兼容修复已合入本分支）