### PR TITLE
fix(代码同步): 失败时展示具体原因而非固定文案

### DIFF
--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -1117,6 +1117,12 @@ class GitService:
             return True
         return re.fullmatch(r"'{0,1}[0-9a-f]{40}'{0,1}", message) is not None
 
+    @staticmethod
+    def _format_source_error(error: BaseException) -> str:
+        """把代码源异常转成面向用户的简短原因，避免展示过长或空信息。"""
+        text = str(error).strip() or error.__class__.__name__
+        return text if len(text) <= 120 else f'{text[:117]}...'
+
     def _rebuild_repository(
         self,
         progress_callback: Callable[[float, str], None] | None,
@@ -1207,6 +1213,7 @@ class GitService:
         success = False
         used_repository: RepositoryItem | None = None
         local_repository_damaged = False
+        source_errors: list[str] = []
 
         try:
             for repository, repository_url in self._get_repository_candidates():
@@ -1234,6 +1241,9 @@ class GitService:
                         local_repository_damaged = True
                         log.error('导入远程对象时发现本地 Git 对象缺失，停止代码源回退', exc_info=True)
                         break
+                    source_errors.append(
+                        f'{repository_name}: {self._format_source_error(error)}'
+                    )
                     log.warning(f'代码源 {repository_name} 拉取失败，尝试下一个代码源', exc_info=True)
         finally:
             restored = True if local_repository_damaged else self._restore_origin()
@@ -1248,7 +1258,10 @@ class GitService:
             return GitSyncStatus.LOCAL_UPDATE_FAILED, gt('本地代码更新失败')
         if not success:
             log.error('所有代码源均拉取失败')
-            return GitSyncStatus.REMOTE_UNAVAILABLE, gt('暂时无法获取更新')
+            message = gt('暂时无法获取更新')
+            if source_errors:
+                message = f'{message}：{"；".join(source_errors)}'
+            return GitSyncStatus.REMOTE_UNAVAILABLE, message
 
         if used_repository is not None:
             try:


### PR DESCRIPTION
## 为什么改

代码同步全部代码源拉取失败时，界面只显示固定的「暂时无法获取更新」，用户无法判断是网络不通、超时还是仓库问题，反馈没有信息量。

## 改动要点

- 变更：_fetch_remote 收集每个代码源的失败原因（超时信息 / pygit2 异常描述）
- 变更：全部源失败时把原因拼接进提示文案，如「暂时无法获取更新：GitHub: Git 远程拉取超过 300 秒；镜像: 连接超时」
- 新增：_format_source_error 把异常转成简短原因并截断到 120 字符