### PR TITLE
fix: 代码同步前隐藏指向非 commit 对象的引用，规避 libgit2 导入报错

### DIFF
--- a/src/one_dragon/envs/git_service.py
+++ b/src/one_dragon/envs/git_service.py
@@ -29,7 +29,13 @@ from pygit2 import (
     init_repository,
     settings,
 )
-from pygit2.enums import CheckoutStrategy, ConfigLevel, ResetMode, SortMode
+from pygit2.enums import (
+    CheckoutStrategy,
+    ConfigLevel,
+    ReferenceType,
+    ResetMode,
+    SortMode,
+)
 
 from one_dragon.base.config.config_item import ConfigItem
 from one_dragon.envs.env_config import EnvConfig
@@ -884,8 +890,10 @@ class GitService:
 
         callbacks = _FetchProgressRemoteCallbacks(report_progress, timeout=None)
 
+        hidden_refs: list[tuple[str, Oid]] = []
         try:
             log.info(f'开始导入临时 Git 仓库: {remote_path}')
+            hidden_refs = self._hide_non_commit_refs(active_repo)
             active_repo.remotes.create(remote_name, remote_path)
             active_repo.config[f'remote.{remote_name}.tagopt'] = '--no-tags'
             remote = active_repo.remotes[remote_name]
@@ -932,6 +940,18 @@ class GitService:
             except Exception:
                 log.error('恢复 Git 导入前状态失败', exc_info=True)
             raise
+        finally:
+            if hidden_refs:
+                try:
+                    restore_repo = self._open_repo()
+                    self._restore_hidden_refs(restore_repo, hidden_refs)
+                    restore_repo.free()
+                except Exception:
+                    log.error(
+                        '恢复导入前隐藏的非 commit 引用失败，对象仍保留在对象库，'
+                        '可用 git fsck --lost-found 找回',
+                        exc_info=True,
+                    )
 
     def _fetch_remote_once(
         self,
@@ -1116,6 +1136,45 @@ class GitService:
         if 'object not found' in message:
             return True
         return re.fullmatch(r"'{0,1}[0-9a-f]{40}'{0,1}", message) is not None
+
+    @staticmethod
+    def _hide_non_commit_refs(repo: Repository) -> list[tuple[str, Oid]]:
+        """删除指向非 commit 对象的引用并记录原名与目标，规避 libgit2 导入报错。
+
+        libgit2 本地 transport 导入 fetch 时会枚举正式仓库的全部引用做 revwalk
+        hide，若某个引用指向 tree/blob 等非 commit 对象（如 Codex CLI 的
+        checkpoint 引用），会报 "object is not a committish" 导致代码同步失败。
+        导入前临时删除这些引用，导入完成后按记录重建；对象本身仍留在对象库，
+        重建不丢数据。
+        """
+        hidden: list[tuple[str, Oid]] = []
+        for ref_name in list(repo.references):
+            ref = repo.references[ref_name]
+            if ref.type != ReferenceType.DIRECT:
+                continue
+            try:
+                repo[ref.target].peel(Commit)
+            except Exception:
+                pass
+            else:
+                continue
+            hidden.append((ref.name, ref.target))
+            repo.references.delete(ref.name)
+        if hidden:
+            log.info(
+                '导入前临时隐藏 %d 个非 commit 引用: %s',
+                len(hidden),
+                ', '.join(name for name, _ in hidden),
+            )
+        return hidden
+
+    @staticmethod
+    def _restore_hidden_refs(repo: Repository, hidden: list[tuple[str, Oid]]) -> None:
+        """按记录重建导入前删除的非 commit 引用。"""
+        for ref_name, target in hidden:
+            repo.references.create(ref_name, target, force=True)
+        if hidden:
+            log.info(f'已恢复 {len(hidden)} 个非 commit 引用')
 
     def _rebuild_repository(
         self,


### PR DESCRIPTION
## 为什么改（why）

用户反馈代码同步报「暂时无法获取更新」，日志显示所有代码源都失败：
`ValueError: object is not a committish`。

根因是 libgit2 本地 transport 的 bug：导入 fetch 结果时会枚举正式仓库**全部引用**做 revwalk hide，若某个引用指向非 commit 对象（tree/blob），会报 `object is not a committish` 导致导入失败。libgit2 的容错只处理了 `GIT_ENOTFOUND` 和 `GIT_ERROR_INVALID`，漏了实际返回的 `GIT_EINVALIDSPEC`（注释写明"may not be a commit"却跳不过去），上游 main 分支同样未修复，应用层必须规避。

实际触发来源：用户机器上有 OpenAI Codex CLI 产生的 `refs/codex/turn-diffs/checkpoints/...` 引用直接指向 tree 对象，撞上该 bug 后代码同步必然失败。

## 改动要点（what）

- 新增 `_hide_non_commit_refs`：导入前扫描正式仓库全部引用，删除指向非 commit 对象的引用并记录原名与目标
- 新增 `_restore_hidden_refs`：导入完成后按记录重建被删除的引用（对象本身留在对象库，不丢数据）
- `_import_fetch_result` 在 try/finally 中调用上述两方法，成功与失败路径都会恢复

注意：不能只改名，libgit2 枚举的是全部引用，改名后仍会被枚举，必须删除、导入后重建。

## 复现方法

```bash
# 1. 造一个指向 tree 对象的引用（模拟 Codex checkpoint ref）
git tag weird <任意tree对象的sha>

# 2. 触发一次代码同步（应用内「代码同步」或任意走 fetch 的路径）
#    本地分支落后远端时（有新对象要下载）必然复现
```

预期结果（修复前）：
```
ValueError: object is not a committish
所有代码源均拉取失败
```

修复后：代码同步正常完成，`refs/tags/weird` 在导入后自动恢复。

用户机器排查命令：`git for-each-ref --format='%(objecttype) %(refname)'`，objecttype 不是 `commit` 的行就是问题引用。