### PR TITLE
fix(启动器): 版本查询恢复后台线程异步语义

### DIFF
--- a/src/one_dragon/envs/update_service.py
+++ b/src/one_dragon/envs/update_service.py
@@ -55,8 +55,11 @@ class UpdateService:
         """获取启动器类型对应的压缩包后缀。"""
         return RUNTIME_LAUNCHER_ZIP_SUFFIX if launcher_type == 'runtime' else LAUNCHER_ZIP_SUFFIX
 
-    def get_launcher_version_info(self, launcher_type: LauncherType) -> tuple[str, str, str]:
-        """获取当前启动器版本、最新稳定版和最新测试版（带缓存，重复调用不重新请求网络）。"""
+    def fetch_launcher_version_info(self, launcher_type: LauncherType) -> tuple[str, str, str]:
+        """查询当前启动器版本、最新稳定版和最新测试版并写入缓存。
+
+        含网络请求，只能在后台线程调用；已缓存时直接返回缓存。
+        """
         cached = self._launcher_version_cache.get(launcher_type)
         if cached is not None:
             return cached
@@ -71,11 +74,19 @@ class UpdateService:
         self._launcher_version_cache[launcher_type] = result
         return result
 
+    def get_launcher_version_info(self, launcher_type: LauncherType) -> tuple[str, str, str]:
+        """读取缓存的启动器版本信息；无缓存时返回空版本，不发起网络请求。
+
+        主线程安全：UI 构造下载项只读缓存，网络查询由后台线程的
+        fetch_launcher_version_info 完成。
+        """
+        return self._launcher_version_cache.get(launcher_type, ('', '', ''))
+
     def is_launcher_update_available(self) -> bool:
-        """检查当前启动器通道是否存在可用更新。"""
+        """检查当前启动器通道是否存在可用更新（后台线程调用，含网络请求）。"""
         launcher_type = self.detect_running_launcher_type() or 'launcher'
         current_version, latest_stable, latest_beta = (
-            self.get_launcher_version_info(launcher_type)
+            self.fetch_launcher_version_info(launcher_type)
         )
         target_latest = self.get_launcher_target_version(
             current_version,

--- a/src/one_dragon_qt/widgets/download_card/launcher_download_card.py
+++ b/src/one_dragon_qt/widgets/download_card/launcher_download_card.py
@@ -40,7 +40,7 @@ class LauncherVersionChecker(QThread):
     def run(self) -> None:
         try:
             current_version, latest_stable, latest_beta = (
-                self.update_service.get_launcher_version_info(self.launcher_type)
+                self.update_service.fetch_launcher_version_info(self.launcher_type)
             )
         except Exception:
             # 检查失败也要发出信号 否则界面会永远停在检查中且按钮不可用


### PR DESCRIPTION
## 为什么改

#2715 合入的版本缓存方案里，get_launcher_version_info 仍保留同步网络查询路径（缓存未命中时主线程会触网）。原版架构是 QThread 后台查询 + 信号回传，重构时把查询写成了同步。本 PR 恢复异步语义：网络请求只在后台线程发生，主线程只读缓存。

## 改动要点

- 变更：UpdateService 拆分 fetch_launcher_version_info（后台线程查询并填缓存）与 get_launcher_version_info（主线程只读缓存，无缓存返回空版本，不触网）
- 变更：is_launcher_update_available 与 LauncherVersionChecker.run 改用 fetch 入口（两者均在后台线程）

## 关联

承接 #2715（已合并）